### PR TITLE
Disable debug messages from the mail.

### DIFF
--- a/pages/signin.php
+++ b/pages/signin.php
@@ -63,7 +63,7 @@ if(Input::exists()){
 								
 								$mail = new PHPMailer;
 								$mail->IsSMTP(); 
-								$mail->SMTPDebug = 2;
+								$mail->SMTPDebug = 0;
 								$mail->Debugoutput = 'html';
 								$mail->Host = $GLOBALS['email']['host'];
 								$mail->Port = $GLOBALS['email']['port'];


### PR DESCRIPTION
I think debug for PHPMailer should be off, now anybody that has SMTP & 2FA enabled can see the communication between server & client. 
(This is my first Pull request, I'm not sure I'm doing it correct)