### PR TITLE
Add a "report closed" label

### DIFF
--- a/pages/mod/reports.php
+++ b/pages/mod/reports.php
@@ -192,7 +192,17 @@ $token = Token::generate();
 							<?php echo '<input type="hidden" name="type" value="update_status">'; ?>
 							<?php echo '<input type="hidden" name="token" value="' .  $token . '">'; ?>
 							<?php echo '<input type="hidden" name="report_id" value="' . $_GET["rid"] . '">'; ?>
-							<button style="display: inline;" type="submit" class="btn btn-danger"><?php echo $mod_language['close_issue']; ?></button>
+							<?php
+								if($report[0]->status == 0) {
+									?>
+									<button style="display: inline;" type="submit" class="btn btn-danger"><?php echo $mod_language['close_issue']; ?></button>
+									<?php
+								} else {
+									?>
+									<span class="label label-danger"><?php echo $mod_language['report_closed']; ?></span>
+									<?php
+								}
+								?>
 						</form>
 					</span>
 					<br /><br />


### PR DESCRIPTION
If a moderator clicked a report alert after it had been closed, the button to close the issue still appeared. This fixes that.