### PR TITLE
Change tachometer function slightly

### DIFF
--- a/core/includes/template/footer.php
+++ b/core/includes/template/footer.php
@@ -21,7 +21,7 @@ $footer_nav = '
 
 if(isset($page_loading) && $page_loading == '1'){
 	$footer_nav .= '
-    <li><a href"" data-toggle="tooltip" id="page_load_tooltip" title="Page loading.."><i class="fa fa-tachometer fa-fw"></i></a></li>';
+    <li><a data-toggle="tooltip" id="page_load_tooltip" title="Page loading.."><i class="fa fa-tachometer fa-fw"></i></a></li>';
 }
 
 if(isset($footer_nav_array)){

--- a/core/includes/template/footer.php
+++ b/core/includes/template/footer.php
@@ -21,7 +21,7 @@ $footer_nav = '
 
 if(isset($page_loading) && $page_loading == '1'){
 	$footer_nav .= '
-    <li><a href="#" data-toggle="tooltip" id="page_load_tooltip" title="Page loading.."><i class="fa fa-tachometer fa-fw"></i></a></li>';
+    <li><a href"" data-toggle="tooltip" id="page_load_tooltip" title="Page loading.."><i class="fa fa-tachometer fa-fw"></i></a></li>';
 }
 
 if(isset($footer_nav_array)){


### PR DESCRIPTION
It was annoying me that the tachometer was clickable, so I was messing with it to make it not clickable but still show up correctly (cause if you remove href alltogher, the tachometer decides it doesnt wanna be in the right place anymore). I honestly came across this solution by accident when I typo'd, but hey, it works. Idk if its valid though. Feel free to send this to the trash can. Just something I liked having.