### PR TITLE
Make the disable avatar button in the admin panel more intuitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Upcoming addons (these will need to be downloaded separately):
 * @IMmmKI
 * @ConnorLinfoot
 * @RobinMCNetwork
+* @PugaBear
 
 **[NamelessMC Website](http://namelessmc.github.io/)**
 * @Samerton

--- a/pages/admin/users.php
+++ b/pages/admin/users.php
@@ -618,6 +618,14 @@ require('core/includes/htmlpurifier/HTMLPurifier.standalone.php'); // HTMLPurifi
 								} catch(Exception $e) {
 									die($e->getMessage());
 								}
+							} else if(Input::get('action') == "avatar_enable"){ 
+								try {
+									$queries->update('users', $_GET["user"], array(
+										"has_avatar" => "1"
+									));
+								} catch(Exception $e) {
+									die($e->getMessage());
+								}
 							}
 						}
 					}
@@ -742,14 +750,31 @@ require('core/includes/htmlpurifier/HTMLPurifier.standalone.php'); // HTMLPurifi
 						$avatar_enabled = $avatar_enabled[0]->value;
 
 						if($avatar_enabled === "1"){
-						?>
-						<strong><?php echo $admin_language['other_actions']; ?></strong><br />
-						<form role="form" action="" method="post">
-						  <input type="hidden" name="token" value="<?php echo $token; ?>">
-						  <input type="hidden" name="action" value="avatar_disable">
-						  <input type="submit" value="<?php echo $admin_language['disable_avatar']; ?>" class="btn btn-danger">
-						</form>
-						<?php 
+							// Does the user have an avatar enabled?
+							$avatar_enabled = $queries->getWhere('users', array('id', '=', $_GET['user']));
+							$avatar_enabled = $avatar_enabled[0]->has_avatar;
+
+							if($avatar_enabled === "1"){ // Yes
+							?>
+							<strong><?php echo $admin_language['other_actions']; ?></strong><br />
+							<form role="form" action="" method="post">
+							  <input type="hidden" name="token" value="<?php echo $token; ?>">
+							  <input type="hidden" name="action" value="avatar_disable">
+							  <input type="submit" value="<?php echo $admin_language['disable_avatar']; ?>" class="btn btn-danger">
+							</form>
+							<?php 
+							
+							// Doesn't have an avatar enabled, but does one exist? If so, let the admin choose to enable it
+							} else if (count(glob(__DIR__ . '/../../avatars/' . $_GET["user"] . '.*'))) { 
+							?>
+							<strong><?php echo $admin_language['other_actions']; ?></strong><br />
+							<form role="form" action="" method="post">
+							  <input type="hidden" name="token" value="<?php echo $token; ?>">
+							  <input type="hidden" name="action" value="avatar_enable">
+							  <input type="submit" value="<?php echo $admin_language['enable_avatar']; ?>" class="btn btn-success">
+							</form>
+							<?php
+							}
 						}
 					}
 				}

--- a/styles/language/Czech/language.php
+++ b/styles/language/Czech/language.php
@@ -203,6 +203,7 @@ $admin_language = array(
 	'ip' => 'IP:',
 	'other_actions' => 'Other actions:',
 	'disable_avatar' => 'Disable avatar',
+	'enable_avatar' => 'Enable avatar',
 	'confirm_user_deletion' => 'Are you sure you want to delete the user {x}?', // Don't replace "{x}"
 	'groups' => 'Groups',
 	'group' => 'Group',

--- a/styles/language/Dutch/language.php
+++ b/styles/language/Dutch/language.php
@@ -208,6 +208,7 @@ $admin_language = array(
     'ip' => 'IP:',
     'other_actions' => 'Andere Actie\'s:',
     'disable_avatar' => 'Schakel avatar uit',
+    'enable_avatar' => 'Enable avatar',
     'confirm_user_deletion' => 'Weet u zeker dat u de gebruiker <b>{x}</b> wilt verwijderen?', // Don't replace "{x}"
     'groups' => 'Groepen',
     'group' => 'Groep',

--- a/styles/language/EnglishUK/language.php
+++ b/styles/language/EnglishUK/language.php
@@ -203,6 +203,7 @@ $admin_language = array(
 	'ip' => 'IP:',
 	'other_actions' => 'Other actions:',
 	'disable_avatar' => 'Disable avatar',
+	'enable_avatar' => 'Enable avatar',
 	'confirm_user_deletion' => 'Are you sure you want to delete the user {x}?', // Don't replace "{x}"
 	'groups' => 'Groups',
 	'group' => 'Group',

--- a/styles/language/Finnish/language.php
+++ b/styles/language/Finnish/language.php
@@ -203,6 +203,7 @@ $admin_language = array(
 	'ip' => 'IP:',
 	'other_actions' => 'Muut toiminnot:',
 	'disable_avatar' => 'Ota avatar pois käytöstä',
+	'enable_avatar' => 'Enable avatar',
 	'confirm_user_deletion' => 'Oletko varma, että haluat poistaa käyttäjän {x}?', // Don't replace "{x}"
 	'groups' => 'Käyttäjäryhmät',
 	'group' => 'Ryhmä',

--- a/styles/language/French/language.php
+++ b/styles/language/French/language.php
@@ -206,6 +206,7 @@ $admin_language = array(
 	'ip' => 'IP:',
 	'other_actions' => 'Autres actions:',
 	'disable_avatar' => 'Désactiver l\'avatar',
+	'enable_avatar' => 'Enable avatar',
 	'confirm_user_deletion' => 'Êtes-vous sûr de vouloir supprimer cet utilisateur: {x} ?', // Don't replace "{x}"
 	'groups' => 'Groupes',
 	'group' => 'Groupe',

--- a/styles/language/German/language.php
+++ b/styles/language/German/language.php
@@ -206,6 +206,7 @@ $admin_language = array(
 	'ip' => 'IP:',
 	'other_actions' => 'Andere Aktionen:',
 	'disable_avatar' => 'Avatar ausschalten',
+	'enable_avatar' => 'Enable avatar',
 	'confirm_user_deletion' => 'Bist du sicher, dass du den Benutzer {x} löschen willst?', // Don't replace "{x}"
 	'groups' => 'Gruppen',
 	'group' => 'Gruppe',

--- a/styles/language/Norsk/language.php
+++ b/styles/language/Norsk/language.php
@@ -203,6 +203,7 @@ $admin_language = array(
 	'ip' => 'IP:',
 	'other_actions' => 'Andre handlinger:',
 	'disable_avatar' => 'Deaktiver avatar',
+	'enable_avatar' => 'Enable avatar',
 	'confirm_user_deletion' => 'Er du sikker på at du vil slette brukeren {x}?', // Don't replace "{x}"
 	'groups' => 'Grupper',
 	'group' => 'Gruppe',

--- a/styles/language/Portugues/language.php
+++ b/styles/language/Portugues/language.php
@@ -207,6 +207,7 @@ $admin_language = array(
 	'ip' => 'IP:',
 	'other_actions' => 'Outras Ações:',
 	'disable_avatar' => 'Desativar avatar',
+	'enable_avatar' => 'Enable avatar',
 	'confirm_user_deletion' => 'Você tem certeza de que deseja excluir o usuário {x}?', // Don't replace "{x}"
 	'groups' => 'Grupos',
 	'group' => 'Grupo',

--- a/styles/language/Slovak/language.php
+++ b/styles/language/Slovak/language.php
@@ -203,6 +203,7 @@ $admin_language = array(
 	'ip' => 'IP:',
 	'other_actions' => 'Ďalšie akcie:',
 	'disable_avatar' => 'Vypnuť avatary',
+	'enable_avatar' => 'Enable avatar',
 	'confirm_user_deletion' => 'Vážne chceš vymazať účet {x}?', // Don't replace "{x}"
 	'groups' => 'Skupiny',
 	'group' => 'Skupina',

--- a/styles/language/Spanish/language.php
+++ b/styles/language/Spanish/language.php
@@ -206,6 +206,7 @@ $admin_language = array(
 	'ip' => 'IP:',
 	'other_actions' => 'Otras acciones:',
 	'disable_avatar' => 'Desactivar avatar',
+	'enable_avatar' => 'Enable avatar',
 	'confirm_user_deletion' => '¿Seguro que quiere borrar el usuario {x}?', // Don't replace "{x}"
 	'groups' => 'Grupos',
 	'group' => 'Grupo',


### PR DESCRIPTION
If the user doesn't have an avatar at all, it won't display the button
If the user does have an enabled avatar, it gives the option to disable it
If the user doesn't have an enabled avatar but the file for one exists, it gives the option to enable it.