### PR TITLE
Change scroll destination

### DIFF
--- a/pages/forum/view_topic.php
+++ b/pages/forum/view_topic.php
@@ -555,6 +555,13 @@ $purifier = new HTMLPurifier($config);
 			$("[rel=tooltip]").tooltip({ placement: 'top'});
 			var hash = window.location.hash.substring(1);
 			$("#" + hash).effect("highlight", {}, 2000);
+			(function() {
+			    if (document.location.hash) {
+			        setTimeout(function() {
+			            window.scrollTo(window.scrollX, window.scrollY - 70);
+			        }, 10);
+			    }
+			})();
 		});
 		
 		CKEDITOR.replace( 'quickreply', {


### PR DESCRIPTION
When you link to posts, the nav bar covers up a part of the reply panel.
![image](https://cloud.githubusercontent.com/assets/12417961/19086023/263d2c3a-8a32-11e6-9058-3c7296ba894d.png)

This adds a bit of padding to the scroll so it shows up like this
![image](https://cloud.githubusercontent.com/assets/12417961/19086043/3df5387c-8a32-11e6-9964-9699c7d9d957.png)