### PR TITLE
Add checks if the user can view staff applications.

### DIFF
--- a/pages/mod/applications.php
+++ b/pages/mod/applications.php
@@ -8,7 +8,7 @@
 
 // Mod check
 if($user->isLoggedIn()){
-	if(!$user->canViewMCP($user->data()->id)){
+	if(!$user->canViewMCP($user->data()->id) || !$user->canViewApps($user->data()->id)){
 		Redirect::to('/');
 		die();
 	}


### PR DESCRIPTION
Currently, namelessmc is vulnerable that users who are in a group that can access the mod cp but aren't allowed to view staff applications don't see the link staff applications but can still browse them by simply going to /mod/applications. This adds the check that they can also view staff applications. If the user can't view staff apps, they cannot accept or deny either because view checks are made earlier.

Ps: dunno about the last no newline / newline edit. Github made that up