### PR TITLE
Remove IRC from README because no one from the project uses it

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,5 +139,5 @@ Upcoming addons (these will need to be downloaded separately):
 ## Discord
 [<img src="https://discordapp.com/api/guilds/246705793066467328/widget.png?style=shield">](https://discord.gg/r7Eq4jw)
 
-## IRC
-\#NamelessMC on [irc.spi.gt](http://irc.spi.gt/iris/?channels=namelessmc)
+<!--## IRC
+\#NamelessMC on [irc.spi.gt](http://irc.spi.gt/iris/?channels=namelessmc)-->


### PR DESCRIPTION
I have had a bouncer on the channel for many months now and its shitposting and people asking questions then leaving 20 seconds later. Better to just point people to discord.