### PR TITLE
Added link to NamelessPlugin Spigot Page

### DIFF
--- a/styles/language/EnglishUK/language.php
+++ b/styles/language/EnglishUK/language.php
@@ -262,7 +262,7 @@ $admin_language = array(
 	'use_plugin' => 'Enable Nameless API?',
 	'force_avatars' => 'Force Minecraft avatars?',
 	'uuid_linking' => 'Enable UUID linking?',
-	'use_plugin_help' => 'Enabling the API, along with the upcoming server plugin, allows for rank synchronisation and also ingame registration and report submission.',
+	'use_plugin_help' => 'Enabling the API, along with the <a href="https://www.spigotmc.org/resources/official-namelessplugin.42698/" title="NamelessPlugin" target="_blank">server plugin</a>, allows for rank synchronisation and also ingame registration and report submission.',
 	'uuid_linking_help' => 'If disabled, user accounts won\'t be linked with UUIDs. It is highly recommended you keep this as enabled.',
 	'plugin_settings' => 'Plugin Settings',
 	'confirm_api_regen' => 'Are you sure you want to generate a new API key?',


### PR DESCRIPTION
**What kind of issue is it (Question, Bug, etc.)?** Bug/Outdated Information.  
**In which version of NamelessMC did it occur (1.x.x)?** Release 1.0.16.  
**How would you describe the issue?** The admin panel page (admin/minecraft) still says 'upcoming server plugin' on the hoverover text for 'Enable Nameless API'.
**Do you have (relevant) resources about this issue (Logs, pictures, etc.)?** Yes, I have the a screenshot of it. [Click here](http://i.imgur.com/LmbjGwc.png)  
**Do you have an idea how or where the issue occurs?** It occurs in the language file. Please see the pull request.