### PR TITLE
Create nginx-ssl.example

### DIFF
--- a/nginx-ssl.example
+++ b/nginx-ssl.example
@@ -1,0 +1,65 @@
+# Written by Latouth (latouth@gmail.com) for nginx on July 19th 2017
+# Please note, this config MAY or MAY NOT work depending on php version, where you got php, where php is listening to (socket or port), etc
+# In which case, please contact the NamelessMC Discord team for support.
+# This is the SSL (HTTPS) example for nginx using a LetsEncrypt SSL Certificate.
+# Instructions on how to generate a letsencrypt ssl certificate available at https://certbot.eff.org/
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name example.com;
+    # enforce https
+    return 301 https://$server_name$request_uri;
+}
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name ~^(www.)?example.com;
+
+    # This depends on where you want to install nameless on file. 
+    root /var/www/example.com/public;
+    index index.php;
+
+    # Logging
+    error_log /var/www/example.com/error.log warn;
+    access_log /var/www/example.com/access.log;
+
+    # allow larger file uploads and longer script runtimes
+    client_max_body_size 128M;
+    client_body_timeout 300s;
+
+    # Sets the SSL Certificate, ciphers & more
+    ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:ECDHE-RSA-AES128-GCM-SHA256:AES256+EECDH:DHE-RSA-AES128-GCM-SHA256:AES256+EDH:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
+    # ssl_dhparam /etc/ssl/certs/dhparam.pem;
+
+    # Serves security related headers
+    add_header Strict-Transport-Security "max-age=15768000; preload;";
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Robots-Tag none;
+    add_header Content-Security-Policy "frame-ancestors 'self'";
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/var/run/php-fpm/php-fpm.sock; 
+        # This greatly depends on where php fpm is located
+        # It can be /var/run/php5/php-fpm.sock or 127.0.0.1:9000 or others.
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include /etc/nginx/fastcgi_params;
+    }
+
+    error_page 404 /404.php;
+
+}
+


### PR DESCRIPTION
Adds a letsencrypt ssl example of the nginx-non-ssl.example file.