### PR TITLE
Add email field to contact form

### DIFF
--- a/custom/languages/Czech/general.php
+++ b/custom/languages/Czech/general.php
@@ -58,8 +58,10 @@ $language = array(
      */
     'contact' => 'Kontakt',
     'message' => 'Zpráva',
+    'email_address' => 'Email Address',
     'contact_email_subject' => 'Nový kontaktní formulář ',
     'contact_message_failed' => 'Nepodařilo se odeslat zprávu. Zajistěte, aby jste vložil zprávu mezi 10 a 5000 znaky dlouhou.',
+    'contact_message_email' => 'The provided email is invalid.',	
     'contact_message_sent' => 'Zpráva byla úspěšně odeslana.',
     'contact_message_limit' => 'Můžete odeslat pouze jednu zprávu za hodinu. Další můžete odeslat za {x} minut.', // Don't replace {x}
 	

--- a/custom/languages/Dutch/general.php
+++ b/custom/languages/Dutch/general.php
@@ -60,8 +60,10 @@ $language = array(
 	 */
 	'contact' => 'Contact',
 	'message' => 'Bericht',
+    'email_address' => 'Email Address',
 	'contact_email_subject' => 'Nieuw contactformulier indiening',
 	'contact_message_failed' => 'Kan bericht niet verzenden. Zorg ervoor dat je bericht tussen de 10 en 5000 karakters lang is.',
+    'contact_message_email' => 'The provided email is invalid.',
 	'contact_message_sent' => 'Bericht succesvol verzonden.',
 	'contact_message_limit' => 'Je kan maar 1 bericht per uur versturen. Je kan pas weer over {x} minuten een nieuw bericht versturen.', // Vervang {x} niet
 	

--- a/custom/languages/EnglishUK/general.php
+++ b/custom/languages/EnglishUK/general.php
@@ -58,9 +58,11 @@ $language = array(
 	 */
     'contact' => 'Contact',
     'message' => 'Message',
+    'email_address' => 'Email Address',
 	'contact_email_subject' => 'New contact form submission',
 	'contact_message_failed' => 'Unable to send message. Please ensure you have entered a message between 10 and 5000 characters long.',
 	'contact_message_sent' => 'Message sent successfully.',
+    'contact_message_email' => 'The provided email is invalid.',
 	'contact_message_limit' => 'You can only send one message per hour. You can next send a message in {x} minutes.', // Don't replace {x}
 	
 	/* 

--- a/custom/languages/EnglishUS/general.php
+++ b/custom/languages/EnglishUS/general.php
@@ -59,9 +59,9 @@ $language = array(
     'contact' => 'Contact',
     'message' => 'Message',
     'email_address' => 'Email Address',
-	'contact_email_subject' => 'New contact form submission',
+    'contact_email_subject' => 'New contact form submission',
     'contact_message_failed' => 'Unable to send message. Please ensure you have entered a message between 10 and 5000 characters long.',
-	'contact_message_email' => 'Unable to send message. The provided email is invalid.',
+    'contact_message_email' => 'Unable to send message. The provided email is invalid.',
     'contact_message_sent' => 'Message sent successfully.',
     'contact_message_limit' => 'You can only send one message per hour. You can next send a message in {x} minutes.', // Don't replace {x}
 	

--- a/custom/languages/EnglishUS/general.php
+++ b/custom/languages/EnglishUS/general.php
@@ -58,10 +58,13 @@ $language = array(
      */
     'contact' => 'Contact',
     'message' => 'Message',
-    'contact_email_subject' => 'New contact form submission',
+    'email_address' => 'Email Address',
+	'contact_email_subject' => 'New contact form submission',
     'contact_message_failed' => 'Unable to send message. Please ensure you have entered a message between 10 and 5000 characters long.',
+	'contact_message_email' => 'Unable to send message. The provided email is invalid.',
     'contact_message_sent' => 'Message sent successfully.',
     'contact_message_limit' => 'You can only send one message per hour. You can next send a message in {x} minutes.', // Don't replace {x}
+	
 	
 	/* 
 	 *  Navbar

--- a/custom/languages/EnglishUS/general.php
+++ b/custom/languages/EnglishUS/general.php
@@ -61,7 +61,7 @@ $language = array(
     'email_address' => 'Email Address',
     'contact_email_subject' => 'New contact form submission',
     'contact_message_failed' => 'Unable to send message. Please ensure you have entered a message between 10 and 5000 characters long.',
-    'contact_message_email' => 'Unable to send message. The provided email is invalid.',
+    'contact_message_email' => 'The provided email is invalid.',
     'contact_message_sent' => 'Message sent successfully.',
     'contact_message_limit' => 'You can only send one message per hour. You can next send a message in {x} minutes.', // Don't replace {x}
 	

--- a/custom/languages/German/general.php
+++ b/custom/languages/German/general.php
@@ -66,8 +66,10 @@ $language = array(
      */
     'contact' => 'Kontakt',
     'message' => 'Nachricht',
+    'email_address' => 'Email Address',
     'contact_email_subject' => 'Neue Kontaktformulareinreichung',
     'contact_message_failed' => 'Nachricht konnte nicht gesendet werden. Bitte stellen Sie sicher, dass Sie eine Nachricht zwischen 10 und 5000 Zeichen lang eingegeben haben.',
+    'contact_message_email' => 'The provided email is invalid.',
     'contact_message_sent' => 'Nachricht erfolgreich gesendet.',
     'contact_message_limit' => 'Sie können nur eine Nachricht pro Stunde senden. Sie können als nächstes eine Nachricht in {x} Minuten senden.', // Don't replace {x}
 	

--- a/custom/languages/Greek/general.php
+++ b/custom/languages/Greek/general.php
@@ -60,8 +60,10 @@ $language = array(
      */
     'contact' => 'Contact',
     'message' => 'Message',
+    'email_address' => 'Email Address',
     'contact_email_subject' => 'New contact form submission',
     'contact_message_failed' => 'Unable to send message. Please ensure you have entered a message between 10 and 5000 characters long.',
+    'contact_message_email' => 'The provided email is invalid.',
     'contact_message_sent' => 'Message sent successfully.',
     'contact_message_limit' => 'You can only send one message per hour. You can next send a message in {x} minutes.', // Don't replace {x}
 

--- a/custom/languages/Japanese/general.php
+++ b/custom/languages/Japanese/general.php
@@ -60,8 +60,10 @@ $language = array(
      */
     'contact' => '問い合わせ',
     'message' => 'メッセージ',
+    'email_address' => 'Email Address',
     'contact_email_subject' => '新しい連絡先フォームの提出',
     'contact_message_failed' => 'メッセージを送信できません。 10~5000 文字のメッセージを入力してください。',
+    'contact_message_email' => 'The provided email is invalid.',
     'contact_message_sent' => '送信に成功しました。',
     'contact_message_limit' => '1時間に1つのメッセージしか送信できません。 次に、{x} 分後にメッセージを送信できます。', // Don't replace {x}
 	

--- a/custom/languages/Norwegian/general.php
+++ b/custom/languages/Norwegian/general.php
@@ -58,8 +58,10 @@ $language = array(
      */
     'contact' => 'Kontakt',
     'message' => 'Melding',
+    'email_address' => 'Email Address',
     'contact_email_subject' => 'Ny kontaktskjema',
     'contact_message_failed' => 'Kunne ikke sende melding. Pass på at meldingen er mellom 10 og 5000 tegn lang',
+    'contact_message_email' => 'The provided email is invalid.',
     'contact_message_sent' => 'Melding suksessfullt sendt!',
     'contact_message_limit' => 'Du kan kun sende èn melding hver time. Du kan sende en ny melding om {x} minutter.', // Don't replace {x}
 	

--- a/custom/languages/Portuguese/general.php
+++ b/custom/languages/Portuguese/general.php
@@ -57,12 +57,14 @@ $language = array(
  	/*
 	*  Contact form
 	*/
-	'contact' => 'Contato',
-	'message' => 'Mensagem',
-	'contact_email_subject' => 'Novo formulário de contato',
-	'contact_message_failed' => 'Não foi possível a mensagem. Certifique-se de ter inserido uma mensagem entre 10 e 5000 caracteres.',
+    'contact' => 'Contato',
+    'message' => 'Mensagem',
+    'email_address' => 'Email Address',
+    'contact_email_subject' => 'Novo formulário de contato',
+    'contact_message_failed' => 'Não foi possível a mensagem. Certifique-se de ter inserido uma mensagem entre 10 e 5000 caracteres.',
+    'contact_message_email' => 'The provided email is invalid.',    
 	'contact_message_sent' => 'Mensagem enviada com sucesso.',
-	'contact_message_limit' => 'Você só pode enviar uma mensagem por hora. Você pode enviar uma mensagem em {x} minutos.', // Don't replace {x}
+    'contact_message_limit' => 'Você só pode enviar uma mensagem por hora. Você pode enviar uma mensagem em {x} minutos.', // Don't replace {x}
 	
 	/* 
 	 *  Navbar

--- a/custom/languages/Romanian/general.php
+++ b/custom/languages/Romanian/general.php
@@ -60,8 +60,10 @@ $language = array(
      */
     'contact' => 'Contact',
     'message' => 'Mesaj',
+    'email_address' => 'Email Address',
     'contact_email_subject' => 'Un nou mesaj prin intermediul formularului de contact',
     'contact_message_failed' => 'Mesaj imposibil de trimis. Asigurați-vă că ați introdus un mesaj între 10 și 5000 de caractere.',
+    'contact_message_email' => 'The provided email is invalid.',
     'contact_message_sent' => 'Mesaj trimis cu succes.',
     'contact_message_limit' => 'Puteți trimite doar un mesaj pe oră. Aveți posibilitatea să trimiteți un nou mesaj în {x} minute.', // Don't replace {x}
     

--- a/custom/languages/Slovak/general.php
+++ b/custom/languages/Slovak/general.php
@@ -58,8 +58,10 @@ $language = array(
      */
     'contact' => 'Kontakt',
     'message' => 'Správa',
+    'email_address' => 'Email Address',
     'contact_email_subject' => 'Nový kontaktný formulár ',
     'contact_message_failed' => 'Nepodarilo sa odoslať zprávu. Zajistěte, aby jste vložil zprávu mezi 10 a 5000 znaky dlouhou.',
+    'contact_message_email' => 'The provided email is invalid.',
     'contact_message_sent' => 'Správa bola úspešne odoslaná.',
     'contact_message_limit' => 'Můžete odeslat pouze jednu zprávu za hodinu. Další můžete odeslat za {x} minut.', // Don't replace {x}
 	

--- a/custom/languages/Spanish/general.php
+++ b/custom/languages/Spanish/general.php
@@ -58,8 +58,10 @@ $language = array(
      */
     'contact' => 'Contacto',
     'message' => 'Mensaje',
+    'email_address' => 'Email Address',
     'contact_email_subject' => 'Nuevo formulario de contacto',
     'contact_message_failed' => 'No se puede enviar el mensaje. Asegúrate de haber ingresado un mensaje entre 10 y 5000 caracteres.',
+    'contact_message_email' => 'The provided email is invalid.',    
     'contact_message_sent' => 'Mensaje enviado con éxito.',
     'contact_message_limit' => 'Sólo puede enviar un mensaje por hora. Puede enviar un mensaje en {x} minutos.', // Don't replace {x}
 	

--- a/custom/languages/SwedishSE/general.php
+++ b/custom/languages/SwedishSE/general.php
@@ -59,10 +59,12 @@ $language = array(
 	 */
     'contact' => 'Kontakt',
     'message' => 'Meddelande',
-	'contact_email_subject' => 'Ny kontaktformulär inlämning.',
-	'contact_message_failed' => 'Det gick inte att skicka meddelandet. Vänligen Unable to send message. Please se till att du har skrivit ett meddelande mellan 10 och 5000 tecken långt.',
-	'contact_message_sent' => 'Meddelande sänt med framgång!',
-	'contact_message_limit' => 'Du kan bara skicka ett meddelande per timme. Du kan sedan skicka ett meddelande om {x} minuter.', // Don't replace {x}
+    'email_address' => 'Email Address',
+    'contact_email_subject' => 'Ny kontaktformulär inlämning.',
+    'contact_message_failed' => 'Det gick inte att skicka meddelandet. Vänligen Unable to send message. Please se till att du har skrivit ett meddelande mellan 10 och 5000 tecken långt.',
+    'contact_message_email' => 'The provided email is invalid.',
+    'contact_message_sent' => 'Meddelande sänt med framgång!',
+    'contact_message_limit' => 'Du kan bara skicka ett meddelande per timme. Du kan sedan skicka ett meddelande om {x} minuter.', // Don't replace {x}
 	
 	/* 
 	 *  Navbar

--- a/custom/templates/Default/contact.tpl
+++ b/custom/templates/Default/contact.tpl
@@ -4,17 +4,20 @@
     <div class="card">
         <div class="card-body">
             <h2>{$CONTACT}</h2>
-            {if isset($ERROR)}
-                <div class="alert alert-danger">
-                    {$ERROR}
-                </div>
-            {/if}
             {if isset($SUCCESS)}
                 <div class="alert alert-success">
                     {$SUCCESS}
                 </div>
             {/if}
             <form action="" method="post">
+			    <div class="form-group">
+			        <input type="email" name="email" id="email" class="form-control form-control-lg" placeholder="{$EMAIL}" tabindex="3">
+			    </div>
+                {if isset($ERROR_CONTENT)}
+                    <div class="alert alert-danger">
+                        {$ERROR_CONTENT}
+                    </div>
+                {/if}
                 <div class="form-group">
                     <label for="inputMessage">{$MESSAGE}</label>
                     <textarea id="inputMessage" name="content" class="form-control" rows="5"></textarea>

--- a/custom/templates/Default/contact.tpl
+++ b/custom/templates/Default/contact.tpl
@@ -10,6 +10,11 @@
                 </div>
             {/if}
             <form action="" method="post">
+                {if isset($ERROR)}
+                    <div class="alert alert-danger">
+                        {$ERROR}
+                    </div>
+                {/if}
                 {if isset($ERROR_EMAIL)}
                     <div class="alert alert-danger">
                         {$ERROR_EMAIL}

--- a/custom/templates/Default/contact.tpl
+++ b/custom/templates/Default/contact.tpl
@@ -10,9 +10,14 @@
                 </div>
             {/if}
             <form action="" method="post">
-			    <div class="form-group">
-			        <input type="email" name="email" id="email" class="form-control form-control-lg" placeholder="{$EMAIL}" tabindex="3">
-			    </div>
+                {if isset($ERROR_EMAIL)}
+                    <div class="alert alert-danger">
+                        {$ERROR_EMAIL}
+                    </div>
+                {/if}			
+                <div class="form-group">
+                    <input type="email" name="email" id="email" class="form-control form-control-lg" placeholder="{$EMAIL}" tabindex="3">
+                </div>
                 {if isset($ERROR_CONTENT)}
                     <div class="alert alert-danger">
                         {$ERROR_CONTENT}

--- a/modules/Core/pages/contact.php
+++ b/modules/Core/pages/contact.php
@@ -186,6 +186,9 @@ if($recaptcha == 'true'){
     $smarty->assign('RECAPTCHA', Output::getClean($recaptcha_key[0]->value));
 }
 
+if(isset($error))
+    $smarty->assign('ERROR', $error);
+
 if(isset($erroremail))
     $smarty->assign('ERROR_EMAIL', $erroremail);
 

--- a/modules/Core/pages/contact.php
+++ b/modules/Core/pages/contact.php
@@ -55,7 +55,12 @@ if(Input::exists()){
                     'required' => true,
                     'min' => 10,
                     'max' => 5000
-                )
+                ),
+				'email' => array(
+					'required' => true,
+					'min' => 4,
+					'max' => 64,
+				)
             ));
 
             if($validation->passed()){
@@ -97,9 +102,10 @@ if(Input::exists()){
                         $subject = SITE_NAME . ' - ' . $language->get('general', 'contact_email_subject');
 
                         $message = Output::getClean(Input::get('content'));
+						$fromemail = Output::getClean(Input::get('email'));
 
                         $headers = 'From: ' . $siteemail . "\r\n" .
-                            'Reply-To: ' . $siteemail . "\r\n" .
+                            'Reply-To: ' . $fromeemail . "\r\n" .
                             'X-Mailer: PHP/' . phpversion() . "\r\n" .
                             'MIME-Version: 1.0' . "\r\n" . 
                             'Content-type: text/html; charset=UTF-8' . "\r\n";
@@ -132,7 +138,17 @@ if(Input::exists()){
                 $_SESSION['last_contact_sent'] = date('U');
                 $success = $language->get('general', 'contact_message_sent');
             } else {
-                $error = $language->get('general', 'contact_message_failed');
+                foreach($validation->errors() as $validation_error){
+					
+				    switch($validation_error){
+					    case (strpos($validation_error, 'content') !== false):
+                            $errorcontent = $language->get('general', 'contact_message_failed');
+                            break;
+					    case (strpos($validation_error, 'email') !== false):
+                            $erroremail = $language->get('general', 'contact_message_email');
+                            break;
+                    }
+                }
             }
 
         } else
@@ -171,13 +187,17 @@ if($recaptcha == 'true'){
     $smarty->assign('RECAPTCHA', Output::getClean($recaptcha_key[0]->value));
 }
 
-if(isset($error))
-  $smarty->assign('ERROR', $error);
+if(isset($erroremail))
+  $smarty->assign('ERROR_EMAIL', $erroremail);
+
+if(isset($errorcontent))
+  $smarty->assign('ERROR_CONTENT', $errorcontent);
 
 if(isset($success))
     $smarty->assign('SUCCESS', $success);
 
 $smarty->assign(array(
+    'EMAIL' => $language->get('general', 'email_address'),
     'CONTACT' => $language->get('general', 'contact'),
     'MESSAGE' => $language->get('general', 'message'),
     'TOKEN' => Token::get(),

--- a/modules/Core/pages/contact.php
+++ b/modules/Core/pages/contact.php
@@ -56,11 +56,11 @@ if(Input::exists()){
                     'min' => 10,
                     'max' => 5000
                 ),
-				'email' => array(
-					'required' => true,
-					'min' => 4,
-					'max' => 64,
-				)
+                'email' => array(
+                    'required' => true,
+                    'min' => 4,
+                    'max' => 64,
+                )
             ));
 
             if($validation->passed()){
@@ -102,7 +102,7 @@ if(Input::exists()){
                         $subject = SITE_NAME . ' - ' . $language->get('general', 'contact_email_subject');
 
                         $message = Output::getClean(Input::get('content'));
-						$fromemail = Output::getClean(Input::get('email'));
+                        $fromemail = Output::getClean(Input::get('email'));
 
                         $headers = 'From: ' . $siteemail . "\r\n" .
                             'Reply-To: ' . $fromeemail . "\r\n" .
@@ -139,12 +139,11 @@ if(Input::exists()){
                 $success = $language->get('general', 'contact_message_sent');
             } else {
                 foreach($validation->errors() as $validation_error){
-					
-				    switch($validation_error){
-					    case (strpos($validation_error, 'content') !== false):
+                    switch($validation_error){
+                        case (strpos($validation_error, 'content') !== false):
                             $errorcontent = $language->get('general', 'contact_message_failed');
                             break;
-					    case (strpos($validation_error, 'email') !== false):
+                        case (strpos($validation_error, 'email') !== false):
                             $erroremail = $language->get('general', 'contact_message_email');
                             break;
                     }
@@ -188,10 +187,10 @@ if($recaptcha == 'true'){
 }
 
 if(isset($erroremail))
-  $smarty->assign('ERROR_EMAIL', $erroremail);
+    $smarty->assign('ERROR_EMAIL', $erroremail);
 
 if(isset($errorcontent))
-  $smarty->assign('ERROR_CONTENT', $errorcontent);
+    $smarty->assign('ERROR_CONTENT', $errorcontent);
 
 if(isset($success))
     $smarty->assign('SUCCESS', $success);


### PR DESCRIPTION
This pull request implements an email field to the contact page #915. Validation is handled on the back end and new error messages have been created to handle an invalid email. These new fields have been added to all the language files so that they remain in sync. 

The email the user provides in the contact form is set in the "Reply To" header for emails sent through the php mail function. However, I could not figure out how to do this with the PHPMailer library so this still needs to be done. 

I have tested the front-end error handling and backend validation. However, I was not able to get email setup locally so this should still be tested.