### PR TITLE
Fixed "View all templates" link for specifically panel templates

### DIFF
--- a/custom/panel_templates/Default/core/panel_templates.tpl
+++ b/custom/panel_templates/Default/core/panel_templates.tpl
@@ -169,7 +169,7 @@
                                 <div class="alert alert-warning">{$UNABLE_TO_RETRIEVE_TEMPLATES}</div>
                             {/if}
 
-                            <a href="{$VIEW_ALL_TEMPLATES_LINK}" class="btn btn-primary" target="_blank">{$VIEW_ALL_TEMPLATES} &raquo;</a>
+                            <a href="{$VIEW_ALL_PANEL_TEMPLATES_LINK}" class="btn btn-primary" target="_blank">{$VIEW_ALL_PANEL_TEMPLATES} &raquo;</a>
 
                         </div>
                     </div>

--- a/modules/Core/pages/panel/panel_templates.php
+++ b/modules/Core/pages/panel/panel_templates.php
@@ -159,7 +159,7 @@ if(!isset($_GET['action'])){
 		'WEBSITE_TEMPLATES' => $all_templates,
 		'VIEW_ALL_TEMPLATES' => $language->get('admin', 'view_all_templates'),
 		'VIEW_ALL_TEMPLATES_LINK' => 'https://namelessmc.com/resources/category/2-namelessmc-v2-templates/',
-		'VIEW_ALL_PANEL_TEMPLATES' => $language->get('admin', 'view_all_templates'),
+		'VIEW_ALL_PANEL_TEMPLATES' => $language->get('admin', 'view_all_panel_templates'),
 		'VIEW_ALL_PANEL_TEMPLATES_LINK' => 'https://namelessmc.com/resources/category/8-namelessmc-panel-templates/',
 		'UNABLE_TO_RETRIEVE_TEMPLATES' => $language->get('admin', 'unable_to_retrieve_templates'),
 		'VIEW' => $language->get('general', 'view'),

--- a/modules/Core/pages/panel/panel_templates.php
+++ b/modules/Core/pages/panel/panel_templates.php
@@ -159,6 +159,8 @@ if(!isset($_GET['action'])){
 		'WEBSITE_TEMPLATES' => $all_templates,
 		'VIEW_ALL_TEMPLATES' => $language->get('admin', 'view_all_templates'),
 		'VIEW_ALL_TEMPLATES_LINK' => 'https://namelessmc.com/resources/category/2-namelessmc-v2-templates/',
+		'VIEW_ALL_PANEL_TEMPLATES' => $language->get('admin', 'view_all_templates'),
+		'VIEW_ALL_PANEL_TEMPLATES_LINK' => 'https://namelessmc.com/resources/category/8-namelessmc-panel-templates/',
 		'UNABLE_TO_RETRIEVE_TEMPLATES' => $language->get('admin', 'unable_to_retrieve_templates'),
 		'VIEW' => $language->get('general', 'view'),
 		'TEMPLATE' => $language->get('admin', 'template'),


### PR DESCRIPTION
Noticed today that the "View all templates" link for panel templates in my StaffCP just sent me to normal templates not panel templates. Thought I'd make a pull request rather than an issue for such a simple fix.