### PR TITLE
Display non-alphanumeric characters in forum URLs

### DIFF
--- a/modules/Forum/classes/Forum.php
+++ b/modules/Forum/classes/Forum.php
@@ -460,7 +460,7 @@ class Forum {
     // Transform a topic title to URL-ify it
     public function titleToURL($topic = null) {
         if ($topic) {
-            $topic = preg_replace("/[^A-Za-z0-9 ]/", '', Util::cyrillicToLatin($topic));
+            $topic = Util::cyrillicToLatin($topic);
             return Output::getClean(strtolower(urlencode(str_replace(' ', '-', htmlspecialchars_decode($topic)))));
         }
 


### PR DESCRIPTION
Topic URLs will now contain non-alphanumeric characters. For example, the [CJKV characters](https://en.wikipedia.org/wiki/CJK_characters).

- Fix #1683

![image](https://user-images.githubusercontent.com/6961187/127974217-a0e2e17b-3040-4c79-af73-9a7b87f51b94.png)

In a past commit(https://github.com/NamelessMC/Nameless/commit/a50fb572181675f0686a54ad94a4e873e65889b4), non-alphanumeric characters were removed from the forum URL. I don't know the reason for this change, but if some reason exists, need to consider changing this Pull Request.