### PR TITLE
Fix latest profile posts link

### DIFF
--- a/modules/Core/widgets/ProfilePostsWidget.php
+++ b/modules/Core/widgets/ProfilePostsWidget.php
@@ -59,7 +59,8 @@ class ProfilePostsWidget extends WidgetBase {
                     if ($post_author->isPrivateProfile() && !$this->_user->hasPermission('profile.private.bypass')) continue;
                 } else if ($post_author->isPrivateProfile()) continue;
 
-                $link =  rtrim($post_author->getProfileURL(), '/');
+                $post_user = new User($post->user_id);
+                $link = rtrim($post_user->getProfileURL(), '/');
 
                 $posts_array[] = array(
                     'avatar' => $post_author->getAvatar(),


### PR DESCRIPTION
The link for the last profile post was generated incorrectly because the author of the post was used in generating the profile post link.