### PR TITLE
Add X-Frame-Options: SAMEORIGIN header via PHP

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,6 +12,8 @@
 // Uncomment to enable debugging
 define('DEBUGGING', 1);
 
+header("X-Frame-Options: SAMEORIGIN");
+
 if ((defined('DEBUGGING') && DEBUGGING) || (isset($_SERVER['NAMELESSMC_DEBUGGING']) && $_SERVER['NAMELESSMC_DEBUGGING'])) {
     ini_set('display_startup_errors', 1);
     ini_set('display_errors', 1);


### PR DESCRIPTION
Add X-Frame-Options: SAMEORIGIN header via PHP instead of .htaccess/nginx example config