### PR TITLE
Add clickable link in toastr when requesting debug url

### DIFF
--- a/custom/languages/EnglishUK/admin.php
+++ b/custom/languages/EnglishUK/admin.php
@@ -81,7 +81,7 @@ $language = [
     'debugging_and_maintenance' => 'Debugging & Maintenance',
     'maintenance' => 'Maintenance',
     'debug_link' => 'Debug Link',
-    'debug_link_toastr' => 'Copied debug link to your clipboard!',
+    'debug_link_toastr' => 'Copied debug link to your clipboard!<br>View the debug log <u><a href="{x}" target="_blank">here</a></u>', // Don't replace "{x}"
     'debugging_settings_updated_successfully' => 'Debugging settings updated successfully.',
     'enable_debug_mode' => 'Enable debug mode?',
     'force_https' => 'Force https?',

--- a/custom/panel_templates/Default/core/debugging_and_maintenance.tpl
+++ b/custom/panel_templates/Default/core/debugging_and_maintenance.tpl
@@ -127,7 +127,7 @@ $('#debug_link').click(() => {
             toastr.options.progressBar = true;
             toastr.options.closeButton = true;
             toastr.options.positionClass = 'toast-bottom-left';
-            toastr.info('{$TOASTR_COPIED}');
+            toastr.info('{$TOASTR_COPIED}'.replaceAll({literal}'{x}'{/literal}, url));
         });
 });
 </script>


### PR DESCRIPTION
Add the ability to click a "here" text when the toaster pops up when the debug link is generated. This will ensure that people can always get the URL, even if the copying to their clipboard for some reason fails