### PR TITLE
Add permission check to debug link query

### DIFF
--- a/error.php
+++ b/error.php
@@ -54,6 +54,7 @@ $smarty->assign([
     'ERROR_TYPE' => is_null($exception) ? $language->get('general', 'error') : (new ReflectionClass($exception))->getName(),
     'ERROR_STRING' => $error_string,
     'ERROR_FILE' => $error_file,
+    'CAN_GENERATE_DEBUG' => $user->hasPermission('admincp.core.debugging'),
     'DEBUG_LINK' => $language->get('admin', 'debug_link'),
     'DEBUG_LINK_URL' => URL::build('/queries/debug_link'),
     'ERROR_SQL_STACK' =>  QueryRecorder::getInstance()->getSqlStack(),

--- a/error.tpl
+++ b/error.tpl
@@ -38,17 +38,18 @@
                             <h2><kbd>{$ERROR_STRING}</kbd></h2>
                             <h3>(File: {$ERROR_FILE})</h3>
                             <a href="{$CURRENT_URL}">{$CURRENT_URL}</a>
-
-                            <button class="float-right btn btn-info d-flex align-items-center" id="debug_link">
-                                <span class="spinner-border spinner-border-sm mr-2" role="status" id="debug_link_loading" style="display: none;"></span>
-                                <span id="debug_link_text">{$DEBUG_LINK}</span>
-                                <span id="debug_link_success" style="display: none;">
-                                    <i class="fa fa-check"></i>
-                                </span>
-                                <span id="debug_link_error" style="display: none;">
-                                    <i class="fa fa-times-circle"></i>
-                                </span>
-                            </button>
+                            {if $CAN_GENERATE_DEBUG}
+                                <button class="float-right btn btn-info d-flex align-items-center" id="debug_link">
+                                    <span class="spinner-border spinner-border-sm mr-2" role="status" id="debug_link_loading" style="display: none;"></span>
+                                    <span id="debug_link_text">{$DEBUG_LINK}</span>
+                                    <span id="debug_link_success" style="display: none;">
+                                        <i class="fa fa-check"></i>
+                                    </span>
+                                    <span id="debug_link_error" style="display: none;">
+                                        <i class="fa fa-times-circle"></i>
+                                    </span>
+                                </button>
+                            {/if}
 
                         {else}
 
@@ -282,39 +283,41 @@ function openSqlFrame(id) {
     $('#sql-button-' + id).addClass('active');
 }
 
-let link_created = false;
+{if $CAN_GENERATE_DEBUG}
+    let link_created = false;
 
-$('#debug_link').click(() => {
-    $('#debug_link').blur();
+    $('#debug_link').click(() => {
+        $('#debug_link').blur();
 
-    if (link_created) {
-        return;
-    }
+        if (link_created) {
+            return;
+        }
 
-    $('#debug_link').prop('disabled', true);
-    $('#debug_link_loading').show(100);
-    $.get('{$DEBUG_LINK_URL}')
-        .done((url) => {
-            link_created = true;
+        $('#debug_link').prop('disabled', true);
+        $('#debug_link_loading').show(100);
+        $.get('{$DEBUG_LINK_URL}')
+            .done((url) => {
+                link_created = true;
 
-            $('#debug_link_loading').hide(100);
-            $('#debug_link').removeClass('btn-info');
-            $('#debug_link_text').hide();
-            $('#debug_link').prop('disabled', false);
+                $('#debug_link_loading').hide(100);
+                $('#debug_link').removeClass('btn-info');
+                $('#debug_link_text').hide();
+                $('#debug_link').prop('disabled', false);
 
-            if (!url.startsWith('https://debug.namelessmc.com/')) {
-                $('#debug_link').addClass('btn-danger');
-                $('#debug_link_error').show();
-                console.log(url);
-                alert('Could not create debug link. Check console for information.');
-            } else {
-                navigator.clipboard.writeText(url);
-                $('#debug_link').addClass('btn-success');
-                $('#debug_link_success').show();
-                alert('Copied debug link to your clipboard.');
-            }
-        });
-});
+                if (!url.startsWith('https://debug.namelessmc.com/')) {
+                    $('#debug_link').addClass('btn-danger');
+                    $('#debug_link_error').show();
+                    console.log(url);
+                    alert('Could not create debug link. Check console for information.');
+                } else {
+                    navigator.clipboard.writeText(url);
+                    $('#debug_link').addClass('btn-success');
+                    $('#debug_link_success').show();
+                    alert('Copied debug link to your clipboard.');
+                }
+            });
+    });
+{/if}
 </script>
 
 </html>

--- a/modules/Core/queries/debug_link.php
+++ b/modules/Core/queries/debug_link.php
@@ -1,5 +1,11 @@
 <?php
 
+// Can user generate the debug link?
+if(!$user->handlePanelPageLoad('admincp.core.debugging')) {
+    require_once(ROOT_PATH . '/403.php');
+    die();
+}
+
 $namelessmc_modules = [];
 $namelessmc_fe_templates = [];
 $namelessmc_panel_templates = [];

--- a/modules/Core/queries/debug_link.php
+++ b/modules/Core/queries/debug_link.php
@@ -1,7 +1,7 @@
 <?php
 
 // Can user generate the debug link?
-if(!$user->handlePanelPageLoad('admincp.core.debugging')) {
+if(!$user->hasPermission('admincp.core.debugging')) {
     require_once(ROOT_PATH . '/403.php');
     die();
 }


### PR DESCRIPTION
This is to prevent any random from the internet from generating a debug link and getting all the debug data from your website.