### PR TITLE
Server Compatibility icons on the left side

### DIFF
--- a/custom/panel_templates/Default/index.tpl
+++ b/custom/panel_templates/Default/index.tpl
@@ -104,8 +104,8 @@
                                 <!-- Card Body -->
                                 <div class="card-body">
                                     {$NAMELESS_VERSION}
-                                    <hr /> {foreach from=$COMPAT_SUCCESS item=item} {$item} <i class="fas fa-check-circle text-success"></i><br /> {/foreach} {if count($COMPAT_ERRORS)}
-                                    <hr /> {foreach from=$COMPAT_ERRORS item=item} {$item} <i class="fas fa-times-circle text-danger"></i><br /> {/foreach} {/if}
+                                    <hr /> {foreach from=$COMPAT_SUCCESS item=item} <i class="fas fa-check-circle text-success"></i> {$item} <br /> {/foreach} {if count($COMPAT_ERRORS)}
+                                    <hr /> {foreach from=$COMPAT_ERRORS item=item} <i class="fas fa-times-circle text-danger"> {$item} </i><br /> {/foreach} {/if}
                                 </div>
                             </div>
                             {/if}


### PR DESCRIPTION
Server Compatibility  iocns on the left side

Looks way more clean.

**Before**
![image](https://user-images.githubusercontent.com/11705513/145184064-dcb41af0-101f-44a1-80e9-45d7adf709d4.png)

**After**
![image](https://user-images.githubusercontent.com/11705513/145184102-297eca19-7a44-4305-8a31-40dba102d2a8.png)
