### PR TITLE
Froum Topic - Group Badges

### DIFF
--- a/custom/templates/DefaultRevamp/css/custom.css
+++ b/custom/templates/DefaultRevamp/css/custom.css
@@ -783,7 +783,7 @@ body.pushable>.pusher {
     margin: 0 .14285714em;
     background-color: #e8e8e8;
     background-image: none;
-    padding: .5833em .833em;
+    padding: 0.3em .3em;
     color: rgba(0, 0, 0, .6);
     text-transform: none;
     font-size: .85714286rem;

--- a/custom/templates/DefaultRevamp/forum/view_topic.tpl
+++ b/custom/templates/DefaultRevamp/forum/view_topic.tpl
@@ -121,10 +121,10 @@
                   <div class="sub header">{$reply.user_title}</div>
                 {/if}
               </h3>
-              {foreach from=$reply.user_groups item=group}
-                {$group}<br />
-              {/foreach}
             </center>
+              {foreach from=$reply.user_groups item=group}
+                {$group}
+              {/foreach}
             <div class="ui list">
               <div class="ui divider"></div>
               <div class="item">


### PR DESCRIPTION
Old Group badges formating is way to big and looks really ugly when you have a group with a long name or your have a lot of groups.
![image](https://user-images.githubusercontent.com/11705513/145870272-db59f830-b56e-4fa4-9adf-cc4ab49ca973.png)

That is my suggestion 
![image](https://user-images.githubusercontent.com/11705513/145870249-dcf90c69-83e8-4686-b05d-7fc4d6d668c0.png)