### PR TITLE
API route binding

### DIFF
--- a/core/classes/Endpoints/EndpointBase.php
+++ b/core/classes/Endpoints/EndpointBase.php
@@ -10,7 +10,7 @@
  *  EndpointsBase class
  */
 
-abstract class EndpointBase {
+class EndpointBase {
 
     protected string $_route;
     protected array $_route_aliases = [];
@@ -62,12 +62,4 @@ abstract class EndpointBase {
     public function getMethod(): string {
         return $this->_method;
     }
-
-    /**
-     * Execute this Endpoint.
-     *
-     * @param Nameless2API $api Instance of API class to use.
-     */
-    public abstract function execute(Nameless2API $api);
-
 }

--- a/core/classes/Endpoints/Endpoints.php
+++ b/core/classes/Endpoints/Endpoints.php
@@ -16,6 +16,11 @@ class Endpoints {
     private iterable $_endpoints = [];
 
     /**
+     * @var array Mapping of key names to closures to transform a variable into an object (ie, a user ID to a User object)
+     */
+    private static array $_transformers = [];
+
+    /**
      * Register an endpoint if it's route is not already taken.
      *
      * @param EndpointBase $endpoint Instance of endpoint class to register.
@@ -29,54 +34,112 @@ class Endpoints {
     }
 
     /**
-     * Find an endpoint which matches this request and `execute()` it.
-     *
-     * @param string $route Route to find endpoint for.
-     * @param string $method HTTP method to find endpoint for.
-     * @param Nameless2API $api Instance of api instance to provide the endpoint.
-     */
-    public function handle(string $route, string $method, Nameless2API $api) {
-
-        $available_methods = [];
-        $matched_endpoint = null;
-
-        foreach ($this->getAll() as $endpoint) {
-            if ($endpoint->getRoute() == $route || in_array($route, $endpoint->getRouteAliases())) {
-
-                if (in_array($route, $endpoint->getRouteAliases())) {
-                    Log::getInstance()->log(
-                        Log::Action('api/route_alias_used'),
-                        str_replace(['{x}', '{y}'], [$route, $endpoint->getRoute()], $api->getLanguage()->get('api', 'route_alias_used'))
-                    );
-                }
-
-                // Save that we actually found an endpoint
-                $matched_endpoint = $endpoint;
-                // Save the methods that are available for this endpoint
-                $available_methods[] = $endpoint->getMethod();
-
-                if ($endpoint->getMethod() == $method) {
-                    $endpoint->execute($api);
-                    return;
-                }
-
-            }
-        }
-
-        if ($matched_endpoint !== null) {
-            $api->throwError(3, $api->getLanguage()->get('api', 'invalid_api_method'), "The $route endpoint only accepts " . join(', ', $available_methods) . ", $method was used.", 405);
-            return;
-        }
-
-        $api->throwError(3, $api->getLanguage()->get('api', 'invalid_api_method'), 'If you are seeing this while in a browser, this does not mean your API is not functioning!', 404);
-    }
-
-    /**
      * Get all registered Endpoints
      *
      * @return EndpointBase[] All endpoints.
      */
     public function getAll(): iterable {
         return $this->_endpoints;
+    }
+
+    /**
+     * Find an endpoint which matches this request and `execute()` it.
+     *
+     * @param string $route Route to find endpoint for.
+     * @param string $method HTTP method to find endpoint for.
+     * @param Nameless2API $api Instance of api instance to provide the endpoint.
+     */
+    public function handle(string $route, string $method, Nameless2API $api): void {
+        $available_methods = [];
+        $matched_endpoint = null;
+
+        foreach ($this->getAll() as $endpoint) {
+            if (($vars = $this->matchRoute($endpoint, $route, $api)) !== false) {
+                // Save that we actually found an endpoint
+                $matched_endpoint = $endpoint;
+                // Save the methods that are available for this endpoint
+                $available_methods[] = $endpoint->getMethod();
+
+                if ($endpoint->getMethod() === $method) {
+                    if (!method_exists($endpoint, 'execute')) {
+                        $api->throwError(35, $api->getLanguage()->get('api', ''));
+                        die();
+                    }
+
+                    $endpoint->execute(
+                        $api,
+                        ...array_map(function ($type, $value) use ($api) {
+                            return $this::convertValue($api, $type, $value);
+                        }, array_keys($vars), $vars)
+                    );
+                    return;
+                }
+            }
+        }
+
+        if ($matched_endpoint !== null) {
+            $api->throwError(3, $api->getLanguage()->get('api', 'invalid_api_method'), "The $route endpoint only accepts " . implode(', ', $available_methods) . ", $method was used.", 405);
+            return;
+        }
+
+        $api->throwError(3, $api->getLanguage()->get('api', 'invalid_api_method'), 'If you are seeing this while in a browser, this does not mean your API is not functioning!', 404);
+    }
+
+    private function matchRoute(EndpointBase $endpoint, string $route, Nameless2API $api) {
+        if (in_array($route, $endpoint->getRouteAliases(), true)) {
+            $error = str_replace(['{x}', '{y}'], [$route, $endpoint->getRoute()], $api->getLanguage()->get('api', 'route_alias_used'));
+
+            Log::getInstance()->log(Log::Action('api/route_alias_used'), $error);
+
+            $api->throwError(3, $api->getLanguage()->get('api', 'route_alias_used'), $error);
+            die();
+        }
+
+        $endpoint_parts = explode('/', $endpoint->getRoute());
+        $endpoint_vars = [];
+
+        $route_parts = explode('/', $route);
+        $route_vars = [];
+
+        $idx = 0;
+        // first, find any variables (e.g. {user}) in the endpoint's route
+        // we save them to an array with their index so we can reference them later
+        foreach ($endpoint_parts as $part) {
+            if (strpos($part, '{') === 0 && substr($part, -1) === '}') {
+                $endpoint_vars[$idx] = substr($part, 1, -1);
+            }
+            $idx++;
+        }
+
+        $idx = 0;
+        // now we go over the route and, if each piece is a variable (according to its index), add it to the returned variable array
+        // otherwise, if it's not supposed to be a variable, we check if it matches the endpoint's respective route fragment and exit if it doesn't
+        foreach ($route_parts as $part) {
+            if (array_key_exists($idx, $endpoint_vars)) {
+                $route_vars[$endpoint_vars[$idx]] = $part;
+            } else if ($endpoint_parts[$idx] !== $part) {
+                return false;
+            }
+            $idx++;
+        }
+
+        return $route_vars;
+    }
+
+    public static function registerTransformer(string $type, Closure $transformer): void {
+        $reflection = new ReflectionFunction($transformer);
+        if ($reflection->getNumberOfParameters() !== 2) {
+            throw new InvalidArgumentException('Endpoint variable transformer must take 2 arguments (Nameless2API and the raw variable).');
+        }
+
+        self::$_transformers[$type] = $transformer;
+    }
+
+    private static function convertValue(Nameless2API $api, string $type, string $value) {
+        if (array_key_exists($type, self::$_transformers)) {
+            return self::$_transformers[$type]($api, $value);
+        }
+
+        return $value;
     }
 }

--- a/core/classes/Endpoints/Endpoints.php
+++ b/core/classes/Endpoints/Endpoints.php
@@ -62,8 +62,12 @@ class Endpoints {
 
                 if ($endpoint->getMethod() === $method) {
                     if (!method_exists($endpoint, 'execute')) {
-                        $api->throwError(35, $api->getLanguage()->get('api', ''));
-                        die();
+                        throw new InvalidArgumentException("Endpoint class must contain an 'execute()' method.");
+                    }
+
+                    $reflection = new ReflectionMethod($endpoint, 'execute');
+                    if ($reflection->getNumberOfParameters() !== (count($vars) + 1)) {
+                        throw new InvalidArgumentException("Endpoint's 'execute()' method must take " . (count($vars) + 1) . " arguments.");
                     }
 
                     $endpoint->execute(
@@ -85,6 +89,15 @@ class Endpoints {
         $api->throwError(3, $api->getLanguage()->get('api', 'invalid_api_method'), 'If you are seeing this while in a browser, this does not mean your API is not functioning!', 404);
     }
 
+    /**
+     * Determine if an Endpoint matches a route.
+     * If it does, return an array of variables to pass to the endpoint.
+     *
+     * @param EndpointBase $endpoint Endpoint to attempt to match.
+     * @param string $route Route to match.
+     * @param Nameless2API $api Instance of API instance to provide the endpoint.
+     * @return array|false Array of variables to pass to the endpoint, or false if the route does not match.
+     */
     private function matchRoute(EndpointBase $endpoint, string $route, Nameless2API $api) {
         if (in_array($route, $endpoint->getRouteAliases(), true)) {
             $error = str_replace(['{x}', '{y}'], [$route, $endpoint->getRoute()], $api->getLanguage()->get('api', 'route_alias_used'));
@@ -101,40 +114,63 @@ class Endpoints {
         $route_parts = explode('/', $route);
         $route_vars = [];
 
-        $idx = 0;
+        $i = 0;
         // first, find any variables (e.g. {user}) in the endpoint's route
-        // we save them to an array with their index so we can reference them later
+        // we save them to an array with their index, so we can reference them later
         foreach ($endpoint_parts as $part) {
             if (strpos($part, '{') === 0 && substr($part, -1) === '}') {
-                $endpoint_vars[$idx] = substr($part, 1, -1);
+                $endpoint_vars[$i] = substr($part, 1, -1);
             }
-            $idx++;
+            $i++;
         }
 
-        $idx = 0;
+        $i = 0;
         // now we go over the route and, if each piece is a variable (according to its index), add it to the returned variable array
         // otherwise, if it's not supposed to be a variable, we check if it matches the endpoint's respective route fragment and exit if it doesn't
         foreach ($route_parts as $part) {
-            if (array_key_exists($idx, $endpoint_vars)) {
-                $route_vars[$endpoint_vars[$idx]] = $part;
-            } else if ($endpoint_parts[$idx] !== $part) {
+            if (array_key_exists($i, $endpoint_vars)) {
+                $route_vars[$endpoint_vars[$i]] = $part;
+            } else if ($endpoint_parts[$i] !== $part) {
                 return false;
             }
-            $idx++;
+            $i++;
         }
 
         return $route_vars;
     }
 
+    /**
+     * Register a transformer for API route binding.
+     *
+     * @param string $type The name of the transformer. This is used to identify the transformer when binding.
+     * @param Closure(Nameless2API, string): mixed $transformer Function which converts the value in the URL to the desired type.
+     */
     public static function registerTransformer(string $type, Closure $transformer): void {
+        if (isset(self::$_transformers[$type])) {
+            throw new InvalidArgumentException("A transformer with for the type '$type' has already been registered.");
+        }
+
         $reflection = new ReflectionFunction($transformer);
         if ($reflection->getNumberOfParameters() !== 2) {
             throw new InvalidArgumentException('Endpoint variable transformer must take 2 arguments (Nameless2API and the raw variable).');
         }
 
+        // if they've provided a typehint for the first argument, make sure it's taking Nameless2API
+        $param = $reflection->getParameters()[0];
+        if ($param->getType() instanceof ReflectionNamedType && $param->getType()->getName() !== Nameless2API::class) {
+            throw new InvalidArgumentException('Endpoint variable transformer must take Nameless2API as the first argument.');
+        }
+
         self::$_transformers[$type] = $transformer;
     }
 
+    /**
+     * Convert a value through a transformer based on its type. If no transformer is found, the value is returned as-is.
+     *
+     * @param Nameless2API $api Instance of API to provide the transformer.
+     * @param string $type The type to use.
+     * @param string $value The value to convert.
+     */
     private static function convertValue(Nameless2API $api, string $type, string $value) {
         if (array_key_exists($type, self::$_transformers)) {
             return self::$_transformers[$type]($api, $value);

--- a/core/classes/Endpoints/Endpoints.php
+++ b/core/classes/Endpoints/Endpoints.php
@@ -82,7 +82,7 @@ class Endpoints {
                     $endpoint->execute(
                         $api,
                         ...array_map(function ($type, $value) use ($api) {
-                            return $this::convertValue($api, $type, $value);
+                            return $this::transform($api, $type, $value);
                         }, array_keys($vars), $vars)
                     );
                     return;
@@ -184,7 +184,7 @@ class Endpoints {
      * @param string $type The type to use.
      * @param string $value The value to convert.
      */
-    private static function convertValue(Nameless2API $api, string $type, string $value) {
+    private static function transform(Nameless2API $api, string $type, string $value) {
         if (array_key_exists($type, self::$_transformers)) {
             return self::$_transformers[$type]['transformer']($api, $value);
         }

--- a/core/classes/Endpoints/Endpoints.php
+++ b/core/classes/Endpoints/Endpoints.php
@@ -43,6 +43,15 @@ class Endpoints {
     }
 
     /**
+     * Get all registered transformers
+     *
+     * @return array All transformers.
+     */
+    public static function getAllTransformers(): array {
+        return self::$_transformers;
+    }
+
+    /**
      * Find an endpoint which matches this request and `execute()` it.
      *
      * @param string $route Route to find endpoint for.
@@ -143,9 +152,10 @@ class Endpoints {
      * Register a transformer for API route binding.
      *
      * @param string $type The name of the transformer. This is used to identify the transformer when binding.
+     * @param string $module The name of the module that registered the transformer.
      * @param Closure(Nameless2API, string): mixed $transformer Function which converts the value in the URL to the desired type.
      */
-    public static function registerTransformer(string $type, Closure $transformer): void {
+    public static function registerTransformer(string $type, string $module, Closure $transformer): void {
         if (isset(self::$_transformers[$type])) {
             throw new InvalidArgumentException("A transformer with for the type '$type' has already been registered.");
         }
@@ -161,7 +171,10 @@ class Endpoints {
             throw new InvalidArgumentException('Endpoint variable transformer must take Nameless2API as the first argument.');
         }
 
-        self::$_transformers[$type] = $transformer;
+        self::$_transformers[$type] = [
+            'module' => $module,
+            'transformer' => $transformer,
+        ];
     }
 
     /**
@@ -173,7 +186,7 @@ class Endpoints {
      */
     private static function convertValue(Nameless2API $api, string $type, string $value) {
         if (array_key_exists($type, self::$_transformers)) {
-            return self::$_transformers[$type]($api, $value);
+            return self::$_transformers[$type]['transformer']($api, $value);
         }
 
         return $value;

--- a/custom/languages/EnglishUK/admin.php
+++ b/custom/languages/EnglishUK/admin.php
@@ -631,6 +631,8 @@ $language = [
     'api_endpoints' => 'API Endpoints',
     'api_endpoints_info' => 'API Endpoints allow Modules to create ways for external applications (such as Minecraft and Discord) to interact with your NamelessMC website. <a href="https://docs.namelessmc.com/en/api-documentation" target="_blank">Check out the API documentation here</a>',
     'route' => 'Route',
+    'method' => 'Method',
+    'transformers' => 'Transformers',
 
     // File uploads
     'drag_files_here' => 'Drag files here to upload.',

--- a/custom/panel_templates/Default/core/api_endpoints.tpl
+++ b/custom/panel_templates/Default/core/api_endpoints.tpl
@@ -54,7 +54,7 @@
                                                 <th>{$ROUTE}</th>
                                                 <th>{$DESCRIPTION}</th>
                                                 <th>{$MODULE}</th>
-                                                <th>Method</th>
+                                                <th>{$METHOD}</th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -71,6 +71,39 @@
                                                 </td>
                                                 <td>
                                                     <div><kbd>{$endpoint.method}</kbd></div>
+                                                </td>
+                                            </tr>
+                                        {/foreach}
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <hr />
+                            {/if}
+
+                        </div>
+                    </div>
+
+                    <div class="card shadow mb-4">
+                        <div class="card-body">
+                            <h5>{$TRANSFORMERS}</h5>
+
+                            {if count($TRANSFORMERS_ARRAY)}
+                                <div class="table-responsive">
+                                    <table class="table table-borderless table-striped">
+                                        <thead>
+                                            <tr>
+                                                <th>{$TYPE}</th>
+                                                <th>{$MODULE}</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                        {foreach from=$TRANSFORMERS_ARRAY key=type item=transformer}
+                                            <tr>
+                                                <td>
+                                                    <div><code>{literal}{{/literal}{$type}{literal}}{/literal}</code></div>
+                                                </td>
+                                                <td>
+                                                    <div>{$transformer.module}</div>
                                                 </td>
                                             </tr>
                                         {/foreach}

--- a/modules/Core/classes/Misc/Nameless2API.php
+++ b/modules/Core/classes/Misc/Nameless2API.php
@@ -11,7 +11,9 @@ class Nameless2API {
             $this->_language = $api_language;
 
             $explode = explode('/', $route);
+            $using_header = false;
 
+            // attempt to get api key from the url
             for ($i = count($explode) - 1; $i >= 0; $i--) {
                 if (strlen($explode[$i]) == 32) {
                     if ($this->validateKey($explode[$i])) {
@@ -21,12 +23,22 @@ class Nameless2API {
                 }
             }
 
+            // if there is no api key in the url, attempt to get it from the X-API-KEY header
+            if (!isset($api_key)) {
+                if (isset($_SERVER['HTTP_X_API_KEY'])) {
+                    if ($this->validateKey($_SERVER['HTTP_X_API_KEY'])) {
+                        $api_key = $_SERVER['HTTP_X_API_KEY'];
+                        $using_header = true;
+                    }
+                }
+            }
+
             if (!isset($api_key)) {
                 $this->throwError(1, $this->_language->get('api', 'invalid_api_key'));
             }
 
             $route = explode('/', $route);
-            $route = array_slice($route, 4);
+            $route = array_slice($route, $using_header ? 3 : 4);
             $route = implode('/', $route);
 
             $_POST = json_decode(file_get_contents('php://input'), true);

--- a/modules/Core/includes/endpoints/GetUserEndpoint.php
+++ b/modules/Core/includes/endpoints/GetUserEndpoint.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * POC, remove upon merge... or not :O
+ */
+class GetUserEndpoint extends EndpointBase {
+
+    public function __construct() {
+        $this->_route = 'user/{user}';
+        $this->_module = 'Core';
+        $this->_description = 'Get a NamelessMC user by their NamelessMC ID';
+        $this->_method = 'GET';
+    }
+
+    public function execute(Nameless2API $api, User $user) {
+        die(json_encode($user->data()));
+    }
+
+}

--- a/modules/Core/module.php
+++ b/modules/Core/module.php
@@ -362,6 +362,15 @@ class Core_Module extends Module {
 
         GroupSyncManager::getInstance()->registerInjector(NamelessMCGroupSyncInjector::class);
         GroupSyncManager::getInstance()->registerInjector(MinecraftGroupSyncInjector::class);
+
+        Endpoints::registerTransformer('user', static function (Nameless2API $api, $value) {
+            $user = new User($value);
+            if (!$user->exists()) {
+                $api->throwError(16, $api->getLanguage()->get('api', 'unable_to_find_user'));
+                die();
+            }
+            return $user;
+        });
     }
 
     public static function getDashboardGraphs(): array {

--- a/modules/Core/module.php
+++ b/modules/Core/module.php
@@ -363,7 +363,7 @@ class Core_Module extends Module {
         GroupSyncManager::getInstance()->registerInjector(NamelessMCGroupSyncInjector::class);
         GroupSyncManager::getInstance()->registerInjector(MinecraftGroupSyncInjector::class);
 
-        Endpoints::registerTransformer('user', static function (Nameless2API $api, $value) {
+        Endpoints::registerTransformer('user', 'Core', static function (Nameless2API $api, $value) {
             $user = new User($value);
             if (!$user->exists()) {
                 $api->throwError(16, $api->getLanguage()->get('api', 'unable_to_find_user'));

--- a/modules/Core/pages/panel/api.php
+++ b/modules/Core/pages/panel/api.php
@@ -343,8 +343,12 @@ if (!isset($_GET['view'])) {
                     'ROUTE' => $language->get('admin', 'route'),
                     'DESCRIPTION' => $language->get('admin', 'description'),
                     'MODULE' => $language->get('admin', 'module'),
+                    'METHOD' => $language->get('admin', 'method'),
                     'ENDPOINTS_INFO' => $language->get('admin', 'api_endpoints_info'),
-                    'ENDPOINTS_ARRAY' => $endpoints_array
+                    'ENDPOINTS_ARRAY' => $endpoints_array,
+                    'TYPE' => $language->get('admin', 'type'),
+                    'TRANSFORMERS' => $language->get('admin', 'transformers'),
+                    'TRANSFORMERS_ARRAY' => Endpoints::getAllTransformers(),
                 ]
             );
 


### PR DESCRIPTION
API "route binding" is a feature which will allow us to simplify the DX of most of our API endpoints, especially simple GET ones.

### Without route binding:
- GET requests are ugly and annoying to debug
- Endpoints have to validate the params themselves
- To use variables passed to the endpoint, they are stored in a simple `<string, string>` array, with no real type checking.
- Example request: `https://example.com/api/users/ban?id=1`

### With route binding:
- "Seamless" routes
- All param validation is done before the request is sent to an Endpoint class
- Params are passed as arguments to the `execute(Nameless2API $api, ...)` method in the Endpoint class, with type checking.
- Example request: `https://example.com/api/users/1/ban`

### How does it work?
Given the second example request above:
- An Endpoint, in this case probably something called `UserBanEndpoint` would register the route as `users/{user}/ban`
- When a request is made, we look for a "transformer" for the `{user}` type
    - Transformer closures are required to have 2 arguments, the first one being a `Nameless2API` instance and the second is the raw value from the request (1)
	- This transformer is built into the Core module (see it's module.php)
	- We call the transformers closure to generate a User object from it's ID (1)
		- Since transformers are required to have an `Nameless2API` argument, if something goes wrong while generating the User object we can call `$api->throwError(...);`
- Finally, the `execute(...)` method in the Endpoint class will be provided the resolved User object in its params. 

### Notes
- Modules can (obviously) register their own transformers using `Endpoints::registerTransformer(string $type, Closure $transformer);`
- Code is yucky, I'll deal with it tomorrow!
- Might add something to the API section of StaffCP to see all registered transformers...
- This will require us to change API endpoints in the next update when merged, so anything which uses an old Endpoint route will not work. Since I think its mainly stuff maintained by us that uses the API, we should be fine - but yeah. Breaking changes! whee
