### PR TITLE
Emailing refactor!

### DIFF
--- a/core/classes/Core/Email.php
+++ b/core/classes/Core/Email.php
@@ -22,6 +22,11 @@ class Email {
     public const MASS_MESSAGE = 6;
 
     /**
+     * @var array Placeholders for email templates
+     */
+    private static array $_message_placeholders;
+
+    /**
      * Send an email.
      *
      * @param array $recipient Array containing `'email'` and `'name'` strings for the recipient of the email.
@@ -136,26 +141,36 @@ class Email {
     }
 
     /**
+     * Add a custom placeholder/variable for email messages.
+     * @param string $key The key to use for the placeholder, should be enclosed in square brackets.
+     * @param string $value The value to replace the placeholder with.
+     */
+    public static function addPlaceholder(string $key, string $value): void {
+        self::$_message_placeholders[$key] = $value;
+    }
+
+    /**
      * Format an email template and replace placeholders.
      *
      * @param string $email Name of email to format.
      * @param Language $viewing_language Instance of Language class to use for translations.
+     *
+     * @return string Formatted email.
      */
     public static function formatEmail(string $email, Language $viewing_language): string {
         return str_replace(
-        // TODO: let modules add their own placeholders here? :o
-            [
+            array_merge([
                 '[Sitename]',
                 '[Greeting]',
                 '[Message]',
                 '[Thanks]',
-            ],
-            [
+            ], array_keys(self::$_message_placeholders)),
+            array_merge([
                 SITE_NAME,
                 $viewing_language->get('emails', 'greeting'),
                 $viewing_language->get('emails', $email . '_message'),
                 $viewing_language->get('emails', 'thanks'),
-            ],
+            ], array_values(self::$_message_placeholders)),
             file_get_contents(implode(DIRECTORY_SEPARATOR, [ROOT_PATH, 'custom', 'templates', TEMPLATE, 'email', $email . '.html']))
         );
     }

--- a/core/classes/Core/Email.php
+++ b/core/classes/Core/Email.php
@@ -57,19 +57,15 @@ class Email {
      * @return array|bool
      */
     private static function sendPHP(array $email) {
-        if (!array_key_exists('headers', $email)) {
-            $outgoing_email = Util::getSetting(DB::getInstance(), 'outgoing_email');
-            $incoming_email = Util::getSetting(DB::getInstance(), 'incoming_email');
+        $outgoing_email = Util::getSetting(DB::getInstance(), 'outgoing_email');
+        $incoming_email = Util::getSetting(DB::getInstance(), 'incoming_email');
 
-            $email['headers'] = [
-                'From' => $outgoing_email,
-                'Reply-To' => $incoming_email,
-                'MIME-Version' => '1.0',
-                'Content-type' => 'text/html; charset=UTF-8'
-            ];
-        }
-
-        if (mail($email['to']['email'], $email['subject'], $email['message'], $email['headers'])) {
+        if (mail($email['to']['email'], $email['subject'], $email['message'], [
+            'From' => $outgoing_email,
+            'Reply-To' => $incoming_email,
+            'MIME-Version' => '1.0',
+            'Content-type' => 'text/html; charset=UTF-8'
+        ])) {
             return true;
         }
 

--- a/core/classes/Core/Email.php
+++ b/core/classes/Core/Email.php
@@ -66,7 +66,7 @@ class Email {
         $incoming_email = Util::getSetting(DB::getInstance(), 'incoming_email');
 
         if (mail($email['to']['email'], $email['subject'], $email['message'], [
-            'From' => $outgoing_email,
+            'From' => SITE_NAME . ' ' . '<' . $outgoing_email . '>',
             'Reply-To' => $incoming_email,
             'MIME-Version' => '1.0',
             'Content-type' => 'text/html; charset=UTF-8'
@@ -142,6 +142,8 @@ class Email {
 
     /**
      * Add a custom placeholder/variable for email messages.
+     * Not used internally, but can be used by other modules.
+     *
      * @param string $key The key to use for the placeholder, should be enclosed in square brackets.
      * @param string $value The value to replace the placeholder with.
      */

--- a/core/classes/Core/Email.php
+++ b/core/classes/Core/Email.php
@@ -10,25 +10,43 @@
 */
 
 use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
 
 class Email {
+
+    public const REGISTRATION = 1;
+    public const CONTACT = 2;
+    public const FORGOT_PASSWORD = 3;
+    public const API_REGISTRATION = 4;
+    public const FORUM_TOPIC_REPLY = 5;
+    public const MASS_MESSAGE = 6;
 
     /**
      * Send an email.
      *
-     * @param array $email Array containing all necessary email information to send as per the sendPHP and sendMailer functions.
-     * @param string $method Email sending method to use (`php` or `mailer`). Uses `php` if not provided.
+     * @param array $recipient Array containing `'email'` and `'name'` strings for the recipient of the email.
+     * @param string $subject Subject of the email.
+     * @param string $message Message of the email.
+     * @param ?array $reply_to Array containing `'email'` and `'name'` strings for the reply-to address.
+     *
+     * @return bool|array Returns true if email sent, otherwise returns an array containing the error.
      */
-    public static function send(array $email, string $method = 'php') {
-        if ($method == 'php') {
-            return self::sendPHP($email);
+    public static function send(array $recipient, string $subject, string $message, ?array $reply_to = null) {
+        $email = [
+            'to' => $recipient,
+            'subject' => $subject,
+            'message' => $message,
+        ];
+
+        if ($reply_to !== null) {
+            $email['replyto'] = $reply_to;
         }
 
-        if ($method == 'mailer') {
+        if (Util::getSetting(DB::getInstance(), 'phpmailer') == '1') {
             return self::sendMailer($email);
         }
 
-        return false;
+        return self::sendPHP($email);
     }
 
     /**
@@ -39,23 +57,27 @@ class Email {
      * @return array|bool
      */
     private static function sendPHP(array $email) {
-        try {
+        if (!array_key_exists('headers', $email)) {
+            $outgoing_email = Util::getSetting(DB::getInstance(), 'outgoing_email');
+            $incoming_email = Util::getSetting(DB::getInstance(), 'incoming_email');
 
-            if (mail($email['to'], $email['subject'], $email['message'], $email['headers'])) {
-                return true;
-            }
-
-            $error = error_get_last();
-
-            return [
-                'error' => $error['message'] ?? 'Unknown error'
-            ];
-
-        } catch (Exception $e) {
-            return [
-                'error' => $e->getMessage()
+            $email['headers'] = [
+                'From' => $outgoing_email,
+                'Reply-To' => $incoming_email,
+                'MIME-Version' => '1.0',
+                'Content-type' => 'text/html; charset=UTF-8'
             ];
         }
+
+        if (mail($email['to']['email'], $email['subject'], $email['message'], $email['headers'])) {
+            return true;
+        }
+
+        $error = error_get_last();
+
+        return [
+            'error' => $error['message'] ?? 'Unknown error'
+        ];
     }
 
     /**
@@ -74,7 +96,7 @@ class Email {
         try {
             // init
             $mail->IsSMTP();
-            $mail->SMTPDebug = 0;
+            $mail->SMTPDebug = SMTP::DEBUG_OFF;
             $mail->Debugoutput = 'html';
             $mail->CharSet = 'UTF-8';
             $mail->Encoding = 'base64';

--- a/custom/templates/DefaultRevamp/email/api_register.html
+++ b/custom/templates/DefaultRevamp/email/api_register.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <title>[Sitename] &bull; [Register]</title>
+  <title>[Sitename]</title>
 </head>
 <body>
 <div style="width: 640px; font-family: Arial, Helvetica, sans-serif; font-size: 11px;">

--- a/custom/templates/DefaultRevamp/email/change_password.html
+++ b/custom/templates/DefaultRevamp/email/change_password.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <title>[Sitename] &bull; [ChangePassword]</title>
+  <title>[Sitename]</title>
 </head>
 <body>
 <div style="width: 640px; font-family: Arial, Helvetica, sans-serif; font-size: 11px;">

--- a/custom/templates/DefaultRevamp/email/register.html
+++ b/custom/templates/DefaultRevamp/email/register.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <title>[Sitename] &bull; [Register]</title>
+  <title>[Sitename]</title>
 </head>
 <body>
 <div style="width: 640px; font-family: Arial, Helvetica, sans-serif; font-size: 11px;">

--- a/custom/templates/DefaultRevamp/email/tfa.html
+++ b/custom/templates/DefaultRevamp/email/tfa.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-  <title>[Sitename] &bull; [tfa]</title>
+  <title>[Sitename]</title>
 </head>
 <body>
 <div style="width: 640px; font-family: Arial, Helvetica, sans-serif; font-size: 11px;">

--- a/modules/Core/includes/emails/register.php
+++ b/modules/Core/includes/emails/register.php
@@ -19,7 +19,6 @@ function sendRegisterEmail(Queries $queries, Language $language, string $email_a
     );
 
     if (isset($sent['error'])) {
-        // Error, log it
         $queries->create('email_errors', [
             'type' => Email::REGISTRATION,
             'content' => $sent['error'],

--- a/modules/Core/includes/emails/register.php
+++ b/modules/Core/includes/emails/register.php
@@ -10,54 +10,22 @@
  */
 
 function sendRegisterEmail(Queries $queries, Language $language, string $email_address, string $username, int $user_id, string $code): bool {
-    $php_mailer = $queries->getWhere('settings', ['name', '=', 'phpmailer']);
-    $php_mailer = $php_mailer[0]->value;
-
     $link = rtrim(Util::getSelfURL(), '/') . URL::build('/validate/', 'c=' . $code);
 
-    if ($php_mailer == '1') {
-        // PHP Mailer
-        $email = [
-            'to' => ['email' => Output::getClean($email_address), 'name' => Output::getClean($username)],
-            'subject' => SITE_NAME . ' - ' . $language->get('emails', 'register_subject'),
-            'message' => str_replace('[Link]', $link, Email::formatEmail('register', $language))
-        ];
-
-        $sent = Email::send($email, 'mailer');
-
-    } else {
-        // PHP mail function
-        $siteemail = $queries->getWhere('settings', ['name', '=', 'outgoing_email']);
-        $siteemail = $siteemail[0]->value;
-
-        $headers = 'From: ' . $siteemail . "\r\n" .
-            'Reply-To: ' . $siteemail . "\r\n" .
-            'X-Mailer: PHP/' . PHP_VERSION . "\r\n" .
-            'MIME-Version: 1.0' . "\r\n" .
-            'Content-type: text/html; charset=UTF-8' . "\r\n";
-
-        $email = [
-            'to' => $email_address,
-            'subject' => SITE_NAME . ' - ' . $language->get('emails', 'register_subject'),
-            'message' => str_replace('[Link]', $link, Email::formatEmail('register', $language)),
-            'headers' => $headers
-        ];
-
-        $sent = Email::send($email);
-
-    }
+    $sent = Email::send(
+        ['email' => Output::getClean($email_address), 'name' => Output::getClean($username)],
+        SITE_NAME . ' - ' . $language->get('emails', 'register_subject'),
+        str_replace('[Link]', $link, Email::formatEmail('register', $language))
+    );
 
     if (isset($sent['error'])) {
         // Error, log it
-        $queries->create(
-            'email_errors',
-            [
-                'type' => 1, // 1 = registration
-                'content' => $sent['error'],
-                'at' => date('U'),
-                'user_id' => $user_id
-            ]
-        );
+        $queries->create('email_errors', [
+            'type' => Email::REGISTRATION,
+            'content' => $sent['error'],
+            'at' => date('U'),
+            'user_id' => $user_id
+        ]);
 
         return false;
     }

--- a/modules/Core/includes/endpoints/RegisterEndpoint.php
+++ b/modules/Core/includes/endpoints/RegisterEndpoint.php
@@ -199,7 +199,6 @@ class RegisterEndpoint extends KeyAuthEndpoint {
         );
 
         if (isset($sent['error'])) {
-            // Error, log it
             $api->getDb()->insert('email_errors', [
                     'type' => Email::API_REGISTRATION,
                     'content' => $sent['error'],

--- a/modules/Core/includes/endpoints/RegisterEndpoint.php
+++ b/modules/Core/includes/endpoints/RegisterEndpoint.php
@@ -204,8 +204,7 @@ class RegisterEndpoint extends KeyAuthEndpoint {
                     'content' => $sent['error'],
                     'at' => date('U'),
                     'user_id' => $user_id
-                ]
-            );
+            ]);
 
             $api->throwError(14, $api->getLanguage()->get('api', 'unable_to_send_registration_email'));
         }
@@ -218,8 +217,7 @@ class RegisterEndpoint extends KeyAuthEndpoint {
                 'avatar_url' => $user->getAvatar(128, true),
                 'url' => Util::getSelfURL() . ltrim(URL::build('/profile/' . Output::getClean($username)), '/'),
                 'language' => $api->getLanguage()
-            ]
-        );
+        ]);
 
         $api->returnArray(['message' => $api->getLanguage()->get('api', 'finish_registration_email')]);
     }

--- a/modules/Core/pages/contact.php
+++ b/modules/Core/pages/contact.php
@@ -55,7 +55,6 @@ if (Input::exists()) {
                     );
 
                     if (isset($sent['error'])) {
-                        // Error, log it
                         $queries->create('email_errors', [
                             'type' => Email::CONTACT,
                             'content' => $sent['error'],

--- a/modules/Core/pages/contact.php
+++ b/modules/Core/pages/contact.php
@@ -47,69 +47,27 @@ if (Input::exists()) {
                 ]);
 
                 if ($validation->passed()) {
-                    try {
-                        $php_mailer = $queries->getWhere('settings', ['name', '=', 'phpmailer']);
-                        $php_mailer = $php_mailer[0]->value;
+                    $sent = Email::send(
+                        ['email' => Output::getClean(Util::getSetting(DB::getInstance(), 'incoming_email')), 'name' => Output::getClean(SITE_NAME)],
+                        SITE_NAME . ' - ' . $language->get('general', 'contact_email_subject'),
+                        Output::getClean(Input::get('content')),
+                        ['email' => Output::getClean(Input::get('email')), 'name' => Output::getClean(Input::get('email'))]
+                    );
 
-                        $contactemail = $queries->getWhere('settings', ['name', '=', 'incoming_email']);
-                        $contactemail = $contactemail[0]->value;
+                    if (isset($sent['error'])) {
+                        // Error, log it
+                        $queries->create('email_errors', [
+                            'type' => Email::CONTACT,
+                            'content' => $sent['error'],
+                            'at' => date('U'),
+                            'user_id' => ($user->isLoggedIn() ? $user->data()->id : null)
+                        ]);
 
-                        if ($php_mailer == '1') {
-                            // PHP Mailer
-                            $html = Output::getClean(Input::get('content'));
-
-                            $email = [
-                                'replyto' => ['email' => Output::getClean(Input::get('email')), 'name' => Output::getClean(Input::get('email'))],
-                                'to' => ['email' => Output::getClean($contactemail), 'name' => Output::getClean(SITE_NAME)],
-                                'subject' => SITE_NAME . ' - ' . $language->get('general', 'contact_email_subject'),
-                                'message' => $html
-                            ];
-
-                            $sent = Email::send($email, 'mailer');
-
-                        } else {
-                            // PHP mail function
-                            $siteemail = $queries->getWhere('settings', ['name', '=', 'outgoing_email']);
-                            $siteemail = $siteemail[0]->value;
-
-                            $to = $contactemail;
-                            $subject = SITE_NAME . ' - ' . $language->get('general', 'contact_email_subject');
-
-                            $message = Output::getClean(Input::get('content'));
-                            $fromemail = Output::getClean(Input::get('email'));
-
-                            $headers = 'From: ' . $siteemail . "\r\n" .
-                                'Reply-To: ' . $fromemail . "\r\n" .
-                                'X-Mailer: PHP/' . PHP_VERSION . "\r\n" .
-                                'MIME-Version: 1.0' . "\r\n" .
-                                'Content-type: text/html; charset=UTF-8' . "\r\n";
-
-                            $email = [
-                                'to' => $to,
-                                'subject' => $subject,
-                                'message' => $message,
-                                'headers' => $headers
-                            ];
-
-                            $sent = Email::send($email);
-
-                        }
-                        if (isset($sent['error'])) {
-                            // Error, log it
-                            $queries->create('email_errors', [
-                                'type' => 2, // 2 = contact
-                                'content' => $sent['error'],
-                                'at' => date('U'),
-                                'user_id' => ($user->isLoggedIn() ? $user->data()->id : null)
-                            ]);
-                        }
-                    } catch (Exception $e) {
-                        // Error
-                        $error = $e->getMessage();
+                        $errors = $sent['error'];
+                    } else {
+                        $_SESSION['last_contact_sent'] = date('U');
+                        $success = $language->get('general', 'contact_message_sent');
                     }
-
-                    $_SESSION['last_contact_sent'] = date('U');
-                    $success = $language->get('general', 'contact_message_sent');
                 } else {
                     $errors = $validation->errors();
                 }

--- a/modules/Core/pages/forgot_password.php
+++ b/modules/Core/pages/forgot_password.php
@@ -45,7 +45,6 @@ if (!isset($_GET['c'])) {
                     );
 
                     if (isset($sent['error'])) {
-                        // Error, log it
                         $queries->create('email_errors', [
                             'type' => Email::FORGOT_PASSWORD,
                             'content' => $sent['error'],

--- a/modules/Core/pages/panel/emails.php
+++ b/modules/Core/pages/panel/emails.php
@@ -47,46 +47,12 @@ if (isset($_GET['action'])) {
         if (isset($_GET['do']) && $_GET['do'] == 'send') {
             $errors = [];
 
-            $php_mailer = $queries->getWhere('settings', ['name', '=', 'phpmailer']);
-            $php_mailer = $php_mailer[0]->value;
+            $sent = Email::send(
+                ['email' => Output::getClean($user->data()->email), 'name' => Output::getClean($user->data()->nickname)],
+                SITE_NAME . ' - Test Email',
+                SITE_NAME . ' - Test email successful!'
+            );
 
-            if ($php_mailer == '1') {
-
-                // PHP Mailer
-                $email = [
-                    'to' => ['email' => Output::getClean($user->data()->email), 'name' => Output::getClean($user->data()->nickname)],
-                    'subject' => SITE_NAME . ' - Test Email',
-                    'message' => SITE_NAME . ' - Test email successful!',
-                ];
-
-                $sent = Email::send($email, 'mailer');
-
-            } else {
-                // PHP mail function
-                $siteemail = $queries->getWhere('settings', ['name', '=', 'outgoing_email']);
-                $siteemail = $siteemail[0]->value;
-
-                $to = $user->data()->email;
-                $subject = SITE_NAME . ' - Test Email';
-
-                $message = SITE_NAME . ' - Test email successful!';
-
-                $headers = 'From: ' . $siteemail . "\r\n" .
-                    'Reply-To: ' . $siteemail . "\r\n" .
-                    'X-Mailer: PHP/' . PHP_VERSION . "\r\n" .
-                    'MIME-Version: 1.0' . "\r\n" .
-                    'Content-type: text/html; charset=UTF-8' . "\r\n";
-
-                $email = [
-                    'to' => $to,
-                    'subject' => $subject,
-                    'message' => $message,
-                    'headers' => $headers
-                ];
-
-                $sent = Email::send($email);
-
-            }
             if (isset($sent['error'])) {
                 $errors[] = $sent['error'];
             }

--- a/modules/Core/pages/panel/emails_errors.php
+++ b/modules/Core/pages/panel/emails_errors.php
@@ -50,22 +50,22 @@ if (isset($_GET['do'])) {
         $error = $error[0];
 
         switch ($error->type) {
-            case 1:
+            case Email::REGISTRATION:
                 $type = $language->get('admin', 'registration_email');
                 break;
-            case 2:
+            case Email::CONTACT:
                 $type = $language->get('admin', 'contact_email');
                 break;
-            case 3:
+            case Email::FORGOT_PASSWORD:
                 $type = $language->get('admin', 'forgot_password_email');
                 break;
-            case 4:
+            case Email::API_REGISTRATION:
                 $type = $language->get('admin', 'api_registration_email');
                 break;
-            case 5:
+            case Email::FORUM_TOPIC_REPLY:
                 $type = $language->get('admin', 'forum_topic_reply_email');
                 break;
-            case 6:
+            case Email::MASS_MESSAGE:
                 $type = $language->get('admin', 'emails_mass_message');
                 break;
             default:
@@ -167,22 +167,22 @@ if (isset($_GET['do'])) {
 
         foreach ($results->data as $nValue) {
             switch ($nValue->type) {
-                case 1:
+                case Email::REGISTRATION:
                     $type = $language->get('admin', 'registration_email');
                     break;
-                case 2:
+                case Email::CONTACT:
                     $type = $language->get('admin', 'contact_email');
                     break;
-                case 3:
+                case Email::FORGOT_PASSWORD:
                     $type = $language->get('admin', 'forgot_password_email');
                     break;
-                case 4:
+                case Email::API_REGISTRATION:
                     $type = $language->get('admin', 'api_registration_email');
                     break;
-                case 5:
+                case Email::FORUM_TOPIC_REPLY:
                     $type = $language->get('admin', 'forum_topic_reply_email');
                     break;
-                case 6:
+                case Email::MASS_MESSAGE:
                     $type = $language->get('admin', 'emails_mass_message');
                     break;
                 default:

--- a/modules/Core/pages/panel/emails_mass_message.php
+++ b/modules/Core/pages/panel/emails_mass_message.php
@@ -48,7 +48,6 @@ if (Input::exists()) {
             $contactemail = $contactemail[0]->value;
 
             foreach ($users as $email_user) {
-                // PHP Mailer
                 $sent = Email::send(
                     ['email' => Output::getClean($email_user->email), 'name' => Output::getClean($email_user->username)],
                     Output::getClean(Input::get('subject')),
@@ -57,7 +56,6 @@ if (Input::exists()) {
                 );
 
                 if (isset($sent['error'])) {
-                    // Error, log it
                     $queries->create('email_errors', [
                         'type' => Email::MASS_MESSAGE,
                         'content' => $sent['error'],

--- a/modules/Forum/pages/forum/view_topic.php
+++ b/modules/Forum/pages/forum/view_topic.php
@@ -362,7 +362,6 @@ if (Input::exists()) {
                         );
 
                         if (isset($sent['error'])) {
-                            // Error, log it
                             $queries->create('email_errors', [
                                 'type' => Email::FORUM_TOPIC_REPLY,
                                 'content' => $sent['error'],

--- a/modules/Forum/pages/forum/view_topic.php
+++ b/modules/Forum/pages/forum/view_topic.php
@@ -336,7 +336,6 @@ if (Input::exists()) {
                     $path = implode(DIRECTORY_SEPARATOR, [ROOT_PATH, 'custom', 'templates', TEMPLATE, 'email', 'forum_topic_reply.html']);
                     $html = file_get_contents($path);
 
-                    // TODO: Add placeholder support for Email::formatEmail()
                     $message = str_replace(
                         ['[Sitename]', '[TopicReply]', '[Greeting]', '[Message]', '[Link]', '[Thanks]'],
                         [


### PR DESCRIPTION
Instead of having a condition for sending mail over the `mail()` function vs PHPMailer, the class handles this on it's own now.

`Email::send(...)` now takes:
- array of "email" and "name" strings to determine the recipient
- string email subject
- string email message
- optional array of "email" and "name" strings to determine the reply-to address

`Email::addPlaceholder(...)` method for modules to add placeholders to their emails