### PR TITLE
Verify captcha before allowing to save

### DIFF
--- a/core/classes/Misc/CaptchaBase.php
+++ b/core/classes/Misc/CaptchaBase.php
@@ -120,6 +120,22 @@ abstract class CaptchaBase {
     abstract public function validateToken(array $post): bool;
 
     /**
+     * Validate if the private key is valid
+     *
+     * @param string $secret The secret key to validate
+     * @return bool Whether the private key is valid or not
+     */
+    abstract public function validateSecret(string $secret) : bool;
+
+    /**
+     * Validate if the public key is valid or not
+     *
+     * @param string $key The public key to validate
+     * @return bool Whether the public key is valid or not
+     */
+    abstract public function validateKey(string $key) : bool;
+
+    /**
      * Get form input HTML to display
      *
      * @return string|null HTML to display

--- a/custom/languages/EnglishUK/admin.php
+++ b/custom/languages/EnglishUK/admin.php
@@ -156,6 +156,7 @@ $language = [
     'captcha_type' => 'Captcha Type',
     'captcha_site_key' => 'Captcha Site Key',
     'captcha_secret_key' => 'Captcha Secret Key',
+    'invalid_recaptcha_settings' => 'Invalid {x} credentials. Ensure the site key and site secret are correct.', // Don't replace {x}
     'registration_disabled_message' => 'Registration disabled message',
     'enable_nicknames_on_registration' => 'Enable nicknames for registering users?',
     'validation_promote_group' => 'Post-validation group',

--- a/modules/Core/classes/Captcha/Recaptcha2.php
+++ b/modules/Core/classes/Captcha/Recaptcha2.php
@@ -28,6 +28,21 @@ class Recaptcha2 extends CaptchaBase {
         return $result['success'] == 'true';
     }
 
+    public function validateSecret(string $secret) : bool {
+        $token = "Verification";
+        $url = 'https://www.google.com/recaptcha/api/siteverify';
+
+        $result = HttpClient::post($url, [
+            'secret' => $secret,
+            'response' => $token
+        ])->json(true);
+        return !($result['error-codes'][0] == 'invalid-input-secret');
+    }
+
+    public function validateKey(string $key) : bool {
+        return true; // No way to verify
+    }
+
     public function getHtml(): string {
         return '<div class="g-recaptcha" data-sitekey="' . $this->getPublicKey() . '"></div>';
     }

--- a/modules/Core/classes/Captcha/Recaptcha2.php
+++ b/modules/Core/classes/Captcha/Recaptcha2.php
@@ -36,7 +36,7 @@ class Recaptcha2 extends CaptchaBase {
             'secret' => $secret,
             'response' => $token
         ])->json(true);
-        return !($result['error-codes'][0] == 'invalid-input-secret');
+        return $result['error-codes'][0] !== 'invalid-input-secret';
     }
 
     public function validateKey(string $key) : bool {

--- a/modules/Core/classes/Captcha/Recaptcha3.php
+++ b/modules/Core/classes/Captcha/Recaptcha3.php
@@ -28,6 +28,23 @@ class Recaptcha3 extends CaptchaBase {
         return $result['success'] == 'true';
     }
 
+    public function validateSecret(string $secret) : bool {
+        $token = "Verification";
+        $url = 'https://www.google.com/recaptcha/api/siteverify';
+
+        $result = HttpClient::post($url, [
+            'secret' => $secret,
+            'response' => $token
+        ])->json(true);
+        return !($result['error-codes'][0] == 'invalid-input-secret');
+    }
+
+    public function validateKey(string $key) : bool {
+        $url = 'https://www.google.com/recaptcha/api.js?render=' . $key;
+        $result = HttpClient::get($url)->contents();
+        return strpos($result, $key) !== false;
+    }
+
     public function getHtml(): ?string {
         return null;
     }

--- a/modules/Core/classes/Captcha/hCaptcha.php
+++ b/modules/Core/classes/Captcha/hCaptcha.php
@@ -28,6 +28,20 @@ class hCaptcha extends CaptchaBase {
         return $result['success'] == 'true';
     }
 
+    public function validateSecret(string $_secret) : bool {
+        return true; // Haven't found a way to verify this
+    }
+
+    public function validateKey(string $key) : bool {
+        $url = 'https://api.hcaptcha.com/checksiteconfig?sitekey=' . $key;
+        $client = HttpClient::get($url);
+        if ($client->hasError()) {
+            return false;
+        } else {
+            return $client->json(true)['pass'] == true;
+        }
+    }
+
     public function getHtml(): string {
         return '<div class="h-captcha" data-sitekey="' . $this->getPublicKey() . '"></div>';
     }

--- a/modules/Core/classes/Captcha/hCaptcha.php
+++ b/modules/Core/classes/Captcha/hCaptcha.php
@@ -37,9 +37,8 @@ class hCaptcha extends CaptchaBase {
         $client = HttpClient::get($url);
         if ($client->hasError()) {
             return false;
-        } else {
-            return $client->json(true)['pass'] == true;
         }
+        return $client->json(true)['pass'] == true;
     }
 
     public function getHtml(): string {

--- a/modules/Core/pages/panel/registration.php
+++ b/modules/Core/pages/panel/registration.php
@@ -52,50 +52,6 @@ if (Input::exists()) {
                 $verification = isset($_POST['verification']) && $_POST['verification'] == 'on' ? 1 : 0;
                 $configuration->set('Core', 'email_verification', $verification);
 
-                // reCAPTCHA enabled?
-                if (Input::get('enable_recaptcha') == 1) {
-                    $captcha = 'true';
-                } else {
-                    $captcha = 'false';
-                }
-                $captcha_id = $queries->getWhere('settings', ['name', '=', 'recaptcha']);
-                $captcha_id = $captcha_id[0]->id;
-                $queries->update('settings', $captcha_id, [
-                    'value' => $captcha
-                ]);
-
-                // Login reCAPTCHA enabled?
-                if (Input::get('enable_recaptcha_login') == 1) {
-                    $captcha = 'true';
-                } else {
-                    $captcha = 'false';
-                }
-                $captcha_login = $queries->getWhere('settings', ['name', '=', 'recaptcha_login']);
-                $captcha_login = $captcha_login[0]->id;
-                $queries->update('settings', $captcha_login, [
-                    'value' => $captcha
-                ]);
-
-                // Config value
-                if (Input::get('enable_recaptcha') == 1 || Input::get('enable_recaptcha_login') == 1) {
-                    if (is_writable(ROOT_PATH . '/' . implode(DIRECTORY_SEPARATOR, ['core', 'config.php']))) {
-                        // Require config
-                        if (isset($path) && file_exists($path . 'core/config.php')) {
-                            $loadedConfig = json_decode(file_get_contents($path . 'core/config.php'), true);
-                        } else {
-                            $loadedConfig = json_decode(file_get_contents(ROOT_PATH . '/core/config.php'), true);
-                        }
-
-                        if (is_array($loadedConfig)) {
-                            $GLOBALS['config'] = $loadedConfig;
-                        }
-
-                        Config::set('core/captcha', true);
-                    } else {
-                        $errors = [$language->get('admin', 'config_not_writable')];
-                    }
-                }
-
                 // reCAPTCHA type
                 $captcha_type = $queries->getWhere('settings', ['name', '=', 'recaptcha_type']);
                 if (!count($captcha_type)) {
@@ -109,18 +65,79 @@ if (Input::exists()) {
                     $configuration->set('Core', 'recaptcha_type', Input::get('captcha_type'));
                 }
 
-                // reCAPTCHA key
-                $configuration->set('Core', 'recaptcha_key', Input::get('recaptcha'));
+                // Verify if the captha inputted is correct (if enabled)
+                if (Input::get('enable_recaptcha') == 1 || Input::get('enable_recaptcha_login') == 1) {
+                    if (
+                        (
+                            CaptchaBase::isCaptchaEnabled('recaptcha_login')
+                            || CaptchaBase::isCaptchaEnabled()
+                        )
+                        && (
+                            CaptchaBase::getActiveProvider()->validateSecret(Input::get('recaptcha_secret')) == false
+                            || CaptchaBase::getActiveProvider()->validateKey(Input::get('recaptcha')) == false
+                        )
+                    ) {
+                        $errors = [$language->get('user', 'invalid_recaptcha')];
+                    } else {
+                        // reCAPTCHA enabled?
+                        if (Input::get('enable_recaptcha') == 1) {
+                            $captcha = 'true';
+                        } else {
+                            $captcha = 'false';
+                        }
+                        $captcha_id = $queries->getWhere('settings', ['name', '=', 'recaptcha']);
+                        $captcha_id = $captcha_id[0]->id;
+                        $queries->update('settings', $captcha_id, [
+                            'value' => $captcha
+                        ]);
 
-                // reCAPTCHA secret key
-                $configuration->set('Core', 'recaptcha_secret', Input::get('recaptcha_secret'));
+                        // Login reCAPTCHA enabled?
+                        if (Input::get('enable_recaptcha_login') == 1) {
+                            $captcha = 'true';
+                        } else {
+                            $captcha = 'false';
+                        }
+                        $captcha_login = $queries->getWhere('settings', ['name', '=', 'recaptcha_login']);
+                        $captcha_login = $captcha_login[0]->id;
+                        $queries->update('settings', $captcha_login, [
+                            'value' => $captcha
+                        ]);
 
-                // Registration disabled message
-                $registration_disabled_id = $queries->getWhere('settings', ['name', '=', 'registration_disabled_message']);
-                $registration_disabled_id = $registration_disabled_id[0]->id;
-                $queries->update('settings', $registration_disabled_id, [
-                    'value' => htmlspecialchars(Input::get('message'))
-                ]);
+                        // Config value
+                        if (Input::get('enable_recaptcha') == 1 || Input::get('enable_recaptcha_login') == 1) {
+                            if (is_writable(ROOT_PATH . '/' . implode(DIRECTORY_SEPARATOR, ['core', 'config.php']))) {
+                                // Require config
+                                if (isset($path) && file_exists($path . 'core/config.php')) {
+                                    $loadedConfig = json_decode(file_get_contents($path . 'core/config.php'), true);
+                                } else {
+                                    $loadedConfig = json_decode(file_get_contents(ROOT_PATH . '/core/config.php'), true);
+                                }
+
+                                if (is_array($loadedConfig)) {
+                                    $GLOBALS['config'] = $loadedConfig;
+                                }
+
+                                Config::set('core/captcha', true);
+                            } else {
+                                $errors = [$language->get('admin', 'config_not_writable')];
+                            }
+                        }
+
+                        // reCAPTCHA key
+                        $configuration->set('Core', 'recaptcha_key', Input::get('recaptcha'));
+
+                        // reCAPTCHA secret key
+                        $configuration->set('Core', 'recaptcha_secret', Input::get('recaptcha_secret'));
+
+                        // Registration disabled message
+                        $registration_disabled_id = $queries->getWhere('settings', ['name', '=', 'registration_disabled_message']);
+                        $registration_disabled_id = $registration_disabled_id[0]->id;
+                        $queries->update('settings', $registration_disabled_id, [
+                            'value' => htmlspecialchars(Input::get('message'))
+                        ]);
+                    }
+                }
+
 
                 // Validation group
                 $validation_group_id = $queries->getWhere('settings', ['name', '=', 'validate_user_action']);

--- a/modules/Core/pages/panel/registration.php
+++ b/modules/Core/pages/panel/registration.php
@@ -77,7 +77,7 @@ if (Input::exists()) {
                             || CaptchaBase::getActiveProvider()->validateKey(Input::get('recaptcha')) == false
                         )
                     ) {
-                        $errors = [$language->get('user', 'invalid_recaptcha')];
+                        $errors = [str_replace('{x}', Input::get('captcha_type'), $language->get('admin', 'invalid_recaptcha_settings'))];
                     } else {
                         // reCAPTCHA enabled?
                         if (Input::get('enable_recaptcha') == 1) {


### PR DESCRIPTION
Altough this doesn't work for every single captcha type. It made more sense to have it for the ones that support it.

**hCaptcha**: 
- [ ] Verify secret key
- [x] Verify public key

**reCaptchaV2**:
- [x] Verify secret key
- [ ] Verify public key

**reCaptchaV3**:
- [x] Verify secret key
- [x] Verify public key

This may not be ideal that it doesn't support everything but it does mean there is some protection in place to prevent people from activating captcha with invalid configurations.
