### PR TITLE
Fixed `hover` and `active` on main nav

### DIFF
--- a/custom/panel_templates/Default/assets/css/custom.css
+++ b/custom/panel_templates/Default/assets/css/custom.css
@@ -199,8 +199,11 @@ option:checked {
     color: rgba(255, 255, 255) !important;
 }
 
-.dark .nav-link:hover,
-.nav-link:active {
+.dark .nav-item:hover{
+    background-color: #161c25 !important;
+}
+
+.dark .nav-item.active{
     background-color: #161c25 !important;
 }
 

--- a/custom/panel_templates/Default/assets/css/custom.css
+++ b/custom/panel_templates/Default/assets/css/custom.css
@@ -199,11 +199,11 @@ option:checked {
     color: rgba(255, 255, 255) !important;
 }
 
-.dark .nav-item:hover{
+.dark .nav-item:hover {
     background-color: #161c25 !important;
 }
 
-.dark .nav-item.active{
+.dark .nav-item.active {
     background-color: #161c25 !important;
 }
 


### PR DESCRIPTION
Fixed `hover` and `active` on the main nav. It was triggered even when dark mode was not active.