### PR TITLE
Add mention suggestions in TinyMCE

### DIFF
--- a/core/classes/Collections/Collection.php
+++ b/core/classes/Collections/Collection.php
@@ -16,10 +16,13 @@ class Collection {
         $this->_items = [];
     }
 
-    public function addItem($item): void {
+    public function addItem(CollectionItemBase $item): void {
         $this->_items[] = $item;
     }
 
+    /**
+     * @return CollectionItemBase[]
+     */
     public function getEnabledItems(): array {
         $items = [];
 
@@ -29,16 +32,19 @@ class Collection {
             }
         }
 
-        uasort($items, static function ($a, $b) {
+        uasort($items, static function (CollectionItemBase $a, CollectionItemBase $b) {
             return $a->getOrder() - $b->getOrder();
         });
 
         return $items;
     }
 
+    /**
+     * @return CollectionItemBase[]
+     */
     public function getAllItems(): array {
         $items = $this->_items;
-        uasort($items, static function ($a, $b) {
+        uasort($items, static function (CollectionItemBase $a, CollectionItemBase $b) {
             return $a->getOrder() - $b->getOrder();
         });
 

--- a/core/classes/Collections/CollectionManager.php
+++ b/core/classes/Collections/CollectionManager.php
@@ -21,12 +21,20 @@ class CollectionManager {
         self::$_collections[$collection]->addItem($item);
     }
 
+    /**
+     * @param string $collection
+     * @return CollectionItemBase[]
+     */
     public static function getFullCollection(string $collection): array {
         return isset(self::$_collections[$collection])
             ? self::$_collections[$collection]->getAllItems()
             : [];
     }
 
+    /**
+     * @param string $collection
+     * @return CollectionItemBase[]
+     */
     public static function getEnabledCollection(string $collection): array {
         return isset(self::$_collections[$collection])
             ? self::$_collections[$collection]->getEnabledItems()

--- a/core/classes/Core/Input.php
+++ b/core/classes/Core/Input.php
@@ -81,7 +81,7 @@ class Input {
                                                     results.push({
                                                         value: '@' + user.username,
                                                         text: user.username,
-                                                        icon: '<img src=\"' + user.avatar_url + '\">'
+                                                        icon: '<img style=\"height:20px; width:20px;\" src=\"' + user.avatar_url + '\">'
                                                     });
                                                 }
     

--- a/core/classes/Core/Input.php
+++ b/core/classes/Core/Input.php
@@ -71,15 +71,15 @@ class Input {
                                 columns: 1,
                                 fetch: function (pattern) {
                                     return new tinymce.util.Promise(function (resolve) {
-                                        fetch('" . URL::build('/queries/mention_users') . "&username=' + pattern)
+                                        fetch('" . URL::build('/queries/mention_users') . "&nickname=' + pattern)
                                             .then((resp) => resp.json())
                                             .then(function (data) {
                                                 const results = [];
     
                                                 for (const user of data) {
                                                     results.push({
-                                                        value: '@' + user.username,
-                                                        text: user.username,
+                                                        value: '@' + user.nickname,
+                                                        text: user.nickname,
                                                         icon: '<img style=\"height:20px; width:20px;\" src=\"' + user.avatar_url + '\">'
                                                     });
                                                 }

--- a/core/classes/Core/Input.php
+++ b/core/classes/Core/Input.php
@@ -74,7 +74,7 @@ class Input {
                                         fetch('" . URL::build('/api/v2/users', 'avatars=true') . "')
                                             .then((resp) => resp.json())
                                             .then(function (data) {
-                                                let results = [];
+                                                const results = [];
                                                 const users = data.users.filter(p => p.username.toLowerCase().includes(pattern.toLowerCase()));
     
                                                 for (const user of users) {
@@ -84,18 +84,8 @@ class Input {
                                                         icon: '<img style=\"height:20px; width:20px;\" src=\"' + user.avatar_url + '\">'
                                                     });
                                                 }
-    
-                                                results.sort(function (a, b) {
-                                                    let x = a.text.toLowerCase();
-                                                    let y = b.text.toLowerCase();
-                                                    if (x < y) {
-                                                        return -1;
-                                                    }
-                                                    if (x > y) {
-                                                        return 1;
-                                                    }
-                                                    return 0;
-                                                });
+
+                                                results.sort((a, b) => a.text.toLowerCase().localeCompare(b.text.toLowerCase()))
     
                                                 resolve(results);
                                             });

--- a/core/classes/Core/Input.php
+++ b/core/classes/Core/Input.php
@@ -71,7 +71,7 @@ class Input {
                                 columns: 1,
                                 fetch: function (pattern) {
                                     return new tinymce.util.Promise(function (resolve) {
-                                        fetch('" . URL::build('/queries/mention_users') . "&nickname=' + pattern)
+                                        fetch('" . URL::build('/queries/mention_users', 'nickname') . "=' + pattern)
                                             .then((resp) => resp.json())
                                             .then(function (data) {
                                                 const results = [];

--- a/core/classes/Core/Input.php
+++ b/core/classes/Core/Input.php
@@ -71,13 +71,12 @@ class Input {
                                 columns: 1,
                                 fetch: function (pattern) {
                                     return new tinymce.util.Promise(function (resolve) {
-                                        fetch('" . URL::build('/api/v2/users', 'avatars=true') . "')
+                                        fetch('" . URL::build('/queries/mention_users') . "&username=' + pattern)
                                             .then((resp) => resp.json())
                                             .then(function (data) {
                                                 const results = [];
-                                                const users = data.users.filter(p => p.username.toLowerCase().includes(pattern.toLowerCase()));
     
-                                                for (const user of users) {
+                                                for (const user of data) {
                                                     results.push({
                                                         value: '@' + user.username,
                                                         text: user.username,

--- a/core/classes/Core/User.php
+++ b/core/classes/Core/User.php
@@ -472,47 +472,7 @@ class User {
      * @return string URL to their avatar image.
      */
     public function getAvatar(int $size = 128, bool $full = false): string {
-        $default = defined('DEFAULT_AVATAR_TYPE') ? DEFAULT_AVATAR_TYPE : 'minecraft';
-
-        // If custom avatars are enabled, first check if they have gravatar enabled, and then fallback to normal image
-        if ($default === 'custom' && defined('CUSTOM_AVATARS')) {
-
-            if ($this->data()->gravatar) {
-                return 'https://secure.gravatar.com/avatar/' . md5(strtolower(trim($this->data()->email))) . '?s=' . $size;
-            }
-
-            if ($this->data()->has_avatar) {
-                $exts = ['png', 'jpg', 'jpeg'];
-
-                if ($this->hasPermission('usercp.gif_avatar')) {
-                    $exts[] = 'gif';
-                }
-
-                foreach ($exts as $ext) {
-                    if (file_exists(ROOT_PATH . '/uploads/avatars/' . $this->data()->id . '.' . $ext)) {
-                        return ($full ? rtrim(Util::getSelfURL(), '/') : '') . ((defined('CONFIG_PATH')) ? CONFIG_PATH . '/' : '/') . 'uploads/avatars/' . $this->data()->id . '.' . $ext . '?v=' . Output::getClean($this->data()->avatar_updated);
-                    }
-                }
-            }
-
-            // Fallback to default avatar image if it is set and the default avatar type is custom
-            if (DEFAULT_AVATAR_IMAGE !== '' && file_exists(ROOT_PATH . '/uploads/avatars/defaults/' . DEFAULT_AVATAR_IMAGE)) {
-                return ($full ? rtrim(Util::getSelfURL(), '/') : '') . ((defined('CONFIG_PATH')) ? CONFIG_PATH . '/' : '/') . 'uploads/avatars/defaults/' . DEFAULT_AVATAR_IMAGE;
-            }
-        }
-
-        // If all else fails, or custom avatars are disabled or default avatar type is 'minecraft', get their MC avatar
-        if ($this->data()->uuid != null && $this->data()->uuid != 'none') {
-            $uuid = $this->data()->uuid;
-        } else {
-            $uuid = $this->data()->username;
-            // Fallback to steve avatar if they have an invalid username
-            if (preg_match('#[^][_A-Za-z0-9]#', $uuid)) {
-                $uuid = 'Steve';
-            }
-        }
-
-        return AvatarSource::getAvatarFromUUID($uuid, $size);
+        return AvatarSource::getAvatarFromUserData($this->data(), $this->hasPermission('usercp.gif_avatar'), $size, $full);
     }
 
     /**

--- a/core/classes/Core/Util.php
+++ b/core/classes/Core/Util.php
@@ -141,29 +141,6 @@ class Util {
     }
 
     /**
-     * Get a Minecraft avatar from a UUID.
-     *
-     * @param string $uuid UUID to get avatar for.
-     * @param int $size Size of avatar in pixels to get URL for.
-     * @return string URL to avatar.
-     */
-    public static function getAvatarFromUUID(string $uuid, int $size = 128): string {
-        return AvatarSource::getAvatarFromUUID($uuid, $size);
-    }
-
-    /**
-     * Get avatar source with UUID as `{x}` and size as `{y}`.
-     * Used for avatar preview in online players list.
-     *
-     * @return string URL to be formatted.
-     * @deprecated Use `AvatarSource::getUrlToFormat()`
-     *
-     */
-    public static function getAvatarSource(): string {
-        return AvatarSource::getUrlToFormat();
-    }
-
-    /**
      * Is a URL internal or external? Accepts full URL and also just a path.
      *
      * @param string $url URL/path to check.

--- a/core/classes/Misc/MentionsParser.php
+++ b/core/classes/Misc/MentionsParser.php
@@ -5,19 +5,10 @@
  * @package NamelessMC\Misc
  * @author Samerton
  * @author fetch404
- * @version 2.0.0-pr9
+ * @version 2.0.0-pr13
  * @license MIT
  */
 class MentionsParser {
-
-    private DB $_db;
-
-    /**
-     * Create a new instance of MentionsParser.
-     */
-    public function __construct() {
-        $this->_db = DB::getInstance();
-    }
 
     /**
      * Parse the given HTML to include @username tags.
@@ -27,9 +18,10 @@ class MentionsParser {
      * @param string $link Link back to post.
      * @param array $alert_short Short alert info.
      * @param array $alert_full Full alert info.
+     *
      * @return string Parsed post content.
      */
-    public function parse(int $author_id, string $value, string $link, array $alert_short, array $alert_full): string {
+    public static function parse(int $author_id, string $value, string $link, array $alert_short, array $alert_full): string {
         if (preg_match_all('/@([A-Za-z0-9\-_!.]+)/', $value, $matches)) {
             $matches = $matches[1];
 
@@ -40,23 +32,13 @@ class MentionsParser {
                     $user = new User($possible_username, 'nickname');
 
                     if ($user->data()) {
-                        $value = preg_replace('/' . preg_quote("@$possible_username", '/') . '/', "<a style=\"" . Output::getClean($user->getGroupClass()) . "\" href=\"" . $user->getProfileURL() . "\">@$possible_username</a>", $value);
+                        $value = preg_replace('/' . preg_quote("@$possible_username", '/') . '/', "<a href=\"" . $user->getProfileURL() . "\">@$possible_username</a>", $value);
 
                         // Check if user is blocked by OP
-                        $user_blocked = $this->_db->get('blocked_users', ['user_id', '=', $user->data()->id]);
-                        if ($user_blocked->count()) {
-                            $user_blocked = $user_blocked->results();
-
-                            foreach ($user_blocked as $item) {
-                                if ($item->user_blocked_id == $author_id) {
-                                    break 2;
-                                }
-                            }
+                        if (!$user->isBlocked($user->data()->id, $author_id)) {
+                            Alert::create($user->data()->id, 'tag', $alert_short, $alert_full, $link);
+                            break;
                         }
-
-                        Alert::create($user->data()->id, 'tag', $alert_short, $alert_full, $link);
-
-                        break;
                     }
 
                     // chop last word off of it

--- a/core/classes/Misc/MentionsParser.php
+++ b/core/classes/Misc/MentionsParser.php
@@ -16,12 +16,12 @@ class MentionsParser {
      * @param int $author_id User ID of post creator.
      * @param string $value Post content.
      * @param string $link Link back to post.
-     * @param array $alert_short Short alert info.
-     * @param array $alert_full Full alert info.
+     * @param ?array $alert_short Short alert info, leave null to not alert user.
+     * @param ?array $alert_full Full alert info, leave null to not alert user.
      *
      * @return string Parsed post content.
      */
-    public static function parse(int $author_id, string $value, string $link, array $alert_short, array $alert_full): string {
+    public static function parse(int $author_id, string $value, string $link, array $alert_short = null, array $alert_full = null): string {
         if (preg_match_all('/@([A-Za-z0-9\-_!.]+)/', $value, $matches)) {
             $matches = $matches[1];
 
@@ -35,7 +35,7 @@ class MentionsParser {
                         $value = preg_replace('/' . preg_quote("@$possible_username", '/') . '/', "<a href=\"" . $user->getProfileURL() . "\">@$possible_username</a>", $value);
 
                         // Check if user is blocked by OP
-                        if (!$user->isBlocked($user->data()->id, $author_id)) {
+                        if (($alert_full && $alert_short) && !$user->isBlocked($user->data()->id, $author_id)) {
                             Alert::create($user->data()->id, 'tag', $alert_short, $alert_full, $link);
                             break;
                         }

--- a/core/classes/Misc/Report.php
+++ b/core/classes/Misc/Report.php
@@ -57,7 +57,7 @@ class Report {
             'username' => $data['reported_mcname'],
             'content' => str_replace('{x}', $user_reporting->data()->username, $language->get('general', 'reported_by')),
             'content_full' => $data['report_reason'],
-            'avatar_url' => $data['reported_id'] == 0 ? null : ($data['reported_uuid'] !== null ? Util::getAvatarFromUUID($data['reported_uuid']) : $reported_user->getAvatar()),
+            'avatar_url' => $data['reported_id'] == 0 ? null : ($data['reported_uuid'] !== null ? AvatarSource::getAvatarFromUUID($data['reported_uuid']) : $reported_user->getAvatar()),
             'title' => $language->get('general', 'view_report'),
             'url' => rtrim(Util::getSelfURL(), '/') . URL::build('/panel/users/reports/', 'id=' . $id)
         ]);

--- a/modules/Core/includes/endpoints/ListUsersEndpoint.php
+++ b/modules/Core/includes/endpoints/ListUsersEndpoint.php
@@ -5,7 +5,7 @@
  *
  * @return string JSON Array
  */
-class ListUsersEndpoint extends KeyAuthEndpoint {
+class ListUsersEndpoint extends NoAuthEndpoint {
 
     public function __construct() {
         $this->_route = 'users';
@@ -20,9 +20,9 @@ class ListUsersEndpoint extends KeyAuthEndpoint {
         $discord_enabled = Util::isModuleEnabled('Discord Integration');
 
         if ($discord_enabled) {
-            $query = 'SELECT u.id, u.username, u.uuid, u.isbanned AS banned, u.discord_id, u.active FROM nl2_users u';
+            $query = 'SELECT u.id, u.username, u.uuid, u.gravatar, u.email, u.avatar_updated, u.isbanned AS banned, u.discord_id, u.active FROM nl2_users u';
         } else {
-            $query = 'SELECT u.id, u.username, u.uuid, u.isbanned AS banned, u.active FROM nl2_users u';
+            $query = 'SELECT u.id, u.username, u.uuid, u.gravatar, u.email, u.avatar_updated, u.isbanned AS banned, u.active FROM nl2_users u';
         }
 
         $operator = isset($_GET['operator']) && $_GET['operator'] == 'OR'
@@ -75,6 +75,11 @@ class ListUsersEndpoint extends KeyAuthEndpoint {
                 'banned' => (bool)$user->banned,
                 'verified' => (bool)$user->active,
             ];
+
+            if (isset($_GET['avatars']) && $_GET['avatars'] == 'true') {
+                // Use the getAvatarFromUserData method so that we don't have to load the whole user again from the database.
+                $user_json['avatar_url'] = AvatarSource::getAvatarFromUserData($user, false, 20, true);
+            }
 
             if ($discord_enabled) {
                 $user_json['discord_id'] = (int)$user->discord_id;

--- a/modules/Core/includes/endpoints/ListUsersEndpoint.php
+++ b/modules/Core/includes/endpoints/ListUsersEndpoint.php
@@ -5,7 +5,7 @@
  *
  * @return string JSON Array
  */
-class ListUsersEndpoint extends NoAuthEndpoint {
+class ListUsersEndpoint extends KeyAuthEndpoint {
 
     public function __construct() {
         $this->_route = 'users';
@@ -20,9 +20,9 @@ class ListUsersEndpoint extends NoAuthEndpoint {
         $discord_enabled = Util::isModuleEnabled('Discord Integration');
 
         if ($discord_enabled) {
-            $query = 'SELECT u.id, u.username, u.uuid, u.gravatar, u.email, u.has_avatar, u.avatar_updated, u.isbanned AS banned, u.discord_id, u.active FROM nl2_users u';
+            $query = 'SELECT u.id, u.username, u.uuid, u.isbanned AS banned, u.discord_id, u.active FROM nl2_users u';
         } else {
-            $query = 'SELECT u.id, u.username, u.uuid, u.gravatar, u.email, u.has_avatar, u.avatar_updated, u.isbanned AS banned, u.active FROM nl2_users u';
+            $query = 'SELECT u.id, u.username, u.uuid, u.isbanned AS banned, u.active FROM nl2_users u';
         }
 
         $operator = isset($_GET['operator']) && $_GET['operator'] == 'OR'
@@ -75,11 +75,6 @@ class ListUsersEndpoint extends NoAuthEndpoint {
                 'banned' => (bool)$user->banned,
                 'verified' => (bool)$user->active,
             ];
-
-            if (isset($_GET['avatars']) && $_GET['avatars'] == 'true') {
-                // Use the getAvatarFromUserData method so that we don't have to load the whole user again from the database.
-                $user_json['avatar_url'] = AvatarSource::getAvatarFromUserData($user, false, 20, true);
-            }
 
             if ($discord_enabled) {
                 $user_json['discord_id'] = (int)$user->discord_id;

--- a/modules/Core/includes/endpoints/ListUsersEndpoint.php
+++ b/modules/Core/includes/endpoints/ListUsersEndpoint.php
@@ -20,9 +20,9 @@ class ListUsersEndpoint extends NoAuthEndpoint {
         $discord_enabled = Util::isModuleEnabled('Discord Integration');
 
         if ($discord_enabled) {
-            $query = 'SELECT u.id, u.username, u.uuid, u.gravatar, u.email, u.avatar_updated, u.isbanned AS banned, u.discord_id, u.active FROM nl2_users u';
+            $query = 'SELECT u.id, u.username, u.uuid, u.gravatar, u.email, u.has_avatar, u.avatar_updated, u.isbanned AS banned, u.discord_id, u.active FROM nl2_users u';
         } else {
-            $query = 'SELECT u.id, u.username, u.uuid, u.gravatar, u.email, u.avatar_updated, u.isbanned AS banned, u.active FROM nl2_users u';
+            $query = 'SELECT u.id, u.username, u.uuid, u.gravatar, u.email, u.has_avatar, u.avatar_updated, u.isbanned AS banned, u.active FROM nl2_users u';
         }
 
         $operator = isset($_GET['operator']) && $_GET['operator'] == 'OR'

--- a/modules/Core/module.php
+++ b/modules/Core/module.php
@@ -40,6 +40,7 @@ class Core_Module extends Module {
         $pages->add('Core', '/register/oauth', 'pages/register.php');
         $pages->add('Core', '/validate', 'pages/validate.php');
         $pages->add('Core', '/queries/admin_users', 'queries/admin_users.php');
+        $pages->add('Core', '/queries/mention_users', 'queries/mention_users.php');
         $pages->add('Core', '/queries/alerts', 'queries/alerts.php');
         $pages->add('Core', '/queries/dark_light_mode', 'queries/dark_light_mode.php');
         $pages->add('Core', '/queries/pms', 'queries/pms.php');

--- a/modules/Core/pages/leaderboards.php
+++ b/modules/Core/pages/leaderboards.php
@@ -46,7 +46,7 @@ foreach ($leaderboard_placeholders as $leaderboard_placeholder) {
         $row_data->server_id = $leaderboard_placeholder->server_id;
         $row_data->name = $leaderboard_placeholder->name;
         $row_data->username = Output::getClean($leaderboard_users[$uuid]->username);
-        $row_data->avatar = Util::getAvatarFromUUID($uuid, 24);
+        $row_data->avatar = AvatarSource::getAvatarFromUUID($uuid, 24);
         $row_data->value = $row->value;
         $row_data->last_updated = ucfirst($timeago->inWords(date('d M Y, H:i', $row->last_updated), $language->getTimeLanguage()));
 

--- a/modules/Core/pages/panel/users_reports.php
+++ b/modules/Core/pages/panel/users_reports.php
@@ -98,7 +98,7 @@ if (!isset($_GET['id'])) {
                 $user_reported = Output::getClean($report->reported_mcname);
                 $user_profile = URL::build('/panel/user/' . Output::getClean($report->reported_id . '-' . $report->reported_mcname));
                 $user_style = '';
-                $user_avatar = $report->reported_id == 0 ? null : Util::getAvatarFromUUID($report->reported_uuid);
+                $user_avatar = $report->reported_id == 0 ? null : AvatarSource::getAvatarFromUUID($report->reported_uuid);
             }
 
             $updated_by_user = new User($report->updated_by);
@@ -226,7 +226,7 @@ if (!isset($_GET['id'])) {
             } else {
                 $reported_user_profile = '#';
                 $reported_user_style = '';
-                $reported_user_avatar = Util::getAvatarFromUUID(Output::getClean($report->reported_uuid));
+                $reported_user_avatar = AvatarSource::getAvatarFromUUID(Output::getClean($report->reported_uuid));
             }
 
             $reported_user_name = Output::getClean($report->reported_mcname);

--- a/modules/Core/queries/mention_users.php
+++ b/modules/Core/queries/mention_users.php
@@ -7,15 +7,14 @@ if (!$user->isLoggedIn()) {
 }
 
 $users = DB::getInstance()->selectQuery(
-    'SELECT u.id, u.username, u.uuid, u.gravatar, u.email, u.has_avatar, u.avatar_updated FROM nl2_users u WHERE u.username LIKE ?',
-    ["{$_GET['username']}%"]
+    'SELECT u.id, u.nickname, u.uuid, u.gravatar, u.email, u.has_avatar, u.avatar_updated FROM nl2_users u WHERE u.nickname LIKE ?',
+    ["{$_GET['nickname']}%"]
 )->results();
 
 $users_json = [];
 foreach ($users as $user) {
     $users_json[] = [
-        'id' => (int)$user->id,
-        'username' => $user->username,
+        'nickname' => $user->nickname,
         'avatar_url' => AvatarSource::getAvatarFromUserData($user, false, 20, true)
     ];
 }

--- a/modules/Core/queries/mention_users.php
+++ b/modules/Core/queries/mention_users.php
@@ -16,7 +16,6 @@ foreach ($users as $user) {
     $users_json[] = [
         'id' => (int)$user->id,
         'username' => $user->username,
-        'uuid' => $user->uuid,
         'avatar_url' => AvatarSource::getAvatarFromUserData($user, false, 20, true)
     ];
 }

--- a/modules/Core/queries/mention_users.php
+++ b/modules/Core/queries/mention_users.php
@@ -1,0 +1,24 @@
+<?php
+
+header('Content-type: application/json;charset=utf-8');
+
+if (!$user->isLoggedIn()) {
+    die();
+}
+
+$users = DB::getInstance()->selectQuery(
+    'SELECT u.id, u.username, u.uuid, u.gravatar, u.email, u.has_avatar, u.avatar_updated FROM nl2_users u WHERE u.username LIKE ?',
+    ["{$_GET['username']}%"]
+)->results();
+
+$users_json = [];
+foreach ($users as $user) {
+    $users_json[] = [
+        'id' => (int)$user->id,
+        'username' => $user->username,
+        'uuid' => $user->uuid,
+        'avatar_url' => AvatarSource::getAvatarFromUserData($user, false, 20, true)
+    ];
+}
+
+die(json_encode($users_json));

--- a/modules/Core/queries/user.php
+++ b/modules/Core/queries/user.php
@@ -13,7 +13,7 @@ if (!is_numeric($_GET['id'])) {
     $username = Output::getClean($_GET['id']);
     $nickname = $username;
     $profile = URL::build('/profile/' . $username);
-    $avatar = (isset($_GET['uuid']) ? Util::getAvatarFromUUID(Output::getClean($_GET['uuid'])) : Util::getAvatarFromUUID($username));
+    $avatar = (isset($_GET['uuid']) ? AvatarSource::getAvatarFromUUID(Output::getClean($_GET['uuid'])) : AvatarSource::getAvatarFromUUID($username));
     $style = '';
     $groups = [];
     $id = 0;

--- a/modules/Forum/pages/forum/edit.php
+++ b/modules/Forum/pages/forum/edit.php
@@ -26,7 +26,6 @@ if (!$user->isLoggedIn()) {
 
 // Initialise
 $forum = new Forum();
-$mentionsParser = new MentionsParser();
 
 if (isset($_GET['pid'], $_GET['tid']) && is_numeric($_GET['pid']) && is_numeric($_GET['tid'])) {
     $post_id = $_GET['pid'];
@@ -120,6 +119,7 @@ if (Input::exists()) {
         if ($validation->passed()) {
             // Valid post content
             $content = Output::getClean(Input::get('content'));
+            $content = MentionsParser::parse($user->data()->id, $content, URL::build('/forum/topic/' . $topic_id, 'pid=' . $post_id), ['path' => ROOT_PATH . '/modules/Forum/language', 'file' => 'forum', 'term' => 'user_tag'], ['path' => ROOT_PATH . '/modules/Forum/language', 'file' => 'forum', 'term' => 'user_tag_info', 'replace' => '{x}', 'replace_with' => Output::getClean($user->data()->nickname)]);
 
             // Update post content
             $queries->update('posts', $post_id, [
@@ -251,7 +251,7 @@ $template->addJSFiles([
     (defined('CONFIG_PATH') ? CONFIG_PATH : '') . '/core/assets/plugins/tinymce/tinymce.min.js' => []
 ]);
 
-$template->addJSScript(Input::createTinyEditor($language, 'editor'));
+$template->addJSScript(Input::createTinyEditor($language, 'editor', true));
 
 // Load modules + template
 Module::loadPage($user, $pages, $cache, $smarty, [$navigation, $cc_nav, $staffcp_nav], $widgets, $template);

--- a/modules/Forum/pages/forum/edit.php
+++ b/modules/Forum/pages/forum/edit.php
@@ -119,7 +119,11 @@ if (Input::exists()) {
         if ($validation->passed()) {
             // Valid post content
             $content = Output::getClean(Input::get('content'));
-            $content = MentionsParser::parse($user->data()->id, $content, URL::build('/forum/topic/' . $topic_id, 'pid=' . $post_id), ['path' => ROOT_PATH . '/modules/Forum/language', 'file' => 'forum', 'term' => 'user_tag'], ['path' => ROOT_PATH . '/modules/Forum/language', 'file' => 'forum', 'term' => 'user_tag_info', 'replace' => '{x}', 'replace_with' => Output::getClean($user->data()->nickname)]);
+            $content = MentionsParser::parse(
+                $user->data()->id,
+                $content,
+                URL::build('/forum/topic/' . $topic_id, 'pid=' . $post_id),
+            );
 
             // Update post content
             $queries->update('posts', $post_id, [

--- a/modules/Forum/pages/forum/new_topic.php
+++ b/modules/Forum/pages/forum/new_topic.php
@@ -20,7 +20,6 @@ if (!$user->isLoggedIn()) {
 }
 
 $forum = new Forum();
-$mentionsParser = new MentionsParser();
 
 if (!isset($_GET['fid']) || !is_numeric($_GET['fid'])) {
     Redirect::to(URL::build('/forum/error/', 'error=not_exist'));
@@ -179,7 +178,7 @@ if (Input::exists()) {
 
                 // Get last post ID
                 $last_post_id = $queries->getLastId();
-                $content = $mentionsParser->parse(
+                $content = MentionsParser::parse(
                     $user->data()->id,
                     $content,
                     URL::build('/forum/topic/' . $topic_id, 'pid=' . $last_post_id),
@@ -279,7 +278,7 @@ $template->addJSFiles([
     (defined('CONFIG_PATH') ? CONFIG_PATH : '') . '/core/assets/plugins/tinymce/tinymce.min.js' => []
 ]);
 
-$template->addJSScript(Input::createTinyEditor($language, 'reply'));
+$template->addJSScript(Input::createTinyEditor($language, 'reply', true));
 
 // Load modules + template
 Module::loadPage($user, $pages, $cache, $smarty, [$navigation, $cc_nav, $staffcp_nav], $widgets, $template);

--- a/modules/Forum/pages/forum/view_topic.php
+++ b/modules/Forum/pages/forum/view_topic.php
@@ -14,7 +14,6 @@ const PAGE = 'forum';
 
 $forum = new Forum();
 $timeago = new TimeAgo(TIMEZONE);
-$mentionsParser = new MentionsParser();
 
 // Get topic ID
 $tid = explode('/', $route);
@@ -273,7 +272,7 @@ if (Input::exists()) {
 
             // Get last post ID
             $last_post_id = $queries->getLastId();
-            $content = $mentionsParser->parse($user->data()->id, $content, URL::build('/forum/topic/' . $tid, 'pid=' . $last_post_id), ['path' => ROOT_PATH . '/modules/Forum/language', 'file' => 'forum', 'term' => 'user_tag'], ['path' => ROOT_PATH . '/modules/Forum/language', 'file' => 'forum', 'term' => 'user_tag_info', 'replace' => '{x}', 'replace_with' => Output::getClean($user->data()->nickname)]);
+            $content = MentionsParser::parse($user->data()->id, $content, URL::build('/forum/topic/' . $tid, 'pid=' . $last_post_id), ['path' => ROOT_PATH . '/modules/Forum/language', 'file' => 'forum', 'term' => 'user_tag'], ['path' => ROOT_PATH . '/modules/Forum/language', 'file' => 'forum', 'term' => 'user_tag_info', 'replace' => '{x}', 'replace_with' => Output::getClean($user->data()->nickname)]);
 
             $queries->update('posts', $last_post_id, [
                 'post_content' => $content
@@ -791,7 +790,7 @@ $template->addJSFiles([
 ]);
 
 if ($user->isLoggedIn()) {
-    $template->addJSScript(Input::createTinyEditor($language, 'quickreply'));
+    $template->addJSScript(Input::createTinyEditor($language, 'quickreply', true));
 }
 
 if ($user->isLoggedIn()) {

--- a/modules/Forum/pages/forum/view_topic.php
+++ b/modules/Forum/pages/forum/view_topic.php
@@ -272,7 +272,13 @@ if (Input::exists()) {
 
             // Get last post ID
             $last_post_id = $queries->getLastId();
-            $content = MentionsParser::parse($user->data()->id, $content, URL::build('/forum/topic/' . $tid, 'pid=' . $last_post_id), ['path' => ROOT_PATH . '/modules/Forum/language', 'file' => 'forum', 'term' => 'user_tag'], ['path' => ROOT_PATH . '/modules/Forum/language', 'file' => 'forum', 'term' => 'user_tag_info', 'replace' => '{x}', 'replace_with' => Output::getClean($user->data()->nickname)]);
+            $content = MentionsParser::parse(
+                $user->data()->id,
+                $content,
+                URL::build('/forum/topic/' . $tid, 'pid=' . $last_post_id),
+                ['path' => ROOT_PATH . '/modules/Forum/language', 'file' => 'forum', 'term' => 'user_tag'],
+                ['path' => ROOT_PATH . '/modules/Forum/language', 'file' => 'forum', 'term' => 'user_tag_info', 'replace' => '{x}', 'replace_with' => Output::getClean($user->data()->nickname)]
+            );
 
             $queries->update('posts', $last_post_id, [
                 'post_content' => $content


### PR DESCRIPTION
https://user-images.githubusercontent.com/26070412/160975475-f199eaae-30c0-4712-9ea3-3f2267dc3527.mov

This also cleans up `MentionsParser` a tiny bit, and makes the `parse` method static.
Additionally, to avoid slowing down the user list endpoint, I had to rework how user avatars are generated so that I can use data already queried in the API endpoint to generate the avatars.

~~We might want to consider adding a `&like=<string>` GET query param to the user list endpoint, because if the suggestions take > 200ms to show up it will be super annoying for the users. @Derkades what are your thoughts on this?~~

~~Also, do you want to keep it as `.includes(...)` or would `.startsWith(...)` be better for showing suggestions?~~
~~- Currently it is using `includes`, which is fine for my dev site since it has very few users - but if someone with many users used this, it would show many more than if we used `startsWith`. Thoughts?~~

(Ignore the random Collection changes, I meant to commit them separately)

Closes #2351