### PR TITLE
Fixes the width for dropdowns when darkmode is enabled

### DIFF
--- a/custom/templates/DefaultRevamp/css/custom.css
+++ b/custom/templates/DefaultRevamp/css/custom.css
@@ -990,7 +990,7 @@ body.dark .ui.popup, body.dark .ui.secondary.menu .ui.popup, body.dark .ui.menu 
     background-color: #222;
     border: 1px solid #444;
     color: rgba(255, 255, 255, 0.6);
-    min-width: 200px;
+    min-width: calc(100% - 1px);
 }
 
 body.dark .ui.button, body.dark .ui.default.button, body.dark .ui.mini.icon.button, body.dark .ui.top.right.attached.label {


### PR DESCRIPTION
Before:
![https://cdn.padow.ru/bODz](https://cdn.padow.ru/bODz)
After:
![https://cdn.padow.ru/MG15](https://cdn.padow.ru/MG15)
