### PR TITLE
Fix long dropdown names overflowing

### DIFF
--- a/custom/panel_templates/Default/assets/css/custom.css
+++ b/custom/panel_templates/Default/assets/css/custom.css
@@ -396,7 +396,7 @@ body {
 }
 
 .collapse-item {
-    white-space: normal !important;;
+    white-space: normal !important;
 }
 
 .table-hover.dataTables-users tbody tr {

--- a/custom/panel_templates/Default/assets/css/custom.css
+++ b/custom/panel_templates/Default/assets/css/custom.css
@@ -395,6 +395,10 @@ body {
     max-width: none;
 }
 
+.collapse-item {
+    white-space: normal !important;;
+}
+
 .table-hover.dataTables-users tbody tr {
     cursor: pointer;
 }


### PR DESCRIPTION
![before](https://user-images.githubusercontent.com/34658474/164914952-904fa787-9fcc-4099-8f06-06e90ef7273b.png)
![after](https://i.imgur.com/mKPCZX7.png)