### PR TITLE
Fixes dark text on Cookies popup

### DIFF
--- a/custom/templates/DefaultRevamp/css/custom.css
+++ b/custom/templates/DefaultRevamp/css/custom.css
@@ -526,7 +526,7 @@ body.pushable>.pusher {
     color: #fff;
 }
 
-.cc-revoke.cc-bottom.cc-right.cc-animate {
+.cc-revoke.cc-bottom.cc-right {
     color: #fff;
 }
 


### PR DESCRIPTION
As on phones there's no animate and the animate class is removed, so the color is not declared for the phone. An actual fix for #2660