### PR TITLE
(Optional) Auto language detection for guests

### DIFF
--- a/core/init.php
+++ b/core/init.php
@@ -219,6 +219,15 @@ if ($page != 'install') {
     }
 
     if (!$user->isLoggedIn() || !($user->data()->language_id)) {
+        // Attempt to get the requested language from the browser if it exists
+        // and if the user has enabled auto language detection
+        $automatic_locale = Locale::acceptFromHttp($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+        if (!Cookie::exists('auto_language') || Cookie::get('auto_language') === 'true') {
+            if (array_key_exists($automatic_locale, Language::LANGUAGES)) {
+                $default_language = $automatic_locale;
+            }
+        }
+
         // Default language for guests
         define('LANGUAGE', $default_language);
     } else {

--- a/core/templates/frontend_init.php
+++ b/core/templates/frontend_init.php
@@ -162,6 +162,9 @@ $smarty->assign([
     'FOOTER_LINKS_TITLE' => $language->get('general', 'links'),
     'FOOTER_SOCIAL_TITLE' => $language->get('general', 'social'),
     'TOGGLE_DARK_MODE_TEXT' => $language->get('general', 'toggle_dark_mode'),
+    'AUTO_LANGUAGE_TEXT' => $language->get('general', 'auto_language'),
+    'ENABLED' => $language->get('user', 'enabled'),
+    'DISABLED' => $language->get('user', 'disabled'),
     'DARK_LIGHT_MODE_ACTION' => URL::build('/queries/dark_light_mode'),
     'DARK_LIGHT_MODE_TOKEN' => $user->isLoggedIn() ? Token::get() : null
 ]);

--- a/custom/languages/en_UK.json
+++ b/custom/languages/en_UK.json
@@ -736,6 +736,7 @@
     "general\/already_registered": "Already Registered?",
     "general\/and_x_more": "and {{count}} more",
     "general\/are_you_sure": "Are you sure?",
+    "general\/auto_language": "Auto language",
     "general\/back": "Back",
     "general\/browse": "Browse",
     "general\/bungee_instance": "This server is a Bungee instance.",

--- a/custom/templates/DefaultRevamp/footer.tpl
+++ b/custom/templates/DefaultRevamp/footer.tpl
@@ -13,6 +13,9 @@
               <span class="item" id="page_load"></span>
             {/if}
             <a class="item" href="javascript:" onclick="toggleDarkLightMode()">{$TOGGLE_DARK_MODE_TEXT}</a>
+            {if !$LOGGED_IN_USER}
+              <a class="item" href="javascript:" onclick="toggleAutoLanguage()" id="auto-language"></a>
+            {/if}
           </div>
         </div>
         <div class="{if $SOCIAL_MEDIA_ICONS|count > 0}five{else}eight{/if} wide column">
@@ -83,6 +86,19 @@
         });
 
       return false;
+    }
+
+    const autoLanguage = document.getElementById('auto-language');
+    const autoLanguageValue = $.cookie('auto_language') ?? 'true';
+    autoLanguage.innerText = '{$AUTO_LANGUAGE_TEXT} (' + (autoLanguageValue === 'true' ? '{$ENABLED}' : '{$DISABLED}') + ')';
+
+    function toggleAutoLanguage() {
+      $.cookie(
+              'auto_language',
+              autoLanguageValue === 'true' ? 'false' : 'true',
+              { path: '/' }
+      );
+      window.location.reload();
     }
   </script>
 


### PR DESCRIPTION
Will close #2196 if approved.

If a user is logged out, and has language detection enabled (via a cookie), or if the cookie doesn't exist, then we attempt to get the browser locale and see if we have a matching language.

Not totally happy with "Auto language" as the button, so ideas are appreciated.