### PR TITLE
Extend popover timeout

### DIFF
--- a/custom/panel_templates/Default/template.php
+++ b/custom/panel_templates/Default/template.php
@@ -120,7 +120,7 @@ if (!class_exists('Default_Panel_Template')) {
 					    if (!$(".popover:hover").length) {
 					      $(_this).popover("hide")
 					    }
-					  }, 100);
+					  }, 250);
 					});
 				});
 


### PR DESCRIPTION
I'll be going through the admin panel to add more documentation links per the Discord discussion, and the method I've settled on requires a longer timeout to give users enough time to move their cursor onto hyperlinks. Example:

![popover](https://user-images.githubusercontent.com/2267126/169720514-fbf7bcec-61c7-4778-b263-f29e5bfc9090.png)

