### PR TITLE
Global debugging constants to optimize requests when users cannot view exception page

### DIFF
--- a/core/classes/Database/QueryRecorder.php
+++ b/core/classes/Database/QueryRecorder.php
@@ -29,10 +29,12 @@ class QueryRecorder extends Instanceable {
      * @param array $params Bound parameters used in the query
      */
     public function pushQuery(string $sql, array $params): void {
+        if (!Debugging::canViewDetailedError()) {
+            return;
+        }
+
         $backtrace = $this->lastReleventBacktrace();
 
-        // TODO: if/when we have a globally available way to get the logged in user,
-        // check if they're able to view the sql exception page, and don't waste time doing all this if they can't
         $this->_query_stack[] = [
             'number' => $this->_query_stack_num,
             'frame' => ErrorHandler::parseFrame(null, $backtrace['file'], $backtrace['line'], $this->_query_stack_num),

--- a/core/classes/Misc/Debugging.php
+++ b/core/classes/Misc/Debugging.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Class to help manage global state of various debugging variables.
+ * TODO: Make `Debugging::enabled()` instead of needing to do `defined('DEBUGGING') && DEBUGGING`
+ *
+ * @package NamelessMC\Misc
+ * @author Aberdeener
+ * @version 2.0.0
+ * @license MIT
+ */
+class Debugging {
+
+    private static bool $_can_view_detailed_error;
+    private static bool $_can_generate_debug_link;
+
+    public static function canViewDetailedError(): bool {
+        return self::$_can_view_detailed_error;
+    }
+
+    public static function setCanViewDetailedError(bool $detailed_error): void {
+        self::$_can_view_detailed_error = $detailed_error;
+    }
+
+    public static function canGenerateDebugLink(): bool {
+        return self::$_can_generate_debug_link;
+    }
+
+    public static function setCanGenerateDebugLink(bool $can_generate_debug_link): void {
+        self::$_can_generate_debug_link = $can_generate_debug_link;
+    }
+
+}

--- a/core/init.php
+++ b/core/init.php
@@ -22,6 +22,9 @@ if (!isset($page)) {
     die('$page variable is unset. Cannot continue.');
 }
 
+Debugging::setCanViewDetailedError(defined('DEBUGGING') && DEBUGGING);
+Debugging::setCanGenerateDebugLink(defined('DEBUGGING') && DEBUGGING);
+
 // All paths should be writable, but recursively checking everything would take too much time.
 // Only check the most important paths.
 $writable_check_paths = [
@@ -500,6 +503,9 @@ if ($page != 'install') {
 
     // Perform tasks if the user is logged in
     if ($user->isLoggedIn()) {
+        Debugging::setCanViewDetailedError($user->hasPermission('admincp.errors'));
+        Debugging::setCanGenerateDebugLink($user->hasPermission('admincp.core.debugging'));
+
         // Ensure a user is not banned
         if ($user->data()->isbanned == 1) {
             $user->logout();

--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@
 header('X-Frame-Options: SAMEORIGIN');
 
 if ((!defined('DEBUGGING') || !DEBUGGING) && (getenv('NAMELESS_DEBUGGING') || isset($_SERVER['NAMELESS_DEBUGGING']))) {
-    define('DEBUGGING', 1);
+    define('DEBUGGING', true);
 }
 
 if (defined('DEBUGGING') && DEBUGGING) {


### PR DESCRIPTION
Bad title 😛 

This PR brings an optimization to the exception page.
Previously, when an exception is caught, the `ErrorHandler` class would go over the backtrace to make all of the frames + SQL query frames, even if the user could not view the detailed page.
Also, the `QueryRecorder` class would generate a frame on every SQL query, even if the user could not view the exception page.
This is because it was previously impossible for these classes to know if the user could view the page or not.

Now with the `Debugging` class which contains global booleans which are initialized according to the logged in user/guest/debugging state, these classes can check if the user can view the exception page or not, and skip doing certain tasks if not.

For example, the `QueryRecorder` will now skip recording a query and generating a frame for it if `Debugging::canViewDetailedError()` is false.

This has yielded me quite a good performance increase:
- [Blackfire link before this change](https://blackfire.io/profiles/768a677c-dced-4ce2-9e68-0e902a3209df/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main()&constraintDoc=)
- [Blackfire link with this change in place](https://blackfire.io/profiles/bfc1ef5d-3287-4485-bff4-2cd66ccefc06/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main()&constraintDoc=)

~100ms difference (this is mostly due to `QueryRecorder::pushQuery` taking 70.8ms before the change), and no method calls to things like `SqlFormatter::highlightToken`!

It's late and I'm pretty sure my typing and wording in this PR is quite bad, let me know if you have any questions!