### PR TITLE
group sync fixes:tm:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - Fix `AssetResolver` adding an asset more than once if several assets depend on it
 - Fix TinyMCE spoiler plugin not being added properly if a custom path is set
 - Fix error when creating group sync rules with only 1 external service
+- Fix website -> Discord group sync issues
 
 ### Deprecated
 *These will be removed in 2.1.0*

--- a/core/classes/Group_Sync/GroupSyncManager.php
+++ b/core/classes/Group_Sync/GroupSyncManager.php
@@ -177,7 +177,6 @@ final class GroupSyncManager extends Instanceable {
                 $injector_column = $injector->getColumnName();
                 $injector_group_id = $rule->{$injector_column};
                 $sending_group_id = $rule->{$sending_injector->getColumnName()};
-                $nameless_group_id = $rule->{$namelessmc_column};
 
                 // Skip this injector if it doesn't have a group id setup for this rule
                 if ($injector_group_id === null) {
@@ -195,16 +194,13 @@ final class GroupSyncManager extends Instanceable {
                 }
 
                 if (in_array($sending_group_id, $group_ids)) {
-                    // echo 'adding ' . $injector_column . ' of ' . $injector_group_id . '(website ' . $nameless_group_id . ') to ' . $user->data()->username . PHP_EOL;
                     // TODO: add bot status of "nochange" @ https://canary.discord.com/channels/246705793066467328/434751012428054530/995503906350174290
-                    //if (!in_array($nameless_group_id, $user_group_ids)) {
-                        // Attempt to add group if this group id was sent in the broadcastChange() method
-                        // and if they don't have the namelessmc equivilant of it
-                        if ($injector->addGroup($user, $injector_group_id)) {
-                            $modified[$injector_column][] = $injector_group_id;
-                            $logs['added'][] = "{$injector_column} -> {$injector_group_id}";
-                        }
-                    //}
+                    // Attempt to add group if this group id was sent in the broadcastChange() method
+                    // and if they don't have the namelessmc equivilant of it
+                    if ($injector->addGroup($user, $injector_group_id)) {
+                        $modified[$injector_column][] = $injector_group_id;
+                        $logs['added'][] = "{$injector_column} -> {$injector_group_id}";
+                    }
                 } else {
                     foreach ($rules as $item) {
                         if (in_array($item->{$sending_injector->getColumnName()}, $group_ids)) {
@@ -213,12 +209,6 @@ final class GroupSyncManager extends Instanceable {
                             }
                         }
                     }
-
-//                    if (!in_array($nameless_group_id, $user_group_ids)) {
-//                        continue;
-//                    }
-
-                    // echo 'removing ' . $injector_column . ' of ' . $injector_group_id . ' from ' . $user->data()->username . PHP_EOL;
 
                     // Attempt to remove this group if it doesn't have multiple rules, or if the group ids
                     // list sent to broadcastChange() was empty - NOT both

--- a/core/classes/Group_Sync/GroupSyncManager.php
+++ b/core/classes/Group_Sync/GroupSyncManager.php
@@ -194,24 +194,31 @@ final class GroupSyncManager extends Instanceable {
                     continue;
                 }
 
-                if (
-                    in_array($sending_group_id, $group_ids)
-                    && !in_array($nameless_group_id, $user->getAllGroupIds())
-                ) {
-                    // Attempt to add group if this group id was sent in the broadcastChange() method
-                    // and if they don't have the namelessmc equivilant of it
-                    if ($injector->addGroup($user, $injector_group_id)) {
-                        $modified[$injector_column][] = $injector_group_id;
-                        $logs['added'][] = "{$injector_column} -> {$injector_group_id}";
-                    }
+                if (in_array($sending_group_id, $group_ids)) {
+                    // echo 'adding ' . $injector_column . ' of ' . $injector_group_id . '(website ' . $nameless_group_id . ') to ' . $user->data()->username . PHP_EOL;
+                    // TODO: add bot status of "nochange" @ https://canary.discord.com/channels/246705793066467328/434751012428054530/995503906350174290
+                    //if (!in_array($nameless_group_id, $user_group_ids)) {
+                        // Attempt to add group if this group id was sent in the broadcastChange() method
+                        // and if they don't have the namelessmc equivilant of it
+                        if ($injector->addGroup($user, $injector_group_id)) {
+                            $modified[$injector_column][] = $injector_group_id;
+                            $logs['added'][] = "{$injector_column} -> {$injector_group_id}";
+                        }
+                    //}
                 } else {
                     foreach ($rules as $item) {
-                        if (in_array($item->{$sending_injector->getColumnName()}, $group_ids)) {
+                        if (in_array($rule->{$sending_injector->getColumnName()}, $group_ids)) {
                             if ($item->{$namelessmc_column} == $rule->{$namelessmc_column}) {
                                 continue 2;
                             }
                         }
                     }
+
+//                    if (!in_array($nameless_group_id, $user_group_ids)) {
+//                        continue;
+//                    }
+
+                    // echo 'removing ' . $injector_column . ' of ' . $injector_group_id . ' from ' . $user->data()->username . PHP_EOL;
 
                     // Attempt to remove this group if it doesn't have multiple rules, or if the group ids
                     // list sent to broadcastChange() was empty - NOT both

--- a/core/classes/Group_Sync/GroupSyncManager.php
+++ b/core/classes/Group_Sync/GroupSyncManager.php
@@ -207,7 +207,7 @@ final class GroupSyncManager extends Instanceable {
                     //}
                 } else {
                     foreach ($rules as $item) {
-                        if (in_array($rule->{$sending_injector->getColumnName()}, $group_ids)) {
+                        if (in_array($item->{$sending_injector->getColumnName()}, $group_ids)) {
                             if ($item->{$namelessmc_column} == $rule->{$namelessmc_column}) {
                                 continue 2;
                             }

--- a/core/classes/Integrations/IntegrationUser.php
+++ b/core/classes/Integrations/IntegrationUser.php
@@ -110,6 +110,9 @@ class IntegrationUser {
             ]
         );
 
+        // Load the data for this integration from the query we just made
+        $this->_data = new IntegrationUserData($this->_db->query('SELECT * FROM nl2_users_integrations WHERE id = ?', [$this->_db->lastId()])->first());
+
         $default_language = new Language('core', DEFAULT_LANGUAGE);
         EventHandler::executeEvent('linkIntegrationUser', [
             'integration' => $this->_integration->getName(),

--- a/modules/Core/includes/endpoints/AddGroupsEndpoint.php
+++ b/modules/Core/includes/endpoints/AddGroupsEndpoint.php
@@ -22,7 +22,6 @@ class AddGroupsEndpoint extends KeyAuthEndpoint {
         }
 
         $log_array = [];
-        $added_groups = [];
         foreach ($groups as $group) {
             $group_query = $api->getDb()->get('groups', ['id', $group]);
             if (!$group_query->count()) {
@@ -31,7 +30,6 @@ class AddGroupsEndpoint extends KeyAuthEndpoint {
             $group_query = $group_query->first();
 
             if ($user->addGroup($group, 0, $group_query)) {
-                $added_groups[] = $group;
                 $log_array['added'][] = $group_query->name;
             }
         }
@@ -39,7 +37,7 @@ class AddGroupsEndpoint extends KeyAuthEndpoint {
         GroupSyncManager::getInstance()->broadcastChange(
             $user,
             NamelessMCGroupSyncInjector::class,
-            $added_groups
+            $user->getAllGroupIds(),
         );
 
         $api->returnArray(array_merge(['message' => $api->getLanguage()->get('api', 'group_updated')], $log_array));

--- a/modules/Core/includes/endpoints/RemoveGroupsEndpoint.php
+++ b/modules/Core/includes/endpoints/RemoveGroupsEndpoint.php
@@ -23,17 +23,14 @@ class RemoveGroupsEndpoint extends KeyAuthEndpoint {
             $api->throwError(Nameless2API::ERROR_INVALID_POST_CONTENTS);
         }
 
-        $removed_groups = [];
         foreach ($groups as $group) {
-            if ($user->removeGroup($group)) {
-                $removed_groups[] = $group;
-            }
+            $user->removeGroup($group);
         }
 
         GroupSyncManager::getInstance()->broadcastChange(
             $user,
             NamelessMCGroupSyncInjector::class,
-            $removed_groups
+            $user->getAllGroupIds(),
         );
 
         $api->returnArray(['message' => $api->getLanguage()->get('api', 'group_updated')]);

--- a/modules/Core/pages/panel/users_integrations.php
+++ b/modules/Core/pages/panel/users_integrations.php
@@ -102,6 +102,10 @@ if (!isset($_GET['action']) || !isset($_GET['integration'])) {
 
                             $integrationUser = new IntegrationUser($integration);
                             $integrationUser->linkIntegration($view_user, Output::getClean(Input::get('identifier')), Output::getClean(Input::get('username')), (bool) Output::getClean(Input::get('verified')), $code);
+
+                            if (Output::getClean(Input::get('verified'))) {
+                                $integrationUser->verifyIntegration();
+                            }
                         } else {
                             // Update existing integration user
                             $integrationUser->update([

--- a/modules/Discord Integration/classes/Discord.php
+++ b/modules/Discord Integration/classes/Discord.php
@@ -25,9 +25,9 @@ class Discord {
     private static Language $_discord_integration_language;
 
     /**
-     * @var array|string[] Valid responses from the Discord bot
+     * @var array Valid responses from the Discord bot
      */
-    private static array $_valid_responses = [
+    private const VALID_RESPONSES = [
         'fullsuccess',
         'badparameter',
         'error',
@@ -71,7 +71,7 @@ class Discord {
         }
 
         if ($result == 'partsuccess') {
-            Log::getInstance()->log(Log::Action('discord/role_set'), self::getLanguageTerm('discord_bot_error_partsuccess'));
+            Log::getInstance()->log(Log::Action('discord/role_set'), self::getLanguageTerm('discord_bot_error_partsuccess'), $user->data()->id);
             return true;
         }
 
@@ -174,7 +174,7 @@ class Discord {
 
         $response = $client->contents();
 
-        if (in_array($response, self::$_valid_responses)) {
+        if (in_array($response, self::VALID_RESPONSES)) {
             return $response;
         }
 
@@ -214,7 +214,7 @@ class Discord {
             ];
         }
 
-        if (in_array($result, self::$_valid_responses)) {
+        if (in_array($result, self::VALID_RESPONSES)) {
             return [self::getLanguageTerm('discord_bot_error_' . $result)];
         }
 

--- a/modules/Discord Integration/classes/Discord.php
+++ b/modules/Discord Integration/classes/Discord.php
@@ -29,6 +29,7 @@ class Discord {
      */
     private const VALID_RESPONSES = [
         'fullsuccess',
+        'partsuccess',
         'badparameter',
         'error',
         'invguild',

--- a/modules/Discord Integration/classes/DiscordIntegration.php
+++ b/modules/Discord Integration/classes/DiscordIntegration.php
@@ -50,7 +50,11 @@ class DiscordIntegration extends IntegrationBase {
         // attempt to update their Discord roles
         $user = $integrationUser->getUser();
 
-        Discord::updateDiscordRoles($user, $user->getAllGroupIds(), []);
+        $roles = array_unique(array_map(static function ($group_id) {
+            return Discord::getDiscordRoleId(DB::getInstance(), $group_id);
+        }, $user->getAllGroupIds()));
+
+        Discord::updateDiscordRoles($user, $roles, []);
     }
 
     public function validateUsername(string $username, int $integration_user_id = 0): bool {


### PR DESCRIPTION
working for me as expected,  the trade-off is that `"discord_role_id -> <role id>"` will be logged every time a group sync broadcast is made to their site logs, even if they already had the group

this *could* be avoided by two ways:
- not log any discord injector changes, meh
	- group sync logging is a mess as it is. might be fine just removing the whole thing 🤔 
- making the bot return some nicer info when requests are made, such as whether the group was added/removed properly, or if they already had it/didn't have it
	- this is probably the better option, but very annoying to implement.


waiting for some more testing from someone else, will merge/edit/rage-quit when i hear back from them

will close https://github.com/NamelessMC/Nameless/issues/2865