### PR TITLE
Fix non-string config values not saving properly

### DIFF
--- a/core/classes/Core/Config.php
+++ b/core/classes/Core/Config.php
@@ -116,7 +116,7 @@ class Config {
                 $loc = &$loc[$step];
             }
             // Check if it is a string here so that `null` is not converted to `''`
-            $loc = $value === null ? $value : addslashes($value);
+            $loc = !is_string($value) ? $value : addslashes($value);
         }
 
         static::write((array) $config);
@@ -140,7 +140,7 @@ class Config {
                 foreach ($path as $step) {
                     $loc = &$loc[$step];
                 }
-                $loc = addslashes($value);
+                $loc = !is_string($value) ? $value : addslashes($value);
             }
         }
 


### PR DESCRIPTION
Fixes issue where friendly URLs, force HTTPS, force WWW were saving into config as `'1'` and `'0'` instead of `true` and `false`