### PR TITLE
Better module/template version check

### DIFF
--- a/core/classes/Core/Util.php
+++ b/core/classes/Core/Util.php
@@ -524,4 +524,19 @@ class Util {
         return [$before, $after];
     }
 
+    /**
+     * Determine whether a module/template version is compatible with the current NamelessMC version.
+     * This ignores patch versions, and only checks major and minor versions.
+     * For example, 2.0.0 and 2.0.1 are compatible, but 2.0.0 and 2.1.0 are not.
+     * @param string $version Version of module/template to check
+     * @param string $nameless_version Current NamelessMC version
+     * @return bool Whether they are compatible or not
+     */
+    public static function isCompatible(string $version, string $nameless_version): bool {
+        [$major, $minor, ] = explode('.', $version);
+        [$nameless_major, $nameless_minor, ] = explode('.', $nameless_version);
+
+        return $major == $nameless_major && $minor == $nameless_minor;
+    }
+
 }

--- a/modules/Core/pages/panel/modules.php
+++ b/modules/Core/pages/panel/modules.php
@@ -54,7 +54,7 @@ if (!isset($_GET['action'])) {
             'nameless_version' => Output::getClean($module->getNamelessVersion()),
             'author' => Output::getPurified($module->getAuthor()),
             'author_x' => $language->get('admin', 'author_x', ['author' => Output::getPurified($module->getAuthor())]),
-            'version_mismatch' => (($module->getNamelessVersion() != NAMELESS_VERSION) ? $language->get('admin', 'module_outdated', [
+            'version_mismatch' => (Util::isCompatible($module->getNamelessVersion(), NAMELESS_VERSION) ? $language->get('admin', 'module_outdated', [
                 'intendedVersion' => Text::bold(Output::getClean($module->getNamelessVersion())),
                 'actualVersion' => Text::bold(NAMELESS_VERSION)
             ]) : false),

--- a/modules/Core/pages/panel/modules.php
+++ b/modules/Core/pages/panel/modules.php
@@ -54,10 +54,10 @@ if (!isset($_GET['action'])) {
             'nameless_version' => Output::getClean($module->getNamelessVersion()),
             'author' => Output::getPurified($module->getAuthor()),
             'author_x' => $language->get('admin', 'author_x', ['author' => Output::getPurified($module->getAuthor())]),
-            'version_mismatch' => (Util::isCompatible($module->getNamelessVersion(), NAMELESS_VERSION) ? $language->get('admin', 'module_outdated', [
+            'version_mismatch' => !Util::isCompatible($module->getNamelessVersion(), NAMELESS_VERSION) ? $language->get('admin', 'module_outdated', [
                 'intendedVersion' => Text::bold(Output::getClean($module->getNamelessVersion())),
                 'actualVersion' => Text::bold(NAMELESS_VERSION)
-            ]) : false),
+            ]) : false,
             'disable_link' => (($module->getName() != 'Core' && $item->enabled) ? URL::build('/panel/core/modules/', 'action=disable&m=' . urlencode($item->id)) : null),
             'enable_link' => (($module->getName() != 'Core' && !$item->enabled) ? URL::build('/panel/core/modules/', 'action=enable&m=' . urlencode($item->id)) : null),
             'enabled' => $item->enabled

--- a/modules/Core/pages/panel/panel_templates.php
+++ b/modules/Core/pages/panel/panel_templates.php
@@ -46,13 +46,10 @@ if (!isset($_GET['action'])) {
             'version' => Output::getClean($template->getVersion()),
             'author' => $template->getAuthor(),
             'author_x' => $language->get('admin', 'author_x', ['author' => $template->getAuthor()]),
-            'version_mismatch' => (Util::isCompatible($template->getNamelessVersion(), NAMELESS_VERSION)
-                ? $language->get('admin', 'template_outdated', [
-                    'intendedVersion' => Output::getClean($template->getNamelessVersion()),
-                    'actualVersion' => NAMELESS_VERSION,
-                ])
-                : false
-            ),
+            'version_mismatch' => !Util::isCompatible($template->getNamelessVersion(), NAMELESS_VERSION) ? $language->get('admin', 'template_outdated', [
+                'intendedVersion' => Output::getClean($template->getNamelessVersion()),
+                'actualVersion' => NAMELESS_VERSION,
+            ]) : false,
             'enabled' => $item->enabled,
             'activate_link' => (($item->enabled) ? null : URL::build('/panel/core/panel_templates/', 'action=activate&template=' . urlencode($item->id))),
             'delete_link' => (($item->id == 1 || $item->enabled) ? null : URL::build('/panel/core/panel_templates/', 'action=delete&template=' . urlencode($item->id))),

--- a/modules/Core/pages/panel/panel_templates.php
+++ b/modules/Core/pages/panel/panel_templates.php
@@ -46,7 +46,7 @@ if (!isset($_GET['action'])) {
             'version' => Output::getClean($template->getVersion()),
             'author' => $template->getAuthor(),
             'author_x' => $language->get('admin', 'author_x', ['author' => $template->getAuthor()]),
-            'version_mismatch' => (($template->getNamelessVersion() != NAMELESS_VERSION)
+            'version_mismatch' => (Util::isCompatible($template->getNamelessVersion(), NAMELESS_VERSION)
                 ? $language->get('admin', 'template_outdated', [
                     'intendedVersion' => Output::getClean($template->getNamelessVersion()),
                     'actualVersion' => NAMELESS_VERSION,

--- a/modules/Core/pages/panel/templates.php
+++ b/modules/Core/pages/panel/templates.php
@@ -56,13 +56,10 @@ if (!isset($_GET['action'])) {
             'version' => Output::getClean($template->getVersion()),
             'author' => $template->getAuthor(),
             'author_x' => $language->get('admin', 'author_x', ['author' => $template->getAuthor()]),
-            'version_mismatch' => (Util::isCompatible($template->getNamelessVersion(), NAMELESS_VERSION)
-                ? $language->get('admin', 'template_outdated', [
-                    'intendedVersion' => Text::bold(Output::getClean($template->getNamelessVersion())),
-                    'actualVersion' => Text::bold(NAMELESS_VERSION)
-                ])
-                : false
-            ),
+            'version_mismatch' => !Util::isCompatible($template->getNamelessVersion(), NAMELESS_VERSION) ? $language->get('admin', 'template_outdated', [
+                'intendedVersion' => Text::bold(Output::getClean($template->getNamelessVersion())),
+                'actualVersion' => Text::bold(NAMELESS_VERSION)
+            ]) : false,
             'enabled' => $item->enabled,
             'default_warning' => (Output::getClean($item->name) == 'Default') ? $language->get('admin', 'template_not_supported') : null,
             'activate_link' => (($item->enabled) ? null : URL::build('/panel/core/templates/', 'action=activate&template=' . urlencode($item->id))),

--- a/modules/Core/pages/panel/templates.php
+++ b/modules/Core/pages/panel/templates.php
@@ -56,7 +56,7 @@ if (!isset($_GET['action'])) {
             'version' => Output::getClean($template->getVersion()),
             'author' => $template->getAuthor(),
             'author_x' => $language->get('admin', 'author_x', ['author' => $template->getAuthor()]),
-            'version_mismatch' => (($template->getNamelessVersion() != NAMELESS_VERSION)
+            'version_mismatch' => (Util::isCompatible($template->getNamelessVersion(), NAMELESS_VERSION)
                 ? $language->get('admin', 'template_outdated', [
                     'intendedVersion' => Text::bold(Output::getClean($template->getNamelessVersion())),
                     'actualVersion' => Text::bold(NAMELESS_VERSION)


### PR DESCRIPTION
Closes https://github.com/NamelessMC/Nameless/issues/2993

This adds a new method named `Util::isCompatible`, which determines if a module/template version is compatible with a given NamelessMC version.
For example:
- 2.0.1 and 2.0.2 are compatible
- 2.0.0 and 2.1.0 are incompatible
- 2.0.0 and 3.0.0 are incompatible 