### PR TITLE
Better missing/extra migration exception page

### DIFF
--- a/core/classes/Database/PhinxAdapter.php
+++ b/core/classes/Database/PhinxAdapter.php
@@ -9,22 +9,45 @@ class PhinxAdapter {
      * @throws RuntimeException If these numbers don't match.
      */
     public static function ensureUpToDate(): void {
-        $migration_files = count(scandir(__DIR__ . '/../../migrations')) - 3; // -3 because of . and .. and phinx.php
-        $migration_database_entries = DB::getInstance()->query('SELECT COUNT(*) AS count FROM nl2_phinxlog')->first()->count;
+        $migration_files = array_map(static function ($file_name) {
+            [$version, $migration_name] = explode('_', $file_name, 2);
+            $migration_name = str_replace(['.php', '_'], '', ucwords($migration_name, '_'));
+            return $version . '_' . $migration_name;
+        }, array_filter(scandir(__DIR__ . '/../../migrations'), static function ($file_name) {
+            return !in_array($file_name, ['.', '..', 'phinx.php']);
+        }));
 
-        if ($migration_files == $migration_database_entries) {
-            return;
-        }
+        $migration_database_entries = array_map(static function ($row) {
+            return $row->version . '_' . $row->migration_name;
+        }, DB::getInstance()->query('SELECT version, migration_name FROM nl2_phinxlog')->results());
+
+        $missing = array_diff($migration_files, $migration_database_entries);
+        $extra = array_diff($migration_database_entries, $migration_files);
 
         // Likely a pull from the repo dev branch or migrations
         // weren't run during an upgrade script.
-        if (($diff = $migration_files - $migration_database_entries) > 0) {
-            throw new RuntimeException("There are {$diff} database migrations pending.");
+        if (($missing_count = count($missing)) > 0) {
+            echo "There are $missing_count migrations files which have not been executed:" . '<br>';
+            foreach ($missing as $missing_migration) {
+                echo " - $missing_migration" . '<br>';
+            }
         }
 
         // Something went wonky, either they've deleted migration files,
         // or they've added stuff to the nl2_phinxlog table.
-        throw new RuntimeException("Inconsistent number of migration database entries ({$migration_database_entries}) and migration files ({$migration_files}).");
+        if (($extra_count = count($extra)) > 0) {
+            if ($missing_count > 0) {
+                echo '<br>';
+            }
+            echo "There are $extra_count executed migrations which do not have migration files associated:" . '<br>';
+            foreach ($extra as $extra_migration) {
+                echo " - $extra_migration" . '<br>';
+            }
+        }
+
+        if ($missing_count > 0 || $extra_count > 0) {
+            die();
+        }
     }
 
     /**

--- a/core/classes/Database/PhinxAdapter.php
+++ b/core/classes/Database/PhinxAdapter.php
@@ -9,13 +9,16 @@ class PhinxAdapter {
      * @throws RuntimeException If these numbers don't match.
      */
     public static function ensureUpToDate(): void {
-        $migration_files = array_map(static function ($file_name) {
-            [$version, $migration_name] = explode('_', $file_name, 2);
-            $migration_name = str_replace(['.php', '_'], '', ucwords($migration_name, '_'));
-            return $version . '_' . $migration_name;
-        }, array_filter(scandir(__DIR__ . '/../../migrations'), static function ($file_name) {
-            return !in_array($file_name, ['.', '..', 'phinx.php']);
-        }));
+        $migration_files = array_map(
+            static function ($file_name) {
+                [$version, $migration_name] = explode('_', $file_name, 2);
+                $migration_name = str_replace(['.php', '_'], '', ucwords($migration_name, '_'));
+                return $version . '_' . $migration_name;
+            },
+            array_filter(scandir(__DIR__ . '/../../migrations'), static function ($file_name) {
+                return !in_array($file_name, ['.', '..', 'phinx.php']);
+            }),
+        );
 
         $migration_database_entries = array_map(static function ($row) {
             return $row->version . '_' . $row->migration_name;


### PR DESCRIPTION
Currently when a site is missing migrations, we [I] do three things that are not ideal:
- Throw an exception
	- This is bad because it requires debugging mode to be enabled, or the user to be admin logged in, which means they often have to check the logs to even see the message
- Missing migrations are determined by just comparing the *size* of the `core/migrations` table and the `nl2_phinxlog` table
    - This is not great because it does not consider the contents of them, and now that we have a new branch system, the likelihood of migrations being a little more messy in dev is much higher, so we should be stricter
- It does not say which migrations are missing

<img width="1721" alt="Screen Shot 2022-08-08 at 08 46 06" src="https://user-images.githubusercontent.com/26070412/183445942-9e9492b6-da1c-48a3-87a4-2d4ef6ca6fdd.png">

This change checks the file names and compares them to the phinxlog table contents, and prints the issues clearly in plain text so they do not need to check their logs.
The page is in plaintext since other fatal issues (wrong php version, missing vendor dir, etc) are also plaintext.

Finally, this is still much faster than forcing phinx to migrate on every page load:
- Force migrate ~18ms:
	- <img width="251" alt="Screen Shot 2022-08-08 at 08 52 55" src="https://user-images.githubusercontent.com/26070412/183447212-79451498-83ef-4d43-b601-9a4f8b5f0653.png">
- This solution ~6ms:
    - <img width="209" alt="Screen Shot 2022-08-08 at 08 53 22" src="https://user-images.githubusercontent.com/26070412/183447324-c9d3c2a0-5f32-42a0-a748-2df580f6c5ba.png">

 