### PR TITLE
Remake tab initialization

### DIFF
--- a/custom/templates/DefaultRevamp/js/core/core.js
+++ b/custom/templates/DefaultRevamp/js/core/core.js
@@ -48,6 +48,8 @@ $(function () {
     $('.message .close').on('click', function () {
         $(this).closest('.message').transition('fade');
     });
+
+    $('.tabular.menu .item').tab();
 });
 
 $(function () {

--- a/custom/templates/DefaultRevamp/js/core/core.js
+++ b/custom/templates/DefaultRevamp/js/core/core.js
@@ -48,9 +48,6 @@ $(function () {
     $('.message .close').on('click', function () {
         $(this).closest('.message').transition('fade');
     });
-
-    $('.menu .item').tab();
-
 });
 
 $(function () {

--- a/custom/templates/DefaultRevamp/js/core/pages.js
+++ b/custom/templates/DefaultRevamp/js/core/pages.js
@@ -57,8 +57,6 @@ if (page !== '') {
             });
         });
     } else if (page === 'profile') {
-        $('.menu.tabular .item').tab();
-
         function showBannerSelect() {
             $('#imageModal').modal({
                 onVisible: function () {


### PR DESCRIPTION
Honestly, when updating to Fomantic UI, with it it is a problem, because "The menu items need to have a referencing `data-tab` property and all missing tabs also a corresponding `tab segment`"
e.g.
```html
<div class="ui top attached tabular menu">
  <a class="item active" data-tab="first">First</a>
  <a class="item" data-tab="second">Second</a>
  <a class="item" data-tab="third">Third</a>
</div>
<div class="ui bottom attached tab segment active" data-tab="first">
  First
</div>
<div class="ui bottom attached tab segment" data-tab="second">
  Second
</div>
<div class="ui bottom attached tab segment" data-tab="third">
  Third
</div>
```

But it is easier to just remove it.
"It makes more sense to fix it yeah but I doubt people will leave a bad review because of it" - @supercrafter100