### PR TITLE
Fix error showing when logging in with OAuth

### DIFF
--- a/core/templates/frontend_init.php
+++ b/core/templates/frontend_init.php
@@ -12,7 +12,7 @@
 const FRONT_END = true;
 
 // Set current page URL in session, provided it's not the login page
-if (defined('PAGE') && PAGE != 'login' && PAGE != 'register' && PAGE != 404 && PAGE != 'maintenance' && (!isset($_GET['route']) || !str_contains($_GET['route'], '/queries'))) {
+if (defined('PAGE') && PAGE != 'login' && PAGE != 'register' && PAGE != 404 && PAGE != 'maintenance' && PAGE != 'oauth' && (!isset($_GET['route']) || !str_contains($_GET['route'], '/queries'))) {
     if (FRIENDLY_URLS === true) {
         $split = explode('?', $_SERVER['REQUEST_URI']);
 


### PR DESCRIPTION
The error occurred when OAuth login was successful and it tried to redirect them to the previous page. Since "oauth" was not a page to be ignored while storing the `last_page` session variable, it would attempt to redirect it to the oauth.php file again, which threw the error since there was no provider in the URL params.