### PR TITLE
Fix OAuth demo URL in registration page

### DIFF
--- a/modules/Core/pages/panel/registration.php
+++ b/modules/Core/pages/panel/registration.php
@@ -193,7 +193,7 @@ $smarty->assign([
     'REDIRECT_URL' => $language->get('admin', 'redirect_url'),
     'CLIENT_ID' => $language->get('admin', 'client_id'),
     'CLIENT_SECRET' => $language->get('admin', 'client_secret'),
-    'OAUTH_URL' => URL::getSelfURL() . ltrim(URL::build('/oauth/', 'provider={{provider}}'), '/'),
+    'OAUTH_URL' => rtrim(URL::getSelfURL(), '/') . URL::build('/oauth', 'provider={{provider}}', 'non-friendly'),
     'PARENT_PAGE' => PARENT_PAGE,
     'DASHBOARD' => $language->get('admin', 'dashboard'),
     'CONFIGURATION' => $language->get('admin', 'configuration'),


### PR DESCRIPTION
As an oversight on my original work on the displaying of the OAuth url, I did not use the same way to build the URL that we do in the NamelessOAuth class.
This PR fixes it.

It will force a non-friendly url for two reasons:
- This bypasses any potential friendly url misconfiguration by going directly to the page. There is the change they have a wonky config that end users would run into if we use a friendly URL here
- If the site owner disables friendly urls, OAuth flows will continue to work

Example support query that this will fix: https://canary.discord.com/channels/246705793066467328/1008929206656303184/1008929210917724223