### PR TITLE
Place dark mode toggle inline

### DIFF
--- a/core/templates/frontend_init.php
+++ b/core/templates/frontend_init.php
@@ -148,7 +148,6 @@ if ($analytics_id) {
 $smarty->assign([
     'FOOTER_LINKS_TITLE' => $language->get('general', 'links'),
     'FOOTER_SOCIAL_TITLE' => $language->get('general', 'social'),
-    'TOGGLE_DARK_MODE_TEXT' => $language->get('general', 'toggle_dark_mode'),
     'AUTO_LANGUAGE_TEXT' => $language->get('general', 'auto_language'),
     'ENABLED' => $language->get('user', 'enabled'),
     'DISABLED' => $language->get('user', 'disabled'),

--- a/custom/languages/en_UK.json
+++ b/custom/languages/en_UK.json
@@ -822,7 +822,6 @@
     "general/status": "Status",
     "general/submit": "Submit",
     "general/success": "Success",
-    "general/toggle_dark_mode": "Toggle dark mode",
     "general/total_online": "Total Online",
     "general/total_online_staff": "Total online staff: {{count}}",
     "general/total_online_users": "Total online users: {{count}}",

--- a/custom/templates/DefaultRevamp/css/custom.css
+++ b/custom/templates/DefaultRevamp/css/custom.css
@@ -970,6 +970,10 @@ select {
     }
 }
 
+#darkmode {
+    display: inline-block;
+}
+
 .darkmode-toggle {
     opacity: 0;
     position: absolute;

--- a/custom/templates/DefaultRevamp/footer.tpl
+++ b/custom/templates/DefaultRevamp/footer.tpl
@@ -12,19 +12,22 @@
                     {if $PAGE_LOAD_TIME}
                     <span class="item" id="page_load"></span>
                     {/if}
-                    <input type="checkbox" class="darkmode-toggle" id="darkmode-toggle" onclick="toggleDarkLightMode()">
-                    <label for="darkmode-toggle" class="darkmode-toggle-label">
-                        <i class="fas fa-moon"></i>
-                        <i class="fas fa-sun"></i>
-                        <div class="darkmode-ball"></div>
-                    </label>
-                    <script type="text/javascript">
-                        if (document.body.classList.contains('dark')) {
-                            document.getElementById("darkmode-toggle").checked = true;
-                        } else {
-                            document.getElementById("darkmode-toggle").checked = false;
-                        }
-                    </script>
+                    <span class="item" id="darkmode">
+                        <input type="checkbox" class="darkmode-toggle" id="darkmode-toggle" onclick="toggleDarkLightMode()">
+                        <label for="darkmode-toggle" class="darkmode-toggle-label">
+                            <i class="fas fa-moon"></i>
+                            <i class="fas fa-sun"></i>
+                            <div class="darkmode-ball"></div>
+                        </label>
+                    
+                        <script type="text/javascript">
+                            if (document.body.classList.contains('dark')) {
+                                document.getElementById("darkmode-toggle").checked = true;
+                            } else {
+                                document.getElementById("darkmode-toggle").checked = false;
+                            }
+                        </script>
+                    </span>
                     {if !$LOGGED_IN_USER}
                     <a class="item" href="javascript:" onclick="toggleAutoLanguage()" id="auto-language"></a>
                     {/if}


### PR DESCRIPTION
On mobile devices (and other low-width screens), footer content is auto-centered, presumably for aesthetics. This PR allows that property to be applied to the new Dark Mode toggle introduced in #2877

Also removes newly unused TOGGLE_DARK_MODE_TEXT