### PR TITLE
Allow OAuth providers to pass additional options to provider constructor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,11 @@
     "description": "NamelessMC is a free, easy to use & powerful website software for your Minecraft server, which includes a large range of features.",
     "type": "project",
     "license": "MIT",
+    "config": {
+        "platform": {
+            "php": "7.4"
+        }
+    },
     "require": {
         "php": ">=7.4",
         "jdorn/sql-formatter": "^1.2",
@@ -26,7 +31,7 @@
         "symfony/http-foundation": "^5.4"
     },
     "require-dev": {
-        "phpstan/phpstan": "1.6.9",
+        "phpstan/phpstan": "^1.8",
         "maximebf/debugbar": "^1.18",
         "junker/debugbar-smarty": "^0.2",
         "hannesvdvreken/guzzle-debugbar": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,6 @@
     "description": "NamelessMC is a free, easy to use & powerful website software for your Minecraft server, which includes a large range of features.",
     "type": "project",
     "license": "MIT",
-    "config": {
-        "platform": {
-            "php": "7.4"
-        }
-    },
     "require": {
         "php": ">=7.4",
         "jdorn/sql-formatter": "^1.2",
@@ -31,7 +26,7 @@
         "symfony/http-foundation": "^5.4"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.8",
+        "phpstan/phpstan": "1.6.9",
         "maximebf/debugbar": "^1.18",
         "junker/debugbar-smarty": "^0.2",
         "hannesvdvreken/guzzle-debugbar": "^3.0",


### PR DESCRIPTION
A simple change which helps us support things like Keycloak.
As you can see from its readme, it wants some additional config options passed to the constructor (`authServerUrl`, `realm`, etc):
https://github.com/stevenmaguire/oauth2-keycloak#authorization-code-flow

This has been tested on a demo keycloak instance thanks to @RediPanda
```php
        NamelessOAuth::getInstance()->registerProvider('keycloak', 'Keycloak Module', [
            'class' => \Stevenmaguire\OAuth2\Client\Provider\Keycloak::class,
            'user_id_name' => 'sub',
            'scope_id_name' => 'profile',
            'icon' => 'fas fa-key',
        ], [
            'authServerUrl'  => 'https://sso.nekonii.xyz',
            'realm' => 'devrealm',
        ]);
```

