### PR TITLE
Show correct server id when it is updated

### DIFF
--- a/modules/Discord Integration/classes/Discord.php
+++ b/modules/Discord Integration/classes/Discord.php
@@ -15,11 +15,6 @@ class Discord {
     private static bool $_is_bot_setup;
 
     /**
-     * @var string|null The ID of this website's Discord server
-     */
-    private static ?string $_guild_id;
-
-    /**
      * @var Language Instance of Language class for translations
      */
     private static Language $_discord_integration_language;
@@ -151,11 +146,7 @@ class Discord {
      * @return string|null Discord guild ID for this site
      */
     public static function getGuildId(): ?string {
-        if (!isset(self::$_guild_id)) {
-            self::$_guild_id = (string) Util::getSetting('discord');
-        }
-
-        return self::$_guild_id;
+        return Util::getSetting('discord');
     }
 
     /**

--- a/modules/Discord Integration/pages/panel/discord.php
+++ b/modules/Discord Integration/pages/panel/discord.php
@@ -123,7 +123,7 @@ $smarty->assign([
     'REQUIREMENTS' => rtrim($language->get('installer', 'requirements'), ':'),
     'BOT_SETUP' => Discord::getLanguageTerm('discord_bot_setup'),
     'DISCORD_GUILD_ID' => Discord::getLanguageTerm('discord_guild_id'),
-    'DISCORD_GUILD_ID_VALUE' => Input::get('discord_guild_id') ?? Discord::getGuildId(),
+    'DISCORD_GUILD_ID_VALUE' => Discord::getGuildId(),
     'ID_INFO' => Discord::getLanguageTerm('discord_id_help', [
         'linkStart' => '<a href="https://support.discord.com/hc/en-us/articles/206346498" target="_blank">',
         'linkEnd' => '</a>',

--- a/modules/Discord Integration/pages/panel/discord.php
+++ b/modules/Discord Integration/pages/panel/discord.php
@@ -123,7 +123,7 @@ $smarty->assign([
     'REQUIREMENTS' => rtrim($language->get('installer', 'requirements'), ':'),
     'BOT_SETUP' => Discord::getLanguageTerm('discord_bot_setup'),
     'DISCORD_GUILD_ID' => Discord::getLanguageTerm('discord_guild_id'),
-    'DISCORD_GUILD_ID_VALUE' => Discord::getGuildId(),
+    'DISCORD_GUILD_ID_VALUE' => Input::get('discord_guild_id') ?? Discord::getGuildId(),
     'ID_INFO' => Discord::getLanguageTerm('discord_id_help', [
         'linkStart' => '<a href="https://support.discord.com/hc/en-us/articles/206346498" target="_blank">',
         'linkEnd' => '</a>',


### PR DESCRIPTION
Because the in-memory cache has not refreshed when the discord id just got updated on the page, it is retrieved from the posted id when this is set so the user sees the actual updated discord id instead of the old one.