### PR TITLE
Simplify missing vendor instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ Here are some things you should know when contributing:
         composer install --dev
         ```
         - This could take up to about a minute depending on your internet connection.
+- We use Yarn to manage frontend dependencies.
+    - Depending on the way you installed Yarn, you will need to run either `yarnpkg` or `yarn install` to download the required dependencies.
 - You can use the CLI (command line) install script to reset your development environment in less than 5 seconds!
     - Run the following command when in the root directory:
         ```console

--- a/index.php
+++ b/index.php
@@ -34,11 +34,11 @@ define('PAGE_START_TIME', microtime(true));
 
 if (!is_dir(__DIR__ . '/vendor') || !is_dir(__DIR__ . '/core/assets/vendor')) {
     die(
-        "Your installation is missing the 'vendor' or 'core/assets/vendor' directory. These directories are included in
-        releases, but not in the git repository. For regular installations, please make sure to download a release from
-        the GitHub releases page, not from the button on the home page to download the latest source code. If you do
-        want to run the latest version from source control for development versions, please run 'composer install'
-        and 'yarnpkg'/'yarn install'."
+        "Your installation is missing the 'vendor' or 'core/assets/vendor' directory.<br>
+        <br>
+        Please use the 'nameless-deps-dist.zip' file, not a source code zip file.<br>
+        <br>
+        If you are a developer, please refer to the instructions in CONTRIBUTING.md"
     );
 }
 


### PR DESCRIPTION
The current message may be too difficult for most users to understand. Or, it's too long so they don't bother reading it.

Now, it's just the one-liner we'd send in Discord support anyway.