### PR TITLE
Return redirect when punishing users

### DIFF
--- a/modules/Core/pages/panel/users_punishments.php
+++ b/modules/Core/pages/panel/users_punishments.php
@@ -263,6 +263,7 @@ if (isset($_GET['user'])) {
                                         }
                                     }
                                 }
+                                Redirect::to(URL::build('/panel/users/punishments/', 'user=' . urlencode($query->id)));
                             } else {
                                 $errors[] = $language->get('moderator', 'cant_punish_admin');
                             }


### PR DESCRIPTION
Minor PR to fix #3039 by returning a redirect as suggested. This will stop a punishment from being made again when the page is reloaded.