### PR TITLE
Add Integrations settings system & Setting to turn off mc username requirement

### DIFF
--- a/core/classes/Integrations/IntegrationBase.php
+++ b/core/classes/Integrations/IntegrationBase.php
@@ -4,7 +4,7 @@
  *
  * @package NamelessMC\Integrations
  * @author Partydragen
- * @version 2.0.0-pr13
+ * @version 2.1.0
  * @license MIT
  */
 
@@ -15,6 +15,7 @@ abstract class IntegrationBase {
     protected string $_icon;
     private array $_errors = [];
     protected Language $_language;
+    protected ?string $_settings = null;
 
     protected string $_name;
     protected ?int $_order;
@@ -57,6 +58,15 @@ abstract class IntegrationBase {
      */
     public function getIcon(): string {
         return $this->_icon;
+    }
+
+    /**
+     * Get the settings path for this integration.
+     *
+     * @return string Integration settings path.
+     */
+    public function getSettings(): ?string {
+        return $this->_settings;
     }
 
     /**

--- a/custom/languages/en_UK.json
+++ b/custom/languages/en_UK.json
@@ -695,6 +695,7 @@
     "admin/https_port_80": "You appear as if you are using HTTPS on port 80, which is almost definitely not true. If you use Cloudflare, make sure to set TLS encryption mode to Full (strict). If you run your own proxy, please configure it to send the X-Forwarded-Port header.",
     "admin/debugging_enabled": "Debugging is enabled, sensitive information may be exposed to unauthorised visitors. Debugging should only be used for development, not on public sites.",
     "admin/require_minecraft_username_on_registration": "Require Minecraft Username on registration?",
+    "admin/integration_settings_does_not_exist": "Integration settings file for integration {{integration}} does not exist",
     "api/account_validated": "Account validated successfully",
     "api/finish_registration_email": "Please check your emails to complete registration.",
     "api/finish_registration_link": "Please click on the following link to complete registration:",

--- a/custom/languages/en_UK.json
+++ b/custom/languages/en_UK.json
@@ -693,6 +693,7 @@
     "admin/trusted_proxies_not_configured": "{{linkStart}}Trusted proxies{{linkEnd}} are not configured, IP bans may not work properly.",
     "admin/https_port_80": "You appear as if you are using HTTPS on port 80, which is almost definitely not true. If you use Cloudflare, make sure to set TLS encryption mode to Full (strict). If you run your own proxy, please configure it to send the X-Forwarded-Port header.",
     "admin/debugging_enabled": "Debugging is enabled, sensitive information may be exposed to unauthorised visitors. Debugging should only be used for development, not on public sites.",
+    "admin/require_minecraft_username_on_registration": "Require Minecraft Username on registration?",
     "api/account_validated": "Account validated successfully",
     "api/finish_registration_email": "Please check your emails to complete registration.",
     "api/finish_registration_link": "Please click on the following link to complete registration:",

--- a/custom/panel_templates/Default/core/integrations_edit.tpl
+++ b/custom/panel_templates/Default/core/integrations_edit.tpl
@@ -73,11 +73,20 @@
                                 </div>
                                 <div class="form-group">
                                     <input type="hidden" name="token" value="{$TOKEN}">
+                                    <input type="hidden" name="action" value="general_settings">
                                     <input type="submit" value="{$SUBMIT}" class="btn btn-primary">
                                 </div>
                             </form>
                         </div>
                     </div>
+
+                    {if isset($SETTINGS_TEMPLATE)}
+                        <div class="card shadow mb-4">
+                            <div class="card-body">
+                                {include file=$SETTINGS_TEMPLATE}
+                            </div>
+                        </div>
+                    {/if}
 
                     <!-- Spacing -->
                     <div style="height:1rem;"></div>

--- a/custom/panel_templates/Default/integrations/discord/discord.tpl
+++ b/custom/panel_templates/Default/integrations/discord/discord.tpl
@@ -84,15 +84,6 @@
                                         <input class="form-control" type="number" name="discord_guild_id"
                                             id="inputDiscordId" value="{$DISCORD_GUILD_ID_VALUE}">
                                     </div>
-                                    <div class="form-group">
-                                        <label for="inputIntegrationLinkMethod">{$INTEGRATION_LINK_METHOD}</label>
-                                        <select name="integration_link_method" class="form-control" id="inputIntegrationLinkMethod">
-                                            <option value="bot" {if $INTEGRATION_LINK_METHOD_VALUE eq "bot" }
-                                                selected{/if}>{$BOT}</option>
-                                            <option value="oauth" {if $INTEGRATION_LINK_METHOD_VALUE eq "oauth" }
-                                                selected{/if}>{$OAUTH}</option>
-                                        </select>
-                                    </div>
                                     <div type="form-group">
                                         <input type="hidden" name="token" value="{$TOKEN}">
                                         <input type="submit" class="btn btn-primary" value="{$SUBMIT}">

--- a/custom/panel_templates/Default/integrations/discord/integration_settings.tpl
+++ b/custom/panel_templates/Default/integrations/discord/integration_settings.tpl
@@ -1,0 +1,16 @@
+<form action="" method="post">
+    <div class="form-group">
+        <label for="inputLinkMethod">{$LINK_METHOD}</label>
+        <select name="link_method" class="form-control" id="inputLinkMethod">
+            <option value="bot" {if $LINK_METHOD_VALUE eq "bot" }
+                selected{/if}>{$DISCORD_BOT}</option>
+            <option value="oauth" {if $LINK_METHOD_VALUE eq "oauth" }
+                selected{/if}>{$OAUTH}</option>
+        </select>
+    </div>
+    <div class="form-group">
+        <input type="hidden" name="token" value="{$TOKEN}">
+        <input type="hidden" name="action" value="integration_settings">
+        <input type="submit" value="{$SUBMIT}" class="btn btn-primary">
+    </div>
+</form>

--- a/custom/panel_templates/Default/integrations/minecraft/integration_settings.tpl
+++ b/custom/panel_templates/Default/integrations/minecraft/integration_settings.tpl
@@ -5,6 +5,12 @@
             {$PREMIUM_ACCOUNTS}
         </label>
     </div>
+    <div class="form-group custom-control custom-switch">
+        <input id="inputUsernameRegistration" name="username_registration" type="checkbox" class="custom-control-input js-check-change" {if $REQUIRE_USERNAME_REGISTRATION_VALUE} checked{/if}/>
+        <label for="inputUsernameRegistration" class="custom-control-label">
+            {$REQUIRE_USERNAME_REGISTRATION}
+        </label>
+    </div>
     <div class="form-group">
         <input type="hidden" name="token" value="{$TOKEN}">
         <input type="hidden" name="action" value="integration_settings">

--- a/custom/panel_templates/Default/integrations/minecraft/integration_settings.tpl
+++ b/custom/panel_templates/Default/integrations/minecraft/integration_settings.tpl
@@ -1,0 +1,13 @@
+<form action="" method="post">
+    <div class="form-group custom-control custom-switch">
+        <input id="inputPremiumAccounts" name="premium_account" type="checkbox" class="custom-control-input js-check-change" {if $PREMIUM_ACCOUNTS_VALUE} checked{/if}/>
+        <label for="inputPremiumAccounts" class="custom-control-label">
+            {$PREMIUM_ACCOUNTS}
+        </label>
+    </div>
+    <div class="form-group">
+        <input type="hidden" name="token" value="{$TOKEN}">
+        <input type="hidden" name="action" value="integration_settings">
+        <input type="submit" value="{$SUBMIT}" class="btn btn-primary">
+    </div>
+</form>

--- a/modules/Core/classes/Integrations/MinecraftIntegration.php
+++ b/modules/Core/classes/Integrations/MinecraftIntegration.php
@@ -135,6 +135,10 @@ class MinecraftIntegration extends IntegrationBase {
     }
 
     public function onRegistrationPageLoad(Fields $fields) {
+        if (Util::getSetting('mc_username_registration', '1', 'Minecraft Integration') != '1') {
+            return;
+        }
+
         $username_value = ((isset($_POST['username']) && $_POST['username']) ? Output::getClean(Input::get('username')) : '');
 
         $fields->add('username', Fields::TEXT, $this->_language->get('user', 'minecraft_username'), true, $username_value, null, null, 1);
@@ -145,6 +149,10 @@ class MinecraftIntegration extends IntegrationBase {
     }
 
     public function afterRegistrationValidation() {
+        if (Util::getSetting('mc_username_registration', '1', 'Minecraft Integration') != '1') {
+            return;
+        }
+
         $username = Input::get('username');
 
         // Validate username
@@ -166,6 +174,10 @@ class MinecraftIntegration extends IntegrationBase {
     }
 
     public function successfulRegistration(User $user) {
+        if (Util::getSetting('mc_username_registration', '1', 'Minecraft Integration') != '1') {
+            return;
+        }
+        
         $code = SecureRandom::alphanumeric();
 
         $integrationUser = new IntegrationUser($this);

--- a/modules/Core/classes/Integrations/MinecraftIntegration.php
+++ b/modules/Core/classes/Integrations/MinecraftIntegration.php
@@ -4,7 +4,7 @@
  *
  * @package Modules\Core\Integrations
  * @author Partydragen
- * @version 2.0.0-pr13
+ * @version 2.1.0
  * @license MIT
  */
 class MinecraftIntegration extends IntegrationBase {
@@ -16,6 +16,7 @@ class MinecraftIntegration extends IntegrationBase {
         $this->_name = 'Minecraft';
         $this->_icon = 'fas fa-cubes';
         $this->_language = $language;
+        $this->_settings = ROOT_PATH . '/modules/Core/includes/admin_integrations/minecraft.php';
 
         parent::__construct();
     }

--- a/modules/Core/includes/admin_integrations/minecraft.php
+++ b/modules/Core/includes/admin_integrations/minecraft.php
@@ -1,0 +1,21 @@
+<?php
+if (Input::exists()) {
+    if (Token::check()) {
+        if (Input::get('action') === 'integration_settings') {
+            $premium_account = isset($_POST['premium_account']) && $_POST['premium_account'] == 'on' ? '1' : '0';
+
+            Util::setSetting('uuid_linking', $premium_account);
+
+            Session::flash('integrations_success', $language->get('admin', 'integration_updated_successfully'));
+            Redirect::to(URL::build('/panel/core/integrations/', 'integration=' . $integration->getName()));
+        }
+    } else {
+        $errors[] = $language->get('general', 'invalid_token');
+    }
+}
+
+$smarty->assign([
+    'PREMIUM_ACCOUNTS' => $language->get('admin', 'force_premium_accounts'),
+    'PREMIUM_ACCOUNTS_VALUE' => Util::getSetting('uuid_linking'),
+    'SETTINGS_TEMPLATE' => 'integrations/minecraft/integration_settings.tpl'
+]);

--- a/modules/Core/includes/admin_integrations/minecraft.php
+++ b/modules/Core/includes/admin_integrations/minecraft.php
@@ -3,8 +3,10 @@ if (Input::exists()) {
     if (Token::check()) {
         if (Input::get('action') === 'integration_settings') {
             $premium_account = isset($_POST['premium_account']) && $_POST['premium_account'] == 'on' ? '1' : '0';
-
             Util::setSetting('uuid_linking', $premium_account);
+
+            $username_registration = isset($_POST['username_registration']) && $_POST['username_registration'] == 'on' ? '1' : '0';
+            Util::setSetting('mc_username_registration', $username_registration, 'Minecraft Integration');
 
             Session::flash('integrations_success', $language->get('admin', 'integration_updated_successfully'));
             Redirect::to(URL::build('/panel/core/integrations/', 'integration=' . $integration->getName()));
@@ -17,5 +19,7 @@ if (Input::exists()) {
 $smarty->assign([
     'PREMIUM_ACCOUNTS' => $language->get('admin', 'force_premium_accounts'),
     'PREMIUM_ACCOUNTS_VALUE' => Util::getSetting('uuid_linking'),
+    'REQUIRE_USERNAME_REGISTRATION' => $language->get('admin', 'require_minecraft_username_on_registration'),
+    'REQUIRE_USERNAME_REGISTRATION_VALUE' => Util::getSetting('mc_username_registration', '1', 'Minecraft Integration'),
     'SETTINGS_TEMPLATE' => 'integrations/minecraft/integration_settings.tpl'
 ]);

--- a/modules/Core/pages/panel/integrations.php
+++ b/modules/Core/pages/panel/integrations.php
@@ -71,12 +71,18 @@ if (!isset($_GET['integration'])) {
         }
     }
 
-    if ($integration->getSettings() !== null && file_exists($integration->getSettings())) {
-        require_once($integration->getSettings());
+    if ($integration->getSettings() !== null) {
+        if (file_exists($integration->getSettings())) {
+            require_once($integration->getSettings());
+        } else {
+            $errors[] = $language->get('admin', 'integration_settings_does_not_exist', [
+                'integration' => Output::getClean($integration->getName())
+            ]);
+        }
     }
 
     $smarty->assign([
-        'EDITING_INTEGRATION' => $language->get('admin', 'editing_integration_x', ['integration' => $integration->getName()]),
+        'EDITING_INTEGRATION' => $language->get('admin', 'editing_integration_x', ['integration' => Output::getClean($integration->getName())]),
         'BACK' => $language->get('general', 'back'),
         'BACK_LINK' => URL::build('/panel/core/integrations'),
         'ENABLED' => $language->get('admin', 'enabled'),

--- a/modules/Core/pages/panel/integrations.php
+++ b/modules/Core/pages/panel/integrations.php
@@ -2,7 +2,7 @@
 /*
  *  Made by Partydragen
  *  https://github.com/NamelessMC/Nameless/
- *  NamelessMC version 2.0.0-pr13
+ *  NamelessMC version 2.1.0
  *
  *  License: MIT
  *
@@ -56,17 +56,23 @@ if (!isset($_GET['integration'])) {
         $errors = [];
 
         if (Token::check()) {
-            DB::getInstance()->update('integrations', $integration->data()->id, [
-                'enabled' => Output::getClean(Input::get('enabled')),
-                'can_unlink' => Output::getClean(Input::get('can_unlink')),
-                'required' => Output::getClean(Input::get('required'))
-            ]);
+            if (Input::get('action') === 'general_settings') {
+                DB::getInstance()->update('integrations', $integration->data()->id, [
+                    'enabled' => Output::getClean(Input::get('enabled')),
+                    'can_unlink' => Output::getClean(Input::get('can_unlink')),
+                    'required' => Output::getClean(Input::get('required'))
+                ]);
 
-            Session::flash('integrations_success', $language->get('admin', 'integration_updated_successfully'));
-            Redirect::to(URL::build('/panel/core/integrations/', 'integration=' . $integration->getName()));
+                Session::flash('integrations_success', $language->get('admin', 'integration_updated_successfully'));
+                Redirect::to(URL::build('/panel/core/integrations/', 'integration=' . $integration->getName()));
+            }
         } else {
             $errors[] = $language->get('general', 'invalid_token');
         }
+    }
+
+    if ($integration->getSettings() !== null && file_exists($integration->getSettings())) {
+        require_once($integration->getSettings());
     }
 
     $smarty->assign([

--- a/modules/Discord Integration/classes/DiscordIntegration.php
+++ b/modules/Discord Integration/classes/DiscordIntegration.php
@@ -4,7 +4,7 @@
  *
  * @package Modules\Core\Integrations
  * @author Partydragen
- * @version 2.0.2
+ * @version 2.1.0
  * @license MIT
  */
 class DiscordIntegration extends IntegrationBase {
@@ -15,6 +15,7 @@ class DiscordIntegration extends IntegrationBase {
         $this->_name = 'Discord';
         $this->_icon = 'fab fa-discord';
         $this->_language = $language;
+        $this->_settings = ROOT_PATH . '/modules/Discord Integration/includes/admin_integrations/discord.php';
 
         parent::__construct();
     }

--- a/modules/Discord Integration/includes/admin_integrations/discord.php
+++ b/modules/Discord Integration/includes/admin_integrations/discord.php
@@ -1,0 +1,21 @@
+<?php
+if (Input::exists()) {
+    if (Token::check()) {
+        if (Input::get('action') === 'integration_settings') {
+            Util::setSetting('integration_link_method', Input::get('link_method'), 'Discord Integration');
+
+            Session::flash('integrations_success', $language->get('admin', 'integration_updated_successfully'));
+            Redirect::to(URL::build('/panel/core/integrations/', 'integration=' . $integration->getName()));
+        }
+    } else {
+        $errors[] = $language->get('general', 'invalid_token');
+    }
+}
+
+$smarty->assign([
+    'OAUTH' => $language->get('admin', 'oauth'),
+    'DISCORD_BOT' => Discord::getLanguageTerm('discord_bot'),
+    'LINK_METHOD' => Discord::getLanguageTerm('link_method'),
+    'LINK_METHOD_VALUE' => Util::getSetting('integration_link_method', 'bot', 'Discord Integration'),
+    'SETTINGS_TEMPLATE' => 'integrations/discord/integration_settings.tpl'
+]);

--- a/modules/Discord Integration/language/en_UK.json
+++ b/modules/Discord Integration/language/en_UK.json
@@ -51,5 +51,5 @@
     "discord_integration\/unable_to_update_discord_roles": "Unable to update Discord roles list.",
     "discord_integration\/unable_to_update_discord_username": "Unable to update Discord username.",
     "discord_integration\/discord_bot": "Discord Bot",
-    "discord_integration\/integration_link_method": "Discord integration link method"
+    "discord_integration\/link_method": "Link method"
 }

--- a/modules/Discord Integration/pages/panel/discord.php
+++ b/modules/Discord Integration/pages/panel/discord.php
@@ -44,7 +44,6 @@ if (Input::exists()) {
             if ($validation->passed()) {
                 Util::setSetting('discord', Input::get('discord_guild_id'));
 
-                Util::setSetting('integration_link_method', Input::get('integration_link_method'), 'Discord Integration');
                 $success = Discord::getLanguageTerm('discord_settings_updated');
 
             } else {
@@ -135,10 +134,6 @@ $smarty->assign([
         'linkStart' => '<a href="https://support.discord.com/hc/en-us/articles/206346498" target="_blank">',
         'linkEnd' => '</a>',
     ]),
-    'OAUTH' => $language->get('admin', 'oauth'),
-    'BOT' => Discord::getLanguageTerm('discord_bot'),
-    'INTEGRATION_LINK_METHOD' => Discord::getLanguageTerm('integration_link_method'),
-    'INTEGRATION_LINK_METHOD_VALUE' => Util::getSetting('integration_link_method', 'bot', 'Discord Integration'),
 ]);
 
 $template->onPageLoad();


### PR DESCRIPTION
Add integrations settings system like how widgets & templates settings work also added the requested feature to turn off minecraft username requirement on registration while keeping the minecraft integration enabled

Closes https://github.com/NamelessMC/Nameless/issues/3043

![minecraft](https://user-images.githubusercontent.com/9625439/195945829-222ce15f-3a7e-47df-94d9-6f2402e382f3.PNG)
![discord](https://user-images.githubusercontent.com/9625439/195945850-b339b46c-e30d-459b-b449-20f5c4a677a1.PNG)
