### PR TITLE
Clarify meaning of "query"

### DIFF
--- a/core/classes/Misc/ErrorHandler.php
+++ b/core/classes/Misc/ErrorHandler.php
@@ -159,7 +159,7 @@ class ErrorHandler {
             'GENERATE_DEBUG_LINK' => $language->get('general', 'generate_debug_link'),
             'CANNOT_READ_FILE' => $language->get('general', 'cannot_read_file'),
             'FRAME' => $language->get('general', 'frame'),
-            'QUERY' => $language->get('general', 'query'),
+            'SQL_QUERY' => $language->get('general', 'sql_query'),
             'NAMELESSMC_SUPPORT' => $language->get('general', 'namelessmc_support'),
             'NAMELESSMC_DOCS' => $language->get('general', 'namelessmc_documentation'),
             'DEBUG_TOAST_CLICK' => $language->get('admin', 'debug_link_toast', [

--- a/core/includes/error.tpl
+++ b/core/includes/error.tpl
@@ -111,7 +111,7 @@
                 <div class="ui tab secondary vertical menu left floated tablinks-container" id="sql-tablinks-container">
                     {foreach from=$ERROR_SQL_STACK item=$stack}
                         <button class="sql-tablinks item" id="sql-button-{$stack['number']}" onclick="openSqlFrame({$stack['number']})">
-                            <h5>{$QUERY} #{$stack['number']}</h5>
+                            <h5>{$SQL_QUERY} #{$stack['number']}</h5>
                             <sub>{$stack['frame']['file']}:{$stack['frame']['line']}</sub>
                         </button>
                     {/foreach}

--- a/custom/languages/en_UK.json
+++ b/custom/languages/en_UK.json
@@ -865,7 +865,7 @@
     "general/brown": "Brown",
     "general/grey": "Grey",
     "general/deleted_user": "Deleted User",
-    "general/query": "Query",
+    "general/sql_query": "SQL Query",
     "general/namelessmc_support": "NamelessMC Support",
     "general/namelessmc_documentation": "NamelessMC Docs",
     "installer/back": "Back",


### PR DESCRIPTION
"Query" can have many different translations depending on context. I've changed the string to be "SQL Query", to clarify to translators that it's a SQL query and to prevent it being used in other contexts.