### PR TITLE
Change to new /configure command

### DIFF
--- a/modules/Discord Integration/pages/panel/discord.php
+++ b/modules/Discord Integration/pages/panel/discord.php
@@ -119,7 +119,7 @@ $smarty->assign([
     'INVITE_LINK' => Discord::getLanguageTerm('discord_invite_info', [
         'inviteLinkStart' => '<a target="_blank" href="https://namelessmc.com/discord-bot-invite">',
         'inviteLinkEnd' => '</a>',
-        'command' => '<code>/apiurl</code>',
+        'command' => '<code>/configure link</code>',
         'selfHostLinkStart' => '<a target="_blank" href="https://github.com/NamelessMC/Nameless-Link/wiki/Installation-guide">',
         'selfHostLinkEnd' => '</a>',
     ]),


### PR DESCRIPTION
Nameless-Link has a new /configure command to replace all previous administrative commands

![image](https://user-images.githubusercontent.com/15892014/210614013-5cac9822-bcc0-4763-ae44-4361410fde11.png)
