### PR TITLE
Add instructions on how to disable portal page to template

### DIFF
--- a/custom/templates/DefaultRevamp/portal.tpl
+++ b/custom/templates/DefaultRevamp/portal.tpl
@@ -1,1 +1,5 @@
-Placeholder - use this template for your own custom portal.
+'Homepage Type' is set to 'Portal', which means NamelessMC renders the 'custom/templates/DefaultRevamp/portal.tpl' template file.<br>
+<br>
+This is a placeholder page, use this template for your own custom portal.<br>
+<br>
+<strong>To revert this change, go to <a href="{$GENERAL_SETTINGS_URL}">StaffCP > Configuration > General Settings</a> and change 'Homepage Type' to 'News'.</strong>

--- a/modules/Core/pages/portal.php
+++ b/modules/Core/pages/portal.php
@@ -22,5 +22,9 @@ $template->onPageLoad();
 require(ROOT_PATH . '/core/templates/navbar.php');
 require(ROOT_PATH . '/core/templates/footer.php');
 
+$smarty->assign([
+    'GENERAL_SETTINGS_URL' => URL::build('/panel/core/general_settings'),
+]);
+
 // Display template
 $template->displayTemplate('portal.tpl', $smarty);


### PR DESCRIPTION
Users commonly accidentally enable the portal page and then don't know how to go back