### PR TITLE
Fix post editing

### DIFF
--- a/modules/Forum/classes/Forum.php
+++ b/modules/Forum/classes/Forum.php
@@ -789,7 +789,7 @@ class Forum {
                     $prev[] = $label->id;
                 }
             }
-            return is_array($prev) ? $prev : [];
-        });
+            return $prev;
+        }, []);
     }
 }

--- a/modules/Forum/pages/forum/edit.php
+++ b/modules/Forum/pages/forum/edit.php
@@ -150,12 +150,12 @@ if (Input::exists()) {
                     }
                     return $prev;
                 });
-                $accessible_labels = Forum::getAccessibleLabels($forum_labels, $user_groups);
+                $accessible_labels = Forum::getAccessibleLabels($forum_labels ?? [], $user_groups);
                 $existing_inaccessible_labels = array_diff($existing_labels, $accessible_labels);
 
                 // Get all the posted labels and see which ones the user can actually edit
                 if (isset($_POST['topic_label']) && !empty($_POST['topic_label']) && is_array($_POST['topic_label'])) {
-                    $post_labels = Forum::getAccessibleLabels($_POST['topic_label'], $user_groups);
+                    $post_labels = Forum::getAccessibleLabels($_POST['topic_label'] ?? [], $user_groups);
                 }
 
                 $post_labels = array_merge($existing_inaccessible_labels, $post_labels);

--- a/modules/Forum/pages/forum/edit.php
+++ b/modules/Forum/pages/forum/edit.php
@@ -149,13 +149,13 @@ if (Input::exists()) {
                         $prev[] = $lbl->id;
                     }
                     return $prev;
-                });
-                $accessible_labels = Forum::getAccessibleLabels($forum_labels ?? [], $user_groups);
+                }, []);
+                $accessible_labels = Forum::getAccessibleLabels($forum_labels, $user_groups);
                 $existing_inaccessible_labels = array_diff($existing_labels, $accessible_labels);
 
                 // Get all the posted labels and see which ones the user can actually edit
                 if (isset($_POST['topic_label']) && !empty($_POST['topic_label']) && is_array($_POST['topic_label'])) {
-                    $post_labels = Forum::getAccessibleLabels($_POST['topic_label'] ?? [], $user_groups);
+                    $post_labels = Forum::getAccessibleLabels($_POST['topic_label'], $user_groups);
                 }
 
                 $post_labels = array_merge($existing_inaccessible_labels, $post_labels);


### PR DESCRIPTION
Previously, if no existing topic labels existed, the site would crash due to the fact that it wouldn't return an empty array but null. This defaults the existing labels array to an empty array. 