### PR TITLE
Revert "Fix footer with CSS to remove flicker on each page load"

### DIFF
--- a/custom/templates/DefaultRevamp/css/custom.css
+++ b/custom/templates/DefaultRevamp/css/custom.css
@@ -441,8 +441,8 @@ body.pushable>.pusher {
 }
 
 /*
- *  -[ FOOTER ]-
- */
+   *  -[ FOOTER ]-
+   */
 
 .ui.footer.segment {
     margin: 1rem 0 -.5rem 0;
@@ -452,14 +452,6 @@ body.pushable>.pusher {
 @media only screen and (max-width: 768px) {
     .ui.footer.segment {
         text-align: center;
-    }
-}
-
-@media only screen and (min-width: 768px) {
-    .ui.footer {
-        position: absolute;
-        bottom: 0;
-        width: 100%;
     }
 }
 

--- a/custom/templates/DefaultRevamp/footer.tpl
+++ b/custom/templates/DefaultRevamp/footer.tpl
@@ -1,7 +1,7 @@
 </div>
 </div>
 
-<div class="ui inverted vertical footer segment">
+<div class="ui inverted vertical footer segment" id="footer">
     <div class="ui container">
         <div class="ui stackable inverted divided equal height stackable grid">
             <div class="{if $SOCIAL_MEDIA_ICONS|count > 0}six{else}eight{/if} wide column">
@@ -19,7 +19,7 @@
                             <i class="fas fa-sun"></i>
                             <div class="darkmode-ball"></div>
                         </label>
-
+                    
                         <script type="text/javascript">
                             if (document.body.classList.contains('dark')) {
                                 document.getElementById("darkmode-toggle").checked = true;

--- a/custom/templates/DefaultRevamp/js/scripts.js
+++ b/custom/templates/DefaultRevamp/js/scripts.js
@@ -1,0 +1,10 @@
+// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat/MIT
+function fixFooter() {
+    var footerHeight = $("#footer").outerHeight() + "px";
+    var wrapperHeight = "calc(100vh - " + footerHeight + ")";
+    $("#wrapper").css({ 'min-height': wrapperHeight });
+}
+
+$(document).ready(fixFooter);
+$(window).resize(fixFooter);
+// @license-end

--- a/custom/templates/DefaultRevamp/template.php
+++ b/custom/templates/DefaultRevamp/template.php
@@ -133,6 +133,7 @@ class DefaultRevamp_Template extends TemplateBase {
             $this->_template['path'] . 'js/core/core.js?v=202' => [],
             $this->_template['path'] . 'js/core/user.js' => [],
             $this->_template['path'] . 'js/core/pages.js?v=202' => [],
+            $this->_template['path'] . 'js/scripts.js' => [],
         ]);
 
         foreach ($this->_pages->getAjaxScripts() as $script) {

--- a/modules/Core/module.php
+++ b/modules/Core/module.php
@@ -199,8 +199,7 @@ class Core_Module extends Module {
                                                     $custom_page->id,
                                                     Output::getClean($custom_page->title),
                                                     (is_null($redirect)) ? URL::build(Output::urlEncodeAllowSlashes($custom_page->url)) : $redirect,
-                                                    'footer',
-                                                    $custom_page->target ? '_blank' : null,
+                                                    'footer', $custom_page->target ? '_blank' : null,
                                                     2000,
                                                     $custom_page->icon
                                                 );


### PR DESCRIPTION
Reverts #3183 

Had problems when page content was taller than screen height, footer would overlap and cover bottom content of page - unsure if this is fixable since our footer has dynamic height 🤔 

<img width="1728" alt="Screenshot 2023-01-14 at 17 15 22" src="https://user-images.githubusercontent.com/26070412/212504239-1b2b237b-ba46-4ce9-afe6-0f6cba0696d5.png">
