### PR TITLE
Add warning for using 3rd party panel templates

### DIFF
--- a/custom/languages/en_UK.json
+++ b/custom/languages/en_UK.json
@@ -440,6 +440,7 @@
     "admin/page_url_contains_nameless_path": "Your custom page would overwrite a NamelessMC page.",
     "admin/pages": "Pages",
     "admin/panel_templates": "Panel Templates",
+    "admin/panel_template_third_party": "Panel template {{name}} is a third party template. Please be aware that any issues with this template should be reported to the template author.",
     "admin/parent_server": "Parent Server",
     "admin/parent_server_help": "A parent server is typically the Bungee instance the server is connected to, if any.",
     "admin/permissions": "Permissions",

--- a/custom/languages/en_UK.json
+++ b/custom/languages/en_UK.json
@@ -440,7 +440,7 @@
     "admin/page_url_contains_nameless_path": "Your custom page would overwrite a NamelessMC page.",
     "admin/pages": "Pages",
     "admin/panel_templates": "Panel Templates",
-    "admin/panel_template_third_party": "Panel template {{name}} is a third party template. Please be aware that any issues with this template should be reported to the template author.",
+    "admin/panel_template_third_party": "Panel template {{name}} is a third party template. Please be aware that version compatibility is not guaranteed between minor NamelessMC updates, and issues should be redirected to the template author.",
     "admin/parent_server": "Parent Server",
     "admin/parent_server_help": "A parent server is typically the Bungee instance the server is connected to, if any.",
     "admin/permissions": "Permissions",

--- a/custom/panel_templates/Default/core/panel_templates.tpl
+++ b/custom/panel_templates/Default/core/panel_templates.tpl
@@ -66,6 +66,12 @@
                                                 data-title="{$WARNING}" data-content="{$template.version_mismatch}"><i
                                                     class="fa fa-exclamation-triangle"></i></button>
                                             {/if}
+                                            {if $template.third_party}
+                                                &nbsp;
+                                                <button role="button" class="btn btn-sm btn-warning" data-toggle="popover"
+                                                        data-title="{$WARNING}" data-content="{$template.third_party}"><i
+                                                            class="fa fa-exclamation-triangle"></i></button>
+                                            {/if}
                                             <br />
                                             <small>{$template.author_x}</small>
                                         </td>

--- a/modules/Core/pages/panel/index.php
+++ b/modules/Core/pages/panel/index.php
@@ -205,6 +205,12 @@ if ($user->hasPermission('admincp.core.debugging')) {
         $compat_errors[] = $language->get('admin', 'debugging_enabled');
     }
 
+    if ($template->getName() !== 'Default') {
+        $compat_warnings[] = $language->get('admin', 'panel_template_third_party', [
+            'name' => Text::bold($template->getName()),
+        ]);
+    }
+
     $smarty->assign([
         'SERVER_COMPATIBILITY' => $language->get('admin', 'server_compatibility'),
         'COMPAT_SUCCESS' => $compat_success,

--- a/modules/Core/pages/panel/panel_templates.php
+++ b/modules/Core/pages/panel/panel_templates.php
@@ -50,6 +50,9 @@ if (!isset($_GET['action'])) {
                 'intendedVersion' => Output::getClean($template->getNamelessVersion()),
                 'actualVersion' => NAMELESS_VERSION,
             ]) : false,
+            'third_party' => $template->getName() !== 'Default' ? $language->get('admin', 'panel_template_third_party', [
+                'name' => Text::bold($template->getName()),
+            ]) : false,
             'enabled' => $item->enabled,
             'activate_link' => (($item->enabled) ? null : URL::build('/panel/core/panel_templates/', 'action=activate&template=' . urlencode($item->id))),
             'delete_link' => (($item->id == 1 || $item->enabled) ? null : URL::build('/panel/core/panel_templates/', 'action=delete&template=' . urlencode($item->id))),


### PR DESCRIPTION
As previously discussed, changes to staffcp templates are not considered breaking, so we are adding a warning that non-default panel templates may not be fully updated.

Original PR https://github.com/NamelessMC/Nameless/pull/2995