### PR TITLE
Create release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /uploads/avatars/**
 /node_modules/
 composer.lock
+/.node_cache/
+/release/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,3 +72,10 @@ Deprecations rule of thumb:
 * Changes should be as small as possible to reduce conflicts.
 * Squash when merging. This makes backporting easier. If you think your changes deserve multiple commits, consider splitting them into multiple pull requests.
 * Mark the pull request with the appropriate milestone. [@Derkades](https://github.com/Derkades) keeps an eye on merged PRs and cherry-pick changes to the appropriate release branch.
+
+## Releasing a new version
+
+1. Ensure you have a clean copy of the source code without leftover files from testing. For example, clone the Nameless repository into a new directory
+2. Run ./release.sh. Release zip files are produced and placed in `./release`.
+3. TODO: Add instructions for producing a zip only containing files changed since the last release
+4. TODO: Add instructions for publishing a release

--- a/dev/scripts/release-entrypoint.sh
+++ b/dev/scripts/release-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+cd /data
+mkdir -p release
+rm -f release/*
+python3 dev/scripts/release.py

--- a/dev/scripts/release-entrypoint.sh
+++ b/dev/scripts/release-entrypoint.sh
@@ -4,5 +4,6 @@ cd /data
 mkdir -p release
 rm -f release/*.zip
 rm -f release/*.tar.xz
-rm -rf release/upgrade_temp
+rm -rf release/upgrade_temp # In case a previous run failed
 python3 dev/scripts/release.py
+rm -rf release/upgrade_temp

--- a/dev/scripts/release-entrypoint.sh
+++ b/dev/scripts/release-entrypoint.sh
@@ -2,5 +2,7 @@
 set -e
 cd /data
 mkdir -p release
-rm -f release/*
+rm -f release/*.zip
+rm -f release/*.tar.xz
+rm -rf release/upgrade_temp
 python3 dev/scripts/release.py

--- a/dev/scripts/release.py
+++ b/dev/scripts/release.py
@@ -1,0 +1,92 @@
+import subprocess
+from subprocess import PIPE
+import itertools
+import shutil
+
+
+EXCLUDE_DIRS = [
+    '.git',
+    '.github',
+    '.idea',
+    '.node-cache',
+    '.vscode',
+    'node_modules',
+    'release',
+]
+EXCLUDE_FILES = [
+    '.gitignore',
+    '.phpcs.xml',
+    'CHANGELOG.md',
+    'composer.json',
+    'composer.lock',
+    'CONTRIBUTING.md',
+    'docker-compose.yaml',
+    'Dockerfile.phpdoc',
+    'nginx.example',
+    'package.json',
+    'package-lock.json',
+    'phpstan.neon',
+    'postinstall.js',
+    'README.md',
+    'release.sh',
+    'yarn-postinstall.js',
+    'yarn.lock',
+    'SECURITY.md',
+    'semantic.json',
+    'web.config.example',
+]
+TARGET_DIR = 'release'
+
+
+def create_archives(archive_name: str):
+    zip_command = [
+        'zip',
+        '-r',  # Recursive
+        '-q',  # Quiet
+        f'{TARGET_DIR}/nameless-{archive_name}.zip',
+        '.',
+        *itertools.chain.from_iterable((('-x', f'{name}/*') for name in EXCLUDE_DIRS)),
+        *itertools.chain.from_iterable((('-x', f'{name}') for name in EXCLUDE_FILES)),
+    ]
+
+    tar_command = [
+        'tar',
+        '-c',  # Compress
+        '-J',  # Use xzip
+        '--owner=0',  # Set owner inside archive to root
+        '--group=0',
+        '-f', f'{TARGET_DIR}/nameless-{archive_name}.tar.xz',
+        *[f'--exclude={name}' for name in [*EXCLUDE_DIRS, *EXCLUDE_FILES]],
+        '.',
+    ]
+
+    print(f'Creating zip archive: {archive_name}')
+    subprocess.check_call(zip_command,
+                          shell=False)
+
+    print(f'Creating tar.xz archive: {archive_name}')
+    subprocess.check_call(tar_command,
+                          env={'XZ_DEFAULTS': '-T 0'},  # Enable multithreading
+                          shell=False)
+
+
+if __name__ == '__main__':
+    print('Deleting vendor files')
+    shutil.rmtree('core/assets/vendor', ignore_errors=True)
+    shutil.rmtree('node_modules', ignore_errors=True)
+    shutil.rmtree('vendor', ignore_errors=True)
+
+    # Create base archive
+    create_archives('base')
+
+    # Run npm and composer (production dependencies only)
+    subprocess.check_call(['npm', 'ci', '-q', '--cache', '.node_cache'],
+                          stdout=PIPE)
+    subprocess.check_call(['composer', 'install', '--no-dev', '--no-interaction'],
+                          stdout=PIPE)
+    create_archives('deps-dist')
+
+    # Run composer again, to install development dependencies
+    subprocess.check_call(['composer', 'install', '--no-interaction'],
+                          stdout=PIPE)
+    create_archives('deps-dev')

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+docker run -it --rm -u $(id -u) -v "$(pwd):/data" --entrypoint="/data/dev/scripts/release-entrypoint.sh" namelessmc/php:dev


### PR DESCRIPTION
This script produces release zip files just like the ci. The advantage of running it locally is that you can do it on any branch (which will be needed for the upcoming 2.0.3 which is not based on the `develop` branch).

Thanks to Docker, it does not require a local installation of php, composer, or npm.

TODO: Generate checksum file, when #3159 is merged
TODO: Finish instructions