### PR TITLE
Remove group sync info from user info endpoint

### DIFF
--- a/core/classes/Core/Util.php
+++ b/core/classes/Core/Util.php
@@ -380,23 +380,6 @@ class Util {
     }
 
     /**
-     * Get in-game rank name from a website group ID, uses Group Sync rules.
-     *
-     * @param int $website_group_id ID of website group to search for.
-     * @return string|null Name of in-game rank or null if rule is not set up.
-     */
-    public static function getIngameRankName(int $website_group_id): ?string {
-        $nameless_injector = GroupSyncManager::getInstance()->getInjectorByClass(NamelessMCGroupSyncInjector::class);
-        $data = DB::getInstance()->get('group_sync', [$nameless_injector->getColumnName(), $website_group_id]);
-
-        if ($data->count()) {
-            return $data->first()->ingame_rank_name;
-        }
-
-        return null;
-    }
-
-    /**
      * Determine if a specific module is enabled
      *
      * @param string $name Name of module to check for.

--- a/modules/Core/includes/endpoints/GroupInfoEndpoint.php
+++ b/modules/Core/includes/endpoints/GroupInfoEndpoint.php
@@ -56,12 +56,7 @@ class GroupInfoEndpoint extends KeyAuthEndpoint {
                 'name' => $group->name,
                 'staff' => (bool)$group->staff,
                 'order' => (int)$group->order,
-                'ingame_rank_name' => Util::getIngameRankName($group->id)
             ];
-
-            if (Util::isModuleEnabled('Discord Integration')) {
-                $group_array['discord_role_id'] = (int)Discord::getDiscordRoleId($api->getDb(), $group->id);
-            }
 
             $groups_array[] = $group_array;
         }

--- a/modules/Core/includes/endpoints/UserInfoEndpoint.php
+++ b/modules/Core/includes/endpoints/UserInfoEndpoint.php
@@ -17,8 +17,6 @@ class UserInfoEndpoint extends KeyAuthEndpoint {
     }
 
     public function execute(Nameless2API $api, User $user): void {
-        $discord_enabled = Util::isModuleEnabled('Discord Integration');
-
         $query = 'SELECT nl2_users.id, nl2_users.username, nl2_languages.short_code as `locale`, nl2_users.nickname as displayname, nl2_users.joined as registered_timestamp, nl2_users.last_online as last_online_timestamp, nl2_users.isbanned as banned, nl2_users.active as validated, nl2_users.user_title as user_title FROM nl2_users LEFT JOIN nl2_languages ON nl2_users.language_id = nl2_languages.id';
 
         // Ensure the user exists
@@ -55,12 +53,7 @@ class UserInfoEndpoint extends KeyAuthEndpoint {
                 'name' => $group->name,
                 'staff' => (bool)$group->staff,
                 'order' => (int)$group->order,
-                'ingame_rank_name' => Util::getIngameRankName($group->id),
             ];
-
-            if ($discord_enabled) {
-                $group_array['discord_role_id'] = (int)Discord::getDiscordRoleId($api->getDb(), $group->id);
-            }
 
             $groups_array[] = $group_array;
         }


### PR DESCRIPTION
This info is not currently used by the plugin or discord bot. Nor is there any reason they would ever use it in the future. Group sync logic is done by the website, not API clients, so API clients need not be aware of group sync rules.

Especially useful to reduce queries for #3193 while still sharing the same format

Curious to hear what you think. In my opinion, if we do need this data in the future, we should add a dedicated group sync info endpoint to request it.