### PR TITLE
Ignore future dates in dashboard overview graph data

### DIFF
--- a/modules/Core/module.php
+++ b/modules/Core/module.php
@@ -1512,7 +1512,7 @@ class Core_Module extends Module {
                         <<<SQL
                             SELECT DATE_FORMAT(FROM_UNIXTIME(`joined`), '%Y-%m-%d') d, COUNT(*) c
                             FROM nl2_users
-                            WHERE `joined` > ?
+                            WHERE `joined` > ? AND `joined` < UNIX_TIMESTAMP()
                             GROUP BY DATE_FORMAT(FROM_UNIXTIME(`joined`), '%Y-%m-%d')
                         SQL,
                         [strtotime('7 days ago')],

--- a/modules/Core/pages/panel/index.php
+++ b/modules/Core/pages/panel/index.php
@@ -23,7 +23,6 @@ require_once(ROOT_PATH . '/core/templates/backend_init.php');
 Module::loadPage($user, $pages, $cache, $smarty, [$navigation, $cc_nav, $staffcp_nav], $widgets, $template);
 
 $dashboard_graphs = Core_Module::getDashboardGraphs();
-
 $graphs = [];
 
 if (count($dashboard_graphs)) {

--- a/modules/Core/pages/panel/index.php
+++ b/modules/Core/pages/panel/index.php
@@ -23,6 +23,7 @@ require_once(ROOT_PATH . '/core/templates/backend_init.php');
 Module::loadPage($user, $pages, $cache, $smarty, [$navigation, $cc_nav, $staffcp_nav], $widgets, $template);
 
 $dashboard_graphs = Core_Module::getDashboardGraphs();
+
 $graphs = [];
 
 if (count($dashboard_graphs)) {

--- a/modules/Forum/module.php
+++ b/modules/Forum/module.php
@@ -324,7 +324,7 @@ class Forum_Module extends Module {
                         <<<SQL
                             SELECT DATE_FORMAT(FROM_UNIXTIME(`topic_date`), '%Y-%m-%d') d, COUNT(*) c
                             FROM nl2_topics
-                            WHERE `topic_date` > ?
+                            WHERE `topic_date` > ? AND `topic_date` < UNIX_TIMESTAMP()
                             AND `deleted` = 0
                             GROUP BY DATE_FORMAT(FROM_UNIXTIME(`topic_date`), '%Y-%m-%d')
                         SQL,
@@ -337,7 +337,7 @@ class Forum_Module extends Module {
                         <<<SQL
                             SELECT DATE_FORMAT(FROM_UNIXTIME(`created`), '%Y-%m-%d') d, COUNT(*) c
                             FROM nl2_posts
-                            WHERE `created` > ?
+                            WHERE `created` > ? AND `created` < UNIX_TIMESTAMP()
                             AND `deleted` = 0
                             GROUP BY DATE_FORMAT(FROM_UNIXTIME(`created`), '%Y-%m-%d')
                         SQL,
@@ -381,7 +381,6 @@ class Forum_Module extends Module {
                         ksort($data);
 
                         $cache->store('forum_data', $data, 120);
-
                     }
 
                     Core_Module::addDataToDashboardGraph($this->_language->get('admin', 'overview'), $data);


### PR DESCRIPTION
When using the DB seeder, we sometimes have data which would have timestamps in the future, making the staffcp dashboard graph look quite funky:
<img width="1079" alt="Screenshot 2023-01-15 at 16 43 22" src="https://user-images.githubusercontent.com/26070412/212576479-7f5aecca-5e4e-42c7-a57b-e02232a06da1.png">

After:
<img width="1095" alt="Screenshot 2023-01-15 at 16 41 44" src="https://user-images.githubusercontent.com/26070412/212576375-409db550-ed32-4254-9c34-6c727bd4bdaf.png">