### PR TITLE
Allow running release script without TTY

### DIFF
--- a/dev/scripts/release-entrypoint.sh
+++ b/dev/scripts/release-entrypoint.sh
@@ -5,5 +5,6 @@ mkdir -p release
 rm -f release/*.zip
 rm -f release/*.tar.xz
 rm -rf release/upgrade_temp # In case a previous run failed
+export PYTHONUNBUFFERED=1
 python3 dev/scripts/release.py
 rm -rf release/upgrade_temp

--- a/dev/scripts/release.py
+++ b/dev/scripts/release.py
@@ -105,6 +105,8 @@ if __name__ == '__main__':
     previous_tag_command = ['git', 'describe', '--abbrev=0', '--tags']
     previous_tag = subprocess.check_output(previous_tag_command, shell=False)[:-1].decode()
 
+    print('Creating files for upgrade from', previous_tag)
+
     # Find all files changed between previous tag and HEAD (current state)
     changed_command = ['git', 'diff', previous_tag, 'HEAD', '--name-only', '--diff-filter=d']
     changed_files = subprocess.check_output(changed_command, shell=False)[:-1].decode()

--- a/release.sh
+++ b/release.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -e
-docker run -it --rm -u $(id -u) -v "$(pwd):/data" --entrypoint="/data/dev/scripts/release-entrypoint.sh" namelessmc/php:dev
+docker run --rm -u $(id -u) -v "$(pwd):/data" --entrypoint="/data/dev/scripts/release-entrypoint.sh" namelessmc/php:dev


### PR DESCRIPTION
Turns out jenkins couldn't run the release script because I added `-it` out of habit