### PR TITLE
Check for pdo_mysql extension, mysqli is no longer used

### DIFF
--- a/core/installation/steps/requirements_validation.php
+++ b/core/installation/steps/requirements_validation.php
@@ -19,8 +19,8 @@ unset($_SESSION['requirements_validated']);
             <div class="sixteen wide mobile eight wide tablet seven wide computer column">
                 <?php
                 validate_requirement('PHP 7.4+', PHP_VERSION_ID >= 70400);
-                validate_requirement('PHP MySQL', extension_loaded('mysql') || extension_loaded('mysqlnd'));
                 validate_requirement('PHP PDO', extension_loaded('PDO'));
+                validate_requirement('PHP PDO MySQL', extension_loaded('pdo_mysql'));
                 validate_requirement('PHP XML', extension_loaded('xml'));
                 validate_requirement('PHP MBString', extension_loaded('mbstring'));
                 ?>

--- a/modules/Core/pages/panel/index.php
+++ b/modules/Core/pages/panel/index.php
@@ -158,10 +158,10 @@ if ($user->hasPermission('admincp.core.debugging')) {
     } else {
         $compat_success[] = 'PHP PDO ' . phpversion('PDO');
     }
-    if (!extension_loaded('mysql') && !extension_loaded('mysqlnd')) {
-        $compat_errors[] = 'PHP MySQL';
+    if (!extension_loaded('pdo_mysql')) {
+        $compat_errors[] = 'PHP PDO MySQL';
     } else {
-        $compat_success[] = 'PHP MySQL ' . (extension_loaded('mysql') ? phpversion('mysql') : explode(' ', phpversion('mysqlnd'))[1]);
+        $compat_success[] = 'PHP PDO MySQL ' . phpversion('pdo_mysql');
     }
     $pdo_driver = DB::getInstance()->getPDO()->getAttribute(PDO::ATTR_DRIVER_NAME);
     $pdo_server_version = DB::getInstance()->getPDO()->getAttribute(PDO::ATTR_SERVER_VERSION);


### PR DESCRIPTION
With #3198, the last usages of mysqli will be removed. Now that `mysqli` is no longer required by NamelessMC, check for presence of the `pdo_mysql` extension instead.