### PR TITLE
Add support for automatically verifying emails from OAuth register

### DIFF
--- a/custom/languages/en_UK.json
+++ b/custom/languages/en_UK.json
@@ -803,6 +803,8 @@
     "general/none": "None",
     "general/normal": "Normal",
     "general/not_registered_yet": "Not registered yet?",
+    "general/oauth_email_verified_automatically": "Email will be verified automatically",
+    "general/oauth_email_not_verified_automatically": "Email will not be verified automatically",
     "general/oauth_message_continue": "Continue registering with {{provider}}",
     "general/oauth_failed_setup": "Something went wrong. The OAuth2 setup is invalid. Contact an administrator",
     "general/oauth_failed": "Something went wrong while trying to use OAuth. Please try again.",

--- a/custom/templates/DefaultRevamp/register.tpl
+++ b/custom/templates/DefaultRevamp/register.tpl
@@ -132,4 +132,28 @@
     </div>
 </div>
 
+{if $OAUTH_FLOW && $OAUTH_EMAIL_VERIFIED}
+    <script>
+        document.getElementById('email').addEventListener('keyup', (e) => {
+            checkEmailValidity(e.target.value);
+        });
+
+        const checkEmailValidity = (email) => {
+            if ('{$OAUTH_EMAIL_VERIFIED}' && email !== '{$OAUTH_EMAIL_ORIGINAL}') {
+                addEmailCaption('{$OAUTH_EMAIL_NOT_VERIFIED_MESSAGE}', 'orange');
+            } else {
+                addEmailCaption('{$OAUTH_EMAIL_VERIFIED_MESSAGE}', 'green');
+            }
+        }
+
+        const addEmailCaption = (text, colour) => {
+            const email = document.getElementById('email');
+            document.getElementById('email-caption')?.remove();
+            email.parentElement.insertAdjacentHTML('beforeend', '<div id="email-caption" style="margin-top: 5px;" class="ui basic ' + colour + ' label">' + text + '</div>');
+        };
+
+        window.onload = () => checkEmailValidity('{$EMAIL_INPUT}');
+    </script>
+{/if}
+
 {include file='footer.tpl'}

--- a/modules/Core/module.php
+++ b/modules/Core/module.php
@@ -508,6 +508,7 @@ class Core_Module extends Module {
             'user_id_name' => 'id',
             'scope_id_name' => 'identify',
             'icon' => 'fab fa-discord',
+            'verify_email' => static fn () => true,
         ]);
 
         NamelessOAuth::getInstance()->registerProvider('google', 'Core', [
@@ -515,6 +516,7 @@ class Core_Module extends Module {
             'user_id_name' => 'sub',
             'scope_id_name' => 'openid',
             'icon' => 'fab fa-google',
+            'verify_email' => static fn () => true,
         ]);
 
         // Captcha

--- a/modules/Core/pages/register.php
+++ b/modules/Core/pages/register.php
@@ -346,6 +346,8 @@ if (Input::exists()) {
                                 $data['provider'],
                                 $data['id'],
                             );
+                            $auto_verify_oauth_email = $data['email'] === Input::get('email') && NamelessOAuth::getInstance()->hasVerifiedEmail($data['provider'], $data['data']);
+
                             Session::delete('oauth_register_data');
                         }
 
@@ -376,7 +378,7 @@ if (Input::exists()) {
                             'language' => $default_language,
                         ]);
 
-                        if (Util::getSetting('email_verification') === '1') {
+                        if (!$auto_verify_oauth_email && Util::getSetting('email_verification') === '1') {
                             // Send registration email
                             sendRegisterEmail($language, Output::getClean(Input::get('email')), $username, $user_id, $code);
 
@@ -427,9 +429,11 @@ if (Util::getSetting('displaynames') === '1') {
 $username_value = ((isset($_POST['username']) && $_POST['username']) ? Output::getClean(Input::get('username')) : '');
 $email_value = ((isset($_POST['email']) && $_POST['email']) ? Output::getClean(Input::get('email')) : '');
 
-if (Session::exists('oauth_register_data')) {
+if ($email === '' && Session::exists('oauth_register_data')) {
     $email_value = json_decode(Session::get('oauth_register_data'), true)['email'];
 }
+
+$smarty->assign('EMAIL_INPUT', $email_value);
 
 $fields->add('username', Fields::TEXT, $language->get('user', 'username'), true, $username_value);
 $fields->add('email', Fields::EMAIL, $language->get('user', 'email_address'), true, $email_value);
@@ -467,6 +471,10 @@ if ($oauth_flow) {
         ]),
         'CANCEL' => $language->get('general', 'cancel'),
         'OAUTH_CANCEL_REGISTER_URL' => URL::build('/oauth', 'action=cancel_registration'),
+        'OAUTH_EMAIL_VERIFIED' => NamelessOAuth::getInstance()->hasVerifiedEmail($data['provider'], $data['data']),
+        'OAUTH_EMAIL_ORIGINAL' => $data['email'],
+        'OAUTH_EMAIL_VERIFIED_MESSAGE' => $language->get('general', 'oauth_email_verified_automatically'),
+        'OAUTH_EMAIL_NOT_VERIFIED_MESSAGE' => $language->get('general', 'oauth_email_not_verified_automatically'),
     ]);
 }
 


### PR DESCRIPTION
This PR adds support to let OAuth providers say whether the returned email from their end is verified or not, and then if it is verified we can automatically mark their NamelessMC email verified (if it matches the one returned from OAuth provider).

Both Discord and Google will only let the OAuth request to go through if their account email is verified, so we always return true for them, but it is possible to do something like this:
```php
'verify_email' => function ($data /* array of resource owner data returned from OAuth provider */ ) {
	return $data['email_validated'];
}
```
If this was the case, then we would only automatically verify the email if the resource owner data contained an array key named `'email_validated'` which had value of `true`.