### PR TITLE
Properly exclude node cache from releaes zips

### DIFF
--- a/dev/scripts/release.py
+++ b/dev/scripts/release.py
@@ -10,7 +10,7 @@ EXCLUDE_DIRS = [
     '.git',
     '.github',
     '.idea',
-    '.node-cache',
+    '.node_cache',
     '.vscode',
     'node_modules',
     'release',


### PR DESCRIPTION
I don't know how I missed this earlier. I noticed the zips were about 30MB larger than they should be :p