### PR TITLE
Add X-API-Key fallback header if Authorization is missing

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@
 # docker compose pull
 #
 # Reinstall:
-# docker compose exec php php -f scripts/cli_install.php '--' '--iSwearIKnowWhatImDoing' '--reinstall'
+# docker compose exec php php -f dev/scripts/cli_install.php '--' '--iSwearIKnowWhatImDoing' '--reinstall'
 #
 # Uninstall
 # docker compose down


### PR DESCRIPTION
Some hosting providers strip the `Authorization` header from requests. By adding a fallback `X-API-Key` header and [always sending both headers in the client](https://github.com/NamelessMC/Nameless-Java-API/commit/1378fdf399e9c09e3a7518c9b062214dc3f7e1f8), it will always work while keeping backwards compatibility.