### PR TITLE
Properly encode content for javascript

### DIFF
--- a/custom/templates/DefaultRevamp/template.php
+++ b/custom/templates/DefaultRevamp/template.php
@@ -123,7 +123,7 @@ class DefaultRevamp_Template extends TemplateBase {
         $JSVars = '';
         $i = 0;
         foreach ($JSVariables as $var => $value) {
-            $JSVars .= ($i == 0 ? 'var ' : ', ') . $var . ' = "' . $value . '"';
+            $JSVars .= ($i == 0 ? 'var ' : ', ') . $var . ' = ' . json_encode($value);
             $i++;
         }
 


### PR DESCRIPTION
`json_encode` is a convenient way to escape backslashes, quotes, and other characters for a javascript string.

Fixes javascript parsing error when route contains `\` or `"`, for example.

![image](https://user-images.githubusercontent.com/15892014/214098577-7eabbd3d-1cbe-41f8-b3ac-0caa9f54a494.png)
