### PR TITLE
Use X-Real-IP header last

### DIFF
--- a/core/classes/Misc/HttpUtils.php
+++ b/core/classes/Misc/HttpUtils.php
@@ -23,15 +23,9 @@ class HttpUtils {
             return $_SERVER['REMOTE_ADDR'];
         }
 
-        // Try the simple headers first that only contain an IP address...
-
-        // Non-standard header that only contains the origin address
-        $x_real_ip = self::getHeader('X-Real-IP');
-        if ($x_real_ip !== null) {
-            return $x_real_ip;
-        }
-
         // Non-standard header sent by Cloudflare that only contains the origin address
+        // We can trust this to be the real IP address, no real-world setup would
+        // have an additional proxy in front of CloudFlare.
         $cf_connecting_ip = self::getHeader('CF-Connecting-IP');
         if ($cf_connecting_ip !== null) {
             return $cf_connecting_ip;
@@ -81,6 +75,13 @@ class HttpUtils {
             if (count($addresses) > 0) {
                 return self::firstNonProxyAddress($addresses);
             }
+        }
+
+        // Non-standard header that only contains the origin address. This header should be tried last, since it does
+        // not work in the case of multiple proxies where at least two of them set the X-Real-IP header.
+        $x_real_ip = self::getHeader('X-Real-IP');
+        if ($x_real_ip !== null) {
+            return $x_real_ip;
         }
 
         return $_SERVER['REMOTE_ADDR'];


### PR DESCRIPTION
Fixes NamelessMC not getting the right IP address in setups with at least two proxies setting the X-Real-IP header