### PR TITLE
Add smarty.js to postinstall script

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -24,6 +24,7 @@ const publicAssets = {
   'codemirror': [
     'lib/codemirror.css',
     'lib/codemirror.js',
+    'mode/smarty/smarty.js',
     'mode/javascript/javascript.js',
     'mode/css/css.js',
     'mode/htmlmixed/htmlmixed.js',


### PR DESCRIPTION
The smarty syntax highlighting javascript file was not moved during postinstall, this lead to the file not being found in the template editor.