### PR TITLE
Run release script with oldest suppported PHP version

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -e
-docker run --rm -u $(id -u) -v "$(pwd):/data" --entrypoint="/data/dev/scripts/release-entrypoint.sh" namelessmc/php:dev
+docker run --rm -u $(id -u) -v "$(pwd):/data" --entrypoint="/data/dev/scripts/release-entrypoint.sh" namelessmc/php:dev-oldphp


### PR DESCRIPTION
For some reason, composer requires at least PHP 8.1 if `composer install` was run on PHP 8.1, even if the platform version is configured differently. To work around this issue, run the release script using the oldest PHP version we support.

dev-oldphp tag was added in commit https://github.com/NamelessMC/Nameless-Docker/commit/7e271820e69412874cd4e21409d8f9de6efb9d4d