### PR TITLE
Include missing smarty.js file

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -24,6 +24,7 @@ const publicAssets = {
   'codemirror': [
     'lib/codemirror.css',
     'lib/codemirror.js',
+    'mode/smarty/smarty.js',
     'mode/javascript/javascript.js',
     'mode/css/css.js',
     'mode/htmlmixed/htmlmixed.js',


### PR DESCRIPTION
This is fixed in `develop`, but I guess it was never backported to v2.0.x.