### PR TITLE
Create `HasWebhookParams` interface

### DIFF
--- a/core/classes/Events/DiscordDispatchable.php
+++ b/core/classes/Events/DiscordDispatchable.php
@@ -14,6 +14,6 @@ interface DiscordDispatchable {
      *
      * @return DiscordWebhookBuilder The webhook builder to send the event as an embed
      */
-    public function toDiscordWebook(): DiscordWebhookBuilder;
+    public function toDiscordWebhook(): DiscordWebhookBuilder;
 
 }

--- a/core/classes/Events/EventHandler.php
+++ b/core/classes/Events/EventHandler.php
@@ -42,7 +42,8 @@ class EventHandler {
         if (class_exists($event)  && is_subclass_of($event, AbstractEvent::class)) {
             $class_name = $event;
             $name = $event::name();
-            $description = $event::description();
+            // We lazy load descriptions for class-based events to avoid loading new Language instances unnecessarily
+            $description = fn () => $event::description();
             $return = $event::return();
             $internal = $event::internal();
         } else {
@@ -210,6 +211,9 @@ class EventHandler {
 
         foreach (self::$_events as $name => $meta) {
             if (!$meta['internal'] || $internal) {
+                if (is_callable($meta['description'])) {
+                    $meta['description'] = $meta['description']();
+                }
                 $return[$name] = $meta['description'];
             }
         }

--- a/core/classes/Events/EventHandler.php
+++ b/core/classes/Events/EventHandler.php
@@ -205,11 +205,11 @@ class EventHandler {
      *
      * @return array List of all currently registered events
      */
-    public static function getEvents(): array {
+    public static function getEvents(bool $showInternal = false): array {
         $return = [];
 
         foreach (self::$_events as $name => $meta) {
-            if ($meta['internal']) {
+            if ($meta['internal'] && !$showInternal) {
                 continue;
             }
 

--- a/core/classes/Events/EventHandler.php
+++ b/core/classes/Events/EventHandler.php
@@ -203,19 +203,28 @@ class EventHandler {
     /**
      * Get a list of events to display on the StaffCP webhooks page.
      *
-     * @param bool $internal Whether to include internal events or not
      * @return array List of all currently registered events
      */
-    public static function getEvents(bool $internal = false): array {
+    public static function getEvents(): array {
         $return = [];
 
         foreach (self::$_events as $name => $meta) {
-            if (!$meta['internal'] || $internal) {
-                if (is_callable($meta['description'])) {
-                    $meta['description'] = $meta['description']();
-                }
-                $return[$name] = $meta['description'];
+            if ($meta['internal']) {
+                continue;
             }
+
+            if (is_callable($meta['description'])) {
+                $description = $meta['description']();
+            } else {
+                $description = $meta['description'];
+            }
+
+            $class = $meta['class_name'];
+            $return[$name] = [
+                'description' => $description,
+                'supports_discord' => $class !== null && is_subclass_of($class, DiscordDispatchable::class),
+                'supports_normal' => $class !== null && is_subclass_of($class, HasWebhookParams::class),
+            ];
         }
 
         return $return;

--- a/core/classes/Events/HasWebhookParams.php
+++ b/core/classes/Events/HasWebhookParams.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Represents an event which has specific parameters to send to a webhook.
+ *
+ * @package NamelessMC\Events
+ * @author Aberdeener
+ * @version 2.2.0
+ * @license MIT
+ */
+interface HasWebhookParams {
+
+    /**
+     * @return array Array of parameters to send to the webhook
+     */
+    public function webhookParams(): array;
+
+}

--- a/core/classes/Events/WebhookDispatcher.php
+++ b/core/classes/Events/WebhookDispatcher.php
@@ -1,0 +1,11 @@
+<?php
+
+interface WebhookDispatcher {
+
+    /**
+     * @param AbstractEvent|array $event Event to execute, or array of params if event is not object based
+     * @param string $webhook_url Webhook URL to use, if not provided in event
+     */
+    public static function execute($event, string $webhook_url = '');
+
+}

--- a/custom/languages/en_UK.json
+++ b/custom/languages/en_UK.json
@@ -146,6 +146,7 @@
     "admin/details": "Details",
     "admin/disable": "Disable",
     "admin/disabled": "Disabled",
+    "admin/discord_hook": "Discord",
     "admin/display_field_on_forum": "Display field on forum?",
     "admin/download": "Download",
     "admin/download_sitemap": "Download Sitemap",

--- a/custom/languages/en_UK.json
+++ b/custom/languages/en_UK.json
@@ -226,6 +226,8 @@
     "admin/query_type": "Query type",
     "admin/internal": "Internal",
     "admin/external": "External",
+    "admin/event_supports_discord": "This event supports Discord webhooks and has a custom embed.",
+    "admin/event_supports_normal": "This event supports normal webhooks.",
     "admin/plugin": "Plugin",
     "admin/query_type_help": "If the default internal server query does not work, try another option.",
     "admin/face": "Face",

--- a/custom/panel_templates/Default/core/hooks_edit.tpl
+++ b/custom/panel_templates/Default/core/hooks_edit.tpl
@@ -79,12 +79,11 @@
                                     <label class="custom-control-label" for="inputevents[{$key|escape}]">
                                         {$meta.description|escape}
                                         {if $meta.supports_discord}
-                                            <span class="badge badge-info">Supports Discord</span>
+                                            <i class="fab fa-discord"></i>
                                         {/if}
                                         {if $meta.supports_normal}
-                                            <span class="badge badge-info">Supports Normal</span>
+                                            <i class="fas fa-globe"></i>
                                         {/if}
-
                                     </label>
                                 </div>
                                 {/foreach}

--- a/custom/panel_templates/Default/core/hooks_edit.tpl
+++ b/custom/panel_templates/Default/core/hooks_edit.tpl
@@ -64,18 +64,27 @@
                                 <div class="form-group">
                                     <label for="link_location">{$HOOK_TYPE}</label>
                                     <select class="form-control" id="hook_type" name="hook_type">
-                                        <option value="2" {if $HOOK_TYPE_VALUE eq 2} selected{/if}>Discord</option>
-                                        <option value="1" {if $HOOK_TYPE_VALUE eq 1} selected{/if}>{$NORMAL}</option>
+                                        <option value="2" {if $HOOK_TYPE_VALUE eq 2} selected{/if}>
+                                            {$DISCORD}
+                                        </option>
+                                        <option value="1" {if $HOOK_TYPE_VALUE eq 1} selected{/if}>
+                                            {$NORMAL}
+                                        </option>
                                     </select>
                                 </div>
                                 <label for="InputName">{$HOOK_EVENTS}</label>
-                                {foreach from=$ALL_EVENTS key=key item=item}
+                                {foreach from=$ALL_EVENTS key=key item=meta}
                                 <div class="form-group custom-control custom-switch">
-                                    <input type="checkbox" id="inputevents[{$key|escape}]" name="events[{$key|escape}]"
-                                        class="custom-control-input" value="1" {if in_array($key|escape,
-                                        $ENABLED_HOOKS)} checked{/if}>
+                                    <input type="checkbox" id="inputevents[{$key|escape}]" name="events[{$key|escape}]" class="custom-control-input" value="1" {if in_array($key|escape, $ENABLED_HOOKS)} checked{/if}>
                                     <label class="custom-control-label" for="inputevents[{$key|escape}]">
-                                        {$item|escape}
+                                        {$meta.description|escape}
+                                        {if $meta.supports_discord}
+                                            <span class="badge badge-info">Supports Discord</span>
+                                        {/if}
+                                        {if $meta.supports_normal}
+                                            <span class="badge badge-info">Supports Normal</span>
+                                        {/if}
+
                                     </label>
                                 </div>
                                 {/foreach}

--- a/custom/panel_templates/Default/core/hooks_new.tpl
+++ b/custom/panel_templates/Default/core/hooks_new.tpl
@@ -75,10 +75,14 @@
                                         <label class="custom-control-label" for="inputevents[{$key|escape}]">
                                             {$meta.description|escape}
                                             {if $meta.supports_discord}
-                                                <span class="badge badge-info">Supports Discord</span>
+                                                <span data-toggle="tooltip" data-original-title="{$SUPPORTS_DISCORD}">
+                                                    <i class="fab fa-discord"></i>
+                                                </span>
                                             {/if}
                                             {if $meta.supports_normal}
-                                                <span class="badge badge-info">Supports Normal</span>
+                                                <span data-toggle="tooltip" data-original-title="{$SUPPORTS_NORMAL}">
+                                                    <i class="fas fa-globe"></i>
+                                                </span>
                                             {/if}
                                         </label>
                                     </div>

--- a/custom/panel_templates/Default/core/hooks_new.tpl
+++ b/custom/panel_templates/Default/core/hooks_new.tpl
@@ -64,19 +64,24 @@
                                 <div class="form-group">
                                     <label for="link_location">{$HOOK_TYPE}</label>
                                     <select class="form-control" id="hook_type" name="hook_type">
-                                        <option value="2">Discord</option>
+                                        <option value="2">{$DISCORD}</option>
                                         <option value="1">{$NORMAL}</option>
                                     </select>
                                 </div>
                                 <label for="InputName">{$HOOK_EVENTS}</label>
-                                {foreach from=$ALL_EVENTS key=key item=item}
-                                <div class="form-group custom-control custom-switch">
-                                    <input type="checkbox" id="inputevents[{$key|escape}]" name="events[{$key|escape}]"
-                                        class="custom-control-input">
-                                    <label class="custom-control-label" for="inputevents[{$key|escape}]">
-                                        {$item|escape}
-                                    </label>
-                                </div>
+                                {foreach from=$ALL_EVENTS key=key item=meta}
+                                    <div class="form-group custom-control custom-switch">
+                                        <input type="checkbox" id="inputevents[{$key|escape}]" name="events[{$key|escape}]" class="custom-control-input">
+                                        <label class="custom-control-label" for="inputevents[{$key|escape}]">
+                                            {$meta.description|escape}
+                                            {if $meta.supports_discord}
+                                                <span class="badge badge-info">Supports Discord</span>
+                                            {/if}
+                                            {if $meta.supports_normal}
+                                                <span class="badge badge-info">Supports Normal</span>
+                                            {/if}
+                                        </label>
+                                    </div>
                                 {/foreach}
                                 <div class="form-group">
                                     <input type="hidden" name="token" value="{$TOKEN}">

--- a/dev/scripts/cli_install.php
+++ b/dev/scripts/cli_install.php
@@ -210,6 +210,8 @@ if ($profile !== null) {
 
 DatabaseInitialiser::runPostUser();
 
+Config::set('core.installed', true);
+
 print(PHP_EOL . '✅ Installation complete! (Took ' . round(microtime(true) - $start, 2) . ' seconds)' . PHP_EOL);
 print(PHP_EOL . '🖥  URL: http://' . $conf['core']['hostname'] . $conf['core']['path']);
 print(PHP_EOL . '🔑 Admin username: ' . $username);

--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@
 header('X-Frame-Options: SAMEORIGIN');
 
 if ((!defined('DEBUGGING') || !DEBUGGING) && (getenv('NAMELESS_DEBUGGING') || isset($_SERVER['NAMELESS_DEBUGGING']))) {
-    define('DEBUGGING', false);
+    define('DEBUGGING', true);
 }
 
 if (defined('DEBUGGING') && DEBUGGING) {

--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@
 header('X-Frame-Options: SAMEORIGIN');
 
 if ((!defined('DEBUGGING') || !DEBUGGING) && (getenv('NAMELESS_DEBUGGING') || isset($_SERVER['NAMELESS_DEBUGGING']))) {
-    define('DEBUGGING', true);
+    define('DEBUGGING', false);
 }
 
 if (defined('DEBUGGING') && DEBUGGING) {

--- a/modules/Core/classes/Events/AnnouncementCreatedEvent.php
+++ b/modules/Core/classes/Events/AnnouncementCreatedEvent.php
@@ -17,7 +17,7 @@ class AnnouncementCreatedEvent extends AbstractEvent implements DiscordDispatcha
     }
 
     public static function description(): string {
-        return (new Language(ROOT_PATH . '/modules/Forum/language'))->get('forum', 'new_topic_hook_info');
+        return (new Language())->get('admin', 'announcement_hook_info');
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/AnnouncementCreatedEvent.php
+++ b/modules/Core/classes/Events/AnnouncementCreatedEvent.php
@@ -20,7 +20,7 @@ class AnnouncementCreatedEvent extends AbstractEvent implements HasWebhookParams
         return (new Language())->get('admin', 'announcement_hook_info');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'user_id' => $this->creator->data()->id,
             'username' => $this->creator->getDisplayname(),

--- a/modules/Core/classes/Events/AnnouncementCreatedEvent.php
+++ b/modules/Core/classes/Events/AnnouncementCreatedEvent.php
@@ -20,7 +20,7 @@ class AnnouncementCreatedEvent extends AbstractEvent implements DiscordDispatcha
         return (new Language(ROOT_PATH . '/modules/Forum/language'))->get('forum', 'new_topic_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language('core', DEFAULT_LANGUAGE);
 
         return DiscordWebhookBuilder::make()

--- a/modules/Core/classes/Events/AnnouncementCreatedEvent.php
+++ b/modules/Core/classes/Events/AnnouncementCreatedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class AnnouncementCreatedEvent extends AbstractEvent implements DiscordDispatchable {
+class AnnouncementCreatedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $creator;
     public string $header;
@@ -18,6 +18,15 @@ class AnnouncementCreatedEvent extends AbstractEvent implements DiscordDispatcha
 
     public static function description(): string {
         return (new Language())->get('admin', 'announcement_hook_info');
+    }
+
+    function webhookParams(): array {
+        return [
+            'user_id' => $this->creator->data()->id,
+            'username' => $this->creator->getDisplayname(),
+            'header' => $this->header,
+            'message' => $this->message
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/ReportCreatedEvent.php
+++ b/modules/Core/classes/Events/ReportCreatedEvent.php
@@ -34,7 +34,7 @@ class ReportCreatedEvent extends AbstractEvent implements HasWebhookParams, Disc
         return (new Language())->get('admin', 'report_hook_info');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'username' => $this->username,
             'title' => $this->title,

--- a/modules/Core/classes/Events/ReportCreatedEvent.php
+++ b/modules/Core/classes/Events/ReportCreatedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class ReportCreatedEvent extends AbstractEvent implements DiscordDispatchable {
+class ReportCreatedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public string $username;
     public string $content;
@@ -32,6 +32,16 @@ class ReportCreatedEvent extends AbstractEvent implements DiscordDispatchable {
 
     public static function description(): string {
         return (new Language())->get('admin', 'report_hook_info');
+    }
+
+    function webhookParams(): array {
+        return [
+            'username' => $this->username,
+            'title' => $this->title,
+            'content' => $this->content,
+            'content_full' => $this->content_full,
+            'url' => $this->url
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/ReportCreatedEvent.php
+++ b/modules/Core/classes/Events/ReportCreatedEvent.php
@@ -34,7 +34,7 @@ class ReportCreatedEvent extends AbstractEvent implements DiscordDispatchable {
         return (new Language())->get('admin', 'report_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         return DiscordWebhookBuilder::make()
             ->setUsername($this->username . ' | ' . SITE_NAME)
             ->setAvatarUrl($this->avatar_url)

--- a/modules/Core/classes/Events/UserBannedEvent.php
+++ b/modules/Core/classes/Events/UserBannedEvent.php
@@ -18,7 +18,7 @@ class UserBannedEvent extends AbstractEvent implements HasWebhookParams, Discord
         return (new Language())->get('admin', 'ban_hook_info');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'punished' => [
                 'user_id' => $this->punished->data()->id,

--- a/modules/Core/classes/Events/UserBannedEvent.php
+++ b/modules/Core/classes/Events/UserBannedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserBannedEvent extends AbstractEvent implements DiscordDispatchable {
+class UserBannedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $punished;
     public User $punisher;
@@ -16,6 +16,21 @@ class UserBannedEvent extends AbstractEvent implements DiscordDispatchable {
 
     public static function description(): string {
         return (new Language())->get('admin', 'ban_hook_info');
+    }
+
+    function webhookParams(): array {
+        return [
+            'punished' => [
+                'user_id' => $this->punished->data()->id,
+                'username' => $this->punished->getDisplayname(),
+            ],
+            'punisher' => [
+                'user_id' => $this->punisher->data()->id,
+                'username' => $this->punisher->getDisplayname(),
+            ],
+            'reason' => $this->reason,
+            'ip_ban' => $this->ip_ban
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/UserBannedEvent.php
+++ b/modules/Core/classes/Events/UserBannedEvent.php
@@ -18,7 +18,7 @@ class UserBannedEvent extends AbstractEvent implements DiscordDispatchable {
         return (new Language())->get('admin', 'ban_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language('core', DEFAULT_LANGUAGE);
 
         return DiscordWebhookBuilder::make()

--- a/modules/Core/classes/Events/UserDeletedEvent.php
+++ b/modules/Core/classes/Events/UserDeletedEvent.php
@@ -12,7 +12,7 @@ class UserDeletedEvent extends AbstractEvent implements HasWebhookParams {
         return 'deleteUser';
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'user_id' => $this->user->data()->id,
             'username' => $this->user->getDisplayname(),

--- a/modules/Core/classes/Events/UserDeletedEvent.php
+++ b/modules/Core/classes/Events/UserDeletedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserDeletedEvent extends AbstractEvent {
+class UserDeletedEvent extends AbstractEvent implements HasWebhookParams {
 
     public User $user;
 
@@ -10,6 +10,13 @@ class UserDeletedEvent extends AbstractEvent {
 
     public static function name(): string {
         return 'deleteUser';
+    }
+
+    function webhookParams(): array {
+        return [
+            'user_id' => $this->user->data()->id,
+            'username' => $this->user->getDisplayname(),
+        ];
     }
 
     public static function description(): string {

--- a/modules/Core/classes/Events/UserGroupAddedEvent.php
+++ b/modules/Core/classes/Events/UserGroupAddedEvent.php
@@ -14,7 +14,7 @@ class UserGroupAddedEvent extends AbstractEvent implements HasWebhookParams, Dis
         return (new Language())->get('admin', 'user_group_added_hook_info');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'user_id' => $this->user->data()->id,
             'username' => $this->user->getDisplayname(),

--- a/modules/Core/classes/Events/UserGroupAddedEvent.php
+++ b/modules/Core/classes/Events/UserGroupAddedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserGroupAddedEvent extends AbstractEvent implements DiscordDispatchable {
+class UserGroupAddedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $user;
     public Group $group;
@@ -12,6 +12,17 @@ class UserGroupAddedEvent extends AbstractEvent implements DiscordDispatchable {
 
     public static function description(): string {
         return (new Language())->get('admin', 'user_group_added_hook_info');
+    }
+
+    function webhookParams(): array {
+        return [
+            'user_id' => $this->user->data()->id,
+            'username' => $this->user->getDisplayname(),
+            'group' => [
+                'id' => $this->group->id,
+                'name' => $this->group->name
+            ]
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/UserGroupAddedEvent.php
+++ b/modules/Core/classes/Events/UserGroupAddedEvent.php
@@ -14,7 +14,7 @@ class UserGroupAddedEvent extends AbstractEvent implements DiscordDispatchable {
         return (new Language())->get('admin', 'user_group_added_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language('core', DEFAULT_LANGUAGE);
 
         return DiscordWebhookBuilder::make()

--- a/modules/Core/classes/Events/UserGroupRemovedEvent.php
+++ b/modules/Core/classes/Events/UserGroupRemovedEvent.php
@@ -14,7 +14,7 @@ class UserGroupRemovedEvent extends AbstractEvent implements HasWebhookParams, D
         return (new Language())->get('admin', 'user_group_removed_hook_info');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'user_id' => $this->user->data()->id,
             'username' => $this->user->getDisplayname(),

--- a/modules/Core/classes/Events/UserGroupRemovedEvent.php
+++ b/modules/Core/classes/Events/UserGroupRemovedEvent.php
@@ -14,7 +14,7 @@ class UserGroupRemovedEvent extends AbstractEvent implements DiscordDispatchable
         return (new Language())->get('admin', 'user_group_removed_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language('core', DEFAULT_LANGUAGE);
 
         return DiscordWebhookBuilder::make()

--- a/modules/Core/classes/Events/UserGroupRemovedEvent.php
+++ b/modules/Core/classes/Events/UserGroupRemovedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserGroupRemovedEvent extends AbstractEvent implements DiscordDispatchable {
+class UserGroupRemovedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $user;
     public Group $group;
@@ -12,6 +12,17 @@ class UserGroupRemovedEvent extends AbstractEvent implements DiscordDispatchable
 
     public static function description(): string {
         return (new Language())->get('admin', 'user_group_removed_hook_info');
+    }
+
+    function webhookParams(): array {
+        return [
+            'user_id' => $this->user->data()->id,
+            'username' => $this->user->getDisplayname(),
+            'group' => [
+                'id' => $this->group->id,
+                'name' => $this->group->name
+            ]
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/UserIntegrationLinkedEvent.php
+++ b/modules/Core/classes/Events/UserIntegrationLinkedEvent.php
@@ -20,7 +20,7 @@ class UserIntegrationLinkedEvent extends AbstractEvent implements HasWebhookPara
         return (new Language())->get('admin', 'user_link_integration_hook_info');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'user_id' => $this->user->data()->id,
             'username' => $this->user->getDisplayname(),

--- a/modules/Core/classes/Events/UserIntegrationLinkedEvent.php
+++ b/modules/Core/classes/Events/UserIntegrationLinkedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserIntegrationLinkedEvent extends AbstractEvent implements DiscordDispatchable {
+class UserIntegrationLinkedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $user;
     public IntegrationBase $integration;
@@ -18,6 +18,19 @@ class UserIntegrationLinkedEvent extends AbstractEvent implements DiscordDispatc
 
     public static function description(): string {
         return (new Language())->get('admin', 'user_link_integration_hook_info');
+    }
+
+    function webhookParams(): array {
+        return [
+            'user_id' => $this->user->data()->id,
+            'username' => $this->user->getDisplayname(),
+            'integration' => [
+                'integration' => $this->integration->getName(),
+                'username' => $this->integration_user->data()->username,
+                'identifier' => $this->integration_user->data()->identifier,
+                'verified' => $this->integration_user->isVerified()
+            ]
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/UserIntegrationLinkedEvent.php
+++ b/modules/Core/classes/Events/UserIntegrationLinkedEvent.php
@@ -20,7 +20,7 @@ class UserIntegrationLinkedEvent extends AbstractEvent implements DiscordDispatc
         return (new Language())->get('admin', 'user_link_integration_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language('core', DEFAULT_LANGUAGE);
 
         return DiscordWebhookBuilder::make()

--- a/modules/Core/classes/Events/UserIntegrationUnlinkedEvent.php
+++ b/modules/Core/classes/Events/UserIntegrationUnlinkedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserIntegrationUnlinkedEvent extends AbstractEvent implements DiscordDispatchable {
+class UserIntegrationUnlinkedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $user;
     public IntegrationBase $integration;
@@ -18,6 +18,19 @@ class UserIntegrationUnlinkedEvent extends AbstractEvent implements DiscordDispa
 
     public static function description(): string {
         return (new Language())->get('admin', 'user_unlink_integration_hook_info');
+    }
+
+    function webhookParams(): array {
+        return [
+            'user_id' => $this->user->data()->id,
+            'username' => $this->user->getDisplayname(),
+            'integration' => [
+                'integration' => $this->integration->getName(),
+                'username' => $this->integration_user->data()->username,
+                'identifier' => $this->integration_user->data()->identifier,
+                'verified' => $this->integration_user->isVerified()
+            ]
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/UserIntegrationUnlinkedEvent.php
+++ b/modules/Core/classes/Events/UserIntegrationUnlinkedEvent.php
@@ -20,7 +20,7 @@ class UserIntegrationUnlinkedEvent extends AbstractEvent implements DiscordDispa
         return (new Language())->get('admin', 'user_unlink_integration_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language('core', DEFAULT_LANGUAGE);
 
         return DiscordWebhookBuilder::make()

--- a/modules/Core/classes/Events/UserIntegrationUnlinkedEvent.php
+++ b/modules/Core/classes/Events/UserIntegrationUnlinkedEvent.php
@@ -20,7 +20,7 @@ class UserIntegrationUnlinkedEvent extends AbstractEvent implements HasWebhookPa
         return (new Language())->get('admin', 'user_unlink_integration_hook_info');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'user_id' => $this->user->data()->id,
             'username' => $this->user->getDisplayname(),

--- a/modules/Core/classes/Events/UserIntegrationVerifiedEvent.php
+++ b/modules/Core/classes/Events/UserIntegrationVerifiedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserIntegrationVerifiedEvent extends AbstractEvent implements DiscordDispatchable {
+class UserIntegrationVerifiedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $user;
     public IntegrationBase $integration;
@@ -18,6 +18,19 @@ class UserIntegrationVerifiedEvent extends AbstractEvent implements DiscordDispa
 
     public static function description(): string {
         return (new Language())->get('admin', 'user_verify_integration_hook_info');
+    }
+
+    function webhookParams(): array {
+        return [
+            'user_id' => $this->user->data()->id,
+            'username' => $this->user->getDisplayname(),
+            'integration' => [
+                'integration' => $this->integration->getName(),
+                'username' => $this->integration_user->data()->username,
+                'identifier' => $this->integration_user->data()->identifier,
+                'verified' => $this->integration_user->isVerified()
+            ]
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/UserIntegrationVerifiedEvent.php
+++ b/modules/Core/classes/Events/UserIntegrationVerifiedEvent.php
@@ -20,7 +20,7 @@ class UserIntegrationVerifiedEvent extends AbstractEvent implements DiscordDispa
         return (new Language())->get('admin', 'user_verify_integration_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language('core', DEFAULT_LANGUAGE);
 
         return DiscordWebhookBuilder::make()

--- a/modules/Core/classes/Events/UserIntegrationVerifiedEvent.php
+++ b/modules/Core/classes/Events/UserIntegrationVerifiedEvent.php
@@ -20,7 +20,7 @@ class UserIntegrationVerifiedEvent extends AbstractEvent implements HasWebhookPa
         return (new Language())->get('admin', 'user_verify_integration_hook_info');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'user_id' => $this->user->data()->id,
             'username' => $this->user->getDisplayname(),

--- a/modules/Core/classes/Events/UserProfilePostCreatedEvent.php
+++ b/modules/Core/classes/Events/UserProfilePostCreatedEvent.php
@@ -20,7 +20,7 @@ class UserProfilePostCreatedEvent extends AbstractEvent implements HasWebhookPar
         return (new Language())->get('admin', 'user_new_profile_post_hook_info');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'poster' => [
                 'user_id' => $this->poster->data()->id,

--- a/modules/Core/classes/Events/UserProfilePostCreatedEvent.php
+++ b/modules/Core/classes/Events/UserProfilePostCreatedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserProfilePostCreatedEvent extends AbstractEvent implements DiscordDispatchable {
+class UserProfilePostCreatedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $poster;
     public User $profile_user;
@@ -18,6 +18,21 @@ class UserProfilePostCreatedEvent extends AbstractEvent implements DiscordDispat
 
     public static function description(): string {
         return (new Language())->get('admin', 'user_new_profile_post_hook_info');
+    }
+
+    function webhookParams(): array {
+        return [
+            'poster' => [
+                'user_id' => $this->poster->data()->id,
+                'username' => $this->poster->getDisplayname()
+            ],
+            'profile_user' => [
+                'user_id' => $this->profile_user->data()->id,
+                'username' => $this->profile_user->getDisplayname()
+            ],
+            'content' => $this->content,
+            'url' => URL::getSelfURL() . ltrim(URL::build('/profile/' . urlencode($this->profile_user->getDisplayname(true)) . '/#post-' . urlencode(DB::getInstance()->lastId())), '/')
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/UserProfilePostCreatedEvent.php
+++ b/modules/Core/classes/Events/UserProfilePostCreatedEvent.php
@@ -20,7 +20,7 @@ class UserProfilePostCreatedEvent extends AbstractEvent implements DiscordDispat
         return (new Language())->get('admin', 'user_new_profile_post_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language('core', DEFAULT_LANGUAGE);
 
         return DiscordWebhookBuilder::make()

--- a/modules/Core/classes/Events/UserProfilePostReplyCreatedEvent.php
+++ b/modules/Core/classes/Events/UserProfilePostReplyCreatedEvent.php
@@ -20,7 +20,7 @@ class UserProfilePostReplyCreatedEvent extends AbstractEvent implements DiscordD
         return (new Language())->get('admin', 'user_profile_post_reply_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language('core', DEFAULT_LANGUAGE);
 
         return DiscordWebhookBuilder::make()

--- a/modules/Core/classes/Events/UserProfilePostReplyCreatedEvent.php
+++ b/modules/Core/classes/Events/UserProfilePostReplyCreatedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserProfilePostReplyCreatedEvent extends AbstractEvent implements DiscordDispatchable {
+class UserProfilePostReplyCreatedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $poster;
     public User $profile_user;
@@ -18,6 +18,21 @@ class UserProfilePostReplyCreatedEvent extends AbstractEvent implements DiscordD
 
     public static function description(): string {
         return (new Language())->get('admin', 'user_profile_post_reply_hook_info');
+    }
+
+    function webhookParams(): array {
+        return [
+            'poster' => [
+                'user_id' => $this->poster->data()->id,
+                'username' => $this->poster->getDisplayname()
+            ],
+            'profile_user' => [
+                'user_id' => $this->profile_user->data()->id,
+                'username' => $this->profile_user->getDisplayname()
+            ],
+            'content' => $this->content,
+            'url' => URL::getSelfURL() . ltrim(URL::build('/profile/' . urlencode($this->profile_user->getDisplayname(true)) . '/#post-' . urlencode(DB::getInstance()->lastId())), '/')
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/UserProfilePostReplyCreatedEvent.php
+++ b/modules/Core/classes/Events/UserProfilePostReplyCreatedEvent.php
@@ -20,7 +20,7 @@ class UserProfilePostReplyCreatedEvent extends AbstractEvent implements HasWebho
         return (new Language())->get('admin', 'user_profile_post_reply_hook_info');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'poster' => [
                 'user_id' => $this->poster->data()->id,

--- a/modules/Core/classes/Events/UserRegisteredEvent.php
+++ b/modules/Core/classes/Events/UserRegisteredEvent.php
@@ -16,7 +16,7 @@ class UserRegisteredEvent extends AbstractEvent implements DiscordDispatchable {
         return (new Language())->get('admin', 'register_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language('core', DEFAULT_LANGUAGE);
 
         return DiscordWebhookBuilder::make()

--- a/modules/Core/classes/Events/UserRegisteredEvent.php
+++ b/modules/Core/classes/Events/UserRegisteredEvent.php
@@ -20,6 +20,7 @@ class UserRegisteredEvent extends AbstractEvent implements HasWebhookParams, Dis
         return [
             'user_id' => $this->user->data()->id,
             'username' => $this->user->getDisplayname(),
+            'profile_url' => URL::getSelfURL() . ltrim($this->user->getProfileURL(), '/')
         ];
     }
 

--- a/modules/Core/classes/Events/UserRegisteredEvent.php
+++ b/modules/Core/classes/Events/UserRegisteredEvent.php
@@ -16,7 +16,7 @@ class UserRegisteredEvent extends AbstractEvent implements HasWebhookParams, Dis
         return (new Language())->get('admin', 'register_hook_info');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'user_id' => $this->user->data()->id,
             'username' => $this->user->getDisplayname(),

--- a/modules/Core/classes/Events/UserRegisteredEvent.php
+++ b/modules/Core/classes/Events/UserRegisteredEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserRegisteredEvent extends AbstractEvent implements DiscordDispatchable {
+class UserRegisteredEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $user;
 
@@ -14,6 +14,13 @@ class UserRegisteredEvent extends AbstractEvent implements DiscordDispatchable {
 
     public static function description(): string {
         return (new Language())->get('admin', 'register_hook_info');
+    }
+
+    function webhookParams(): array {
+        return [
+            'user_id' => $this->user->data()->id,
+            'username' => $this->user->getDisplayname(),
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/UserValidatedEvent.php
+++ b/modules/Core/classes/Events/UserValidatedEvent.php
@@ -16,7 +16,7 @@ class UserValidatedEvent extends AbstractEvent implements DiscordDispatchable {
         return (new Language())->get('admin', 'validate_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language('core', DEFAULT_LANGUAGE);
 
         return DiscordWebhookBuilder::make()

--- a/modules/Core/classes/Events/UserValidatedEvent.php
+++ b/modules/Core/classes/Events/UserValidatedEvent.php
@@ -16,7 +16,7 @@ class UserValidatedEvent extends AbstractEvent implements HasWebhookParams, Disc
         return (new Language())->get('admin', 'validate_hook_info');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'user_id' => $this->user->data()->id,
             'username' => $this->user->getDisplayname(),

--- a/modules/Core/classes/Events/UserValidatedEvent.php
+++ b/modules/Core/classes/Events/UserValidatedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserValidatedEvent extends AbstractEvent implements DiscordDispatchable {
+class UserValidatedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $user;
 
@@ -14,6 +14,13 @@ class UserValidatedEvent extends AbstractEvent implements DiscordDispatchable {
 
     public static function description(): string {
         return (new Language())->get('admin', 'validate_hook_info');
+    }
+
+    function webhookParams(): array {
+        return [
+            'user_id' => $this->user->data()->id,
+            'username' => $this->user->getDisplayname(),
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/UserValidatedEvent.php
+++ b/modules/Core/classes/Events/UserValidatedEvent.php
@@ -20,6 +20,7 @@ class UserValidatedEvent extends AbstractEvent implements HasWebhookParams, Disc
         return [
             'user_id' => $this->user->data()->id,
             'username' => $this->user->getDisplayname(),
+            'profile_url' => URL::getSelfURL() . ltrim($this->user->getProfileURL(), '/')
         ];
     }
 

--- a/modules/Core/classes/Events/UserWarnedEvent.php
+++ b/modules/Core/classes/Events/UserWarnedEvent.php
@@ -16,7 +16,7 @@ class UserWarnedEvent extends AbstractEvent implements DiscordDispatchable {
         return (new Language())->get('admin', 'warning_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language('core', DEFAULT_LANGUAGE);
 
         return DiscordWebhookBuilder::make()

--- a/modules/Core/classes/Events/UserWarnedEvent.php
+++ b/modules/Core/classes/Events/UserWarnedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserWarnedEvent extends AbstractEvent implements DiscordDispatchable {
+class UserWarnedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $punished;
     public User $punisher;
@@ -14,6 +14,20 @@ class UserWarnedEvent extends AbstractEvent implements DiscordDispatchable {
 
     public static function description(): string {
         return (new Language())->get('admin', 'warning_hook_info');
+    }
+
+    function webhookParams(): array {
+        return [
+            'punished' => [
+                'user_id' => $this->punished->data()->id,
+                'username' => $this->punished->getDisplayname(),
+            ],
+            'punisher' => [
+                'user_id' => $this->punisher->data()->id,
+                'username' => $this->punisher->getDisplayname(),
+            ],
+            'reason' => $this->reason
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Core/classes/Events/UserWarnedEvent.php
+++ b/modules/Core/classes/Events/UserWarnedEvent.php
@@ -16,7 +16,7 @@ class UserWarnedEvent extends AbstractEvent implements HasWebhookParams, Discord
         return (new Language())->get('admin', 'warning_hook_info');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         return [
             'punished' => [
                 'user_id' => $this->punished->data()->id,

--- a/modules/Core/hooks/WebHook.php
+++ b/modules/Core/hooks/WebHook.php
@@ -1,20 +1,34 @@
 <?php
-/*
- *  Made by Partydragen
- *  https://github.com/NamelessMC/Nameless/
- *  NamelessMC version 2.0.0
+/**
+ * Webhook handler class
  *
- *  Webhook handler class
+ * @package NamelessMC\Events
+ * @author Partydragen
+ * @version 2.2.0
+ * @license MIT
  */
+class WebHook implements WebhookDispatcher {
 
-class WebHook {
+    public static function execute($event, string $webhook_url = ''): void {
+        if ($event instanceof HasWebhookParams) {
+            $params = $event->webhookParams();
+        } else if ($event instanceof AbstractEvent) {
+            ErrorHandler::logWarning('Event ' . $event::name() . ' does not implement HasWebhookParams, using `params()` instead');
+            $params = $event->params();
+        } else {
+            $params = $event;
+        }
 
-    public static function execute(array $params = []): void {
+        $webhook_url = $event instanceof AbstractEvent
+            ? $webhook_url
+            : $params['webhook'];
+
         $return = $params;
         unset($return['webhook']);
+
         $json = json_encode($return, JSON_UNESCAPED_SLASHES);
 
-        $httpClient = HttpClient::post($params['webhook'], $json, [
+        $httpClient = HttpClient::post($webhook_url, $json, [
             'headers' => [
                 'Content-Type' => 'application/json',
             ],

--- a/modules/Core/pages/panel/hooks.php
+++ b/modules/Core/pages/panel/hooks.php
@@ -114,6 +114,7 @@ if (!isset($_GET['action'])) {
                 'HOOK_EVENTS' => $language->get('admin', 'hook_events'),
                 'BACK' => $language->get('general', 'back'),
                 'BACK_LINK' => URL::build('/panel/core/hooks'),
+                'DISCORD' => $language->get('admin', 'discord_hook'),
                 'NORMAL' => $language->get('general', 'normal'),
                 'ALL_EVENTS' => EventHandler::getEvents(),
             ]);
@@ -200,6 +201,7 @@ if (!isset($_GET['action'])) {
                 'HOOK_EVENTS' => $language->get('admin', 'hook_events'),
                 'BACK' => $language->get('general', 'back'),
                 'BACK_LINK' => URL::build('/panel/core/hooks'),
+                'DISCORD' => $language->get('admin', 'discord_hook'),
                 'NORMAL' => $language->get('general', 'normal'),
                 'ALL_EVENTS' => EventHandler::getEvents(),
                 'ENABLED_HOOKS' => json_decode($hook->events, true)

--- a/modules/Core/pages/panel/hooks.php
+++ b/modules/Core/pages/panel/hooks.php
@@ -117,6 +117,8 @@ if (!isset($_GET['action'])) {
                 'DISCORD' => $language->get('admin', 'discord_hook'),
                 'NORMAL' => $language->get('general', 'normal'),
                 'ALL_EVENTS' => EventHandler::getEvents(),
+                'SUPPORTS_DISCORD' => $language->get('admin', 'event_supports_discord'),
+                'SUPPORTS_NORMAL' => $language->get('admin', 'event_supports_normal'),
             ]);
 
             $template_file = 'core/hooks_new.tpl';
@@ -204,7 +206,9 @@ if (!isset($_GET['action'])) {
                 'DISCORD' => $language->get('admin', 'discord_hook'),
                 'NORMAL' => $language->get('general', 'normal'),
                 'ALL_EVENTS' => EventHandler::getEvents(),
-                'ENABLED_HOOKS' => json_decode($hook->events, true)
+                'ENABLED_HOOKS' => json_decode($hook->events, true),
+                'SUPPORTS_DISCORD' => $language->get('admin', 'event_supports_discord'),
+                'SUPPORTS_NORMAL' => $language->get('admin', 'event_supports_normal'),
             ]);
 
             $template_file = 'core/hooks_edit.tpl';

--- a/modules/Discord Integration/hooks/DiscordHook.php
+++ b/modules/Discord Integration/hooks/DiscordHook.php
@@ -1,17 +1,14 @@
 <?php
-/*
- *  Made by Samerton
- *  https://github.com/NamelessMC/Nameless/
- *  NamelessMC version 2.1.0
+/**
+ * Discord webhook handler class
  *
- *  Discord webhook handler class
+ * @package NamelessMC\Events
+ * @author Samerton
+ * @version 2.2.0
+ * @license MIT
  */
+class DiscordHook implements WebhookDispatcher {
 
-class DiscordHook {
-
-    /**
-     * @param AbstractEvent|array $event Event to execute, or array of params if event is not object based
-     */
     public static function execute($event, string $webhook_url = ''): void {
         $params = $event instanceof AbstractEvent
             ? $event->params()
@@ -34,6 +31,8 @@ class DiscordHook {
             $format,
             $params,
         ))['format'];
+
+        unset($return['webhook']);
 
         if ($return instanceof DiscordWebhookBuilder) {
             $return = $return->toArray();

--- a/modules/Discord Integration/hooks/DiscordHook.php
+++ b/modules/Discord Integration/hooks/DiscordHook.php
@@ -32,7 +32,9 @@ class DiscordHook implements WebhookDispatcher {
             $params,
         ))['format'];
 
-        unset($return['webhook']);
+        if (is_array($return) && isset($return['webhook'])) {
+            unset($return['webhook']);
+        }
 
         if ($return instanceof DiscordWebhookBuilder) {
             $return = $return->toArray();

--- a/modules/Discord Integration/hooks/DiscordHook.php
+++ b/modules/Discord Integration/hooks/DiscordHook.php
@@ -23,7 +23,7 @@ class DiscordHook implements WebhookDispatcher {
             : $params['event'];
 
         $format = $event instanceof DiscordDispatchable
-            ? $event->toDiscordWebook()
+            ? $event->toDiscordWebhook()
             : [];
 
         $return = EventHandler::executeEvent(new DiscordWebhookFormatterEvent(

--- a/modules/Forum/classes/Events/TopicCreatedEvent.php
+++ b/modules/Forum/classes/Events/TopicCreatedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class TopicCreatedEvent extends AbstractEvent implements DiscordDispatchable {
+class TopicCreatedEvent extends AbstractEvent implements DiscordDispatchable, HasWebhookParams {
 
     public User $creator;
     public string $forum_title;
@@ -30,7 +30,7 @@ class TopicCreatedEvent extends AbstractEvent implements DiscordDispatchable {
     }
 
     public static function description(): string {
-        return (new Language())->get('admin', 'announcement_hook_info');
+        return (new Language(ROOT_PATH . '/modules/Forum/language'))->get('forum', 'new_topic');
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {
@@ -50,5 +50,9 @@ class TopicCreatedEvent extends AbstractEvent implements DiscordDispatchable {
                     ->setDescription(Text::embedSafe($this->content))
                     ->setUrl(URL::getSelfURL() . ltrim(URL::build('/forum/topic/' . urlencode($this->topic_id) . '-' . $forum->titleToURL($this->topic_title)), '/'));
             });
+    }
+
+    public function webhookParams(): array {
+        return [];
     }
 }

--- a/modules/Forum/classes/Events/TopicCreatedEvent.php
+++ b/modules/Forum/classes/Events/TopicCreatedEvent.php
@@ -34,6 +34,8 @@ class TopicCreatedEvent extends AbstractEvent implements HasWebhookParams, Disco
     }
 
     function webhookParams(): array {
+        $forum = new Forum();
+
         return [
             'user_id' => $this->creator->data()->id,
             'username' => $this->creator->getDisplayname(),

--- a/modules/Forum/classes/Events/TopicCreatedEvent.php
+++ b/modules/Forum/classes/Events/TopicCreatedEvent.php
@@ -33,7 +33,7 @@ class TopicCreatedEvent extends AbstractEvent implements DiscordDispatchable {
         return (new Language())->get('admin', 'announcement_hook_info');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language(ROOT_PATH . '/modules/Forum/language', DEFAULT_LANGUAGE);
         $forum = new Forum();
 

--- a/modules/Forum/classes/Events/TopicCreatedEvent.php
+++ b/modules/Forum/classes/Events/TopicCreatedEvent.php
@@ -33,7 +33,7 @@ class TopicCreatedEvent extends AbstractEvent implements HasWebhookParams, Disco
         return (new Language(ROOT_PATH . '/modules/Forum/language'))->get('forum', 'new_topic');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         $forum = new Forum();
 
         return [

--- a/modules/Forum/classes/Events/TopicCreatedEvent.php
+++ b/modules/Forum/classes/Events/TopicCreatedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class TopicCreatedEvent extends AbstractEvent implements DiscordDispatchable, HasWebhookParams {
+class TopicCreatedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $creator;
     public string $forum_title;
@@ -33,6 +33,22 @@ class TopicCreatedEvent extends AbstractEvent implements DiscordDispatchable, Ha
         return (new Language(ROOT_PATH . '/modules/Forum/language'))->get('forum', 'new_topic');
     }
 
+    function webhookParams(): array {
+        return [
+            'user_id' => $this->creator->data()->id,
+            'username' => $this->creator->getDisplayname(),
+            'forum' => [
+                'title' => $this->forum_title
+            ],
+            'topic' => [
+                'id' => $this->topic_id,
+                'title' => $this->topic_title
+            ],
+            'content' => $this->content,
+            'url' => URL::getSelfURL() . ltrim(URL::build('/forum/topic/' . urlencode($this->topic_id) . '-' . $forum->titleToURL($this->topic_title)), '/')
+        ];
+    }
+
     public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language(ROOT_PATH . '/modules/Forum/language', DEFAULT_LANGUAGE);
         $forum = new Forum();
@@ -50,9 +66,5 @@ class TopicCreatedEvent extends AbstractEvent implements DiscordDispatchable, Ha
                     ->setDescription(Text::embedSafe($this->content))
                     ->setUrl(URL::getSelfURL() . ltrim(URL::build('/forum/topic/' . urlencode($this->topic_id) . '-' . $forum->titleToURL($this->topic_title)), '/'));
             });
-    }
-
-    public function webhookParams(): array {
-        return [];
     }
 }

--- a/modules/Forum/classes/Events/TopicReplyCreatedEvent.php
+++ b/modules/Forum/classes/Events/TopicReplyCreatedEvent.php
@@ -30,7 +30,7 @@ class TopicReplyCreatedEvent extends AbstractEvent implements HasWebhookParams, 
         return (new Language(ROOT_PATH . '/modules/Forum/language'))->get('forum', 'topic_reply');
     }
 
-    function webhookParams(): array {
+    public function webhookParams(): array {
         $forum = new Forum();
 
         return [

--- a/modules/Forum/classes/Events/TopicReplyCreatedEvent.php
+++ b/modules/Forum/classes/Events/TopicReplyCreatedEvent.php
@@ -30,7 +30,7 @@ class TopicReplyCreatedEvent extends AbstractEvent implements DiscordDispatchabl
         return (new Language(ROOT_PATH . '/modules/Forum/language'))->get('forum', 'topic_reply');
     }
 
-    public function toDiscordWebook(): DiscordWebhookBuilder {
+    public function toDiscordWebhook(): DiscordWebhookBuilder {
         $language = new Language(ROOT_PATH . '/modules/Forum/language', DEFAULT_LANGUAGE);
         $forum = new Forum();
 

--- a/modules/Forum/classes/Events/TopicReplyCreatedEvent.php
+++ b/modules/Forum/classes/Events/TopicReplyCreatedEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-class TopicReplyCreatedEvent extends AbstractEvent implements DiscordDispatchable {
+class TopicReplyCreatedEvent extends AbstractEvent implements HasWebhookParams, DiscordDispatchable {
 
     public User $creator;
     public string $topic_title;
@@ -28,6 +28,19 @@ class TopicReplyCreatedEvent extends AbstractEvent implements DiscordDispatchabl
 
     public static function description(): string {
         return (new Language(ROOT_PATH . '/modules/Forum/language'))->get('forum', 'topic_reply');
+    }
+
+    function webhookParams(): array {
+        return [
+            'user_id' => $this->creator->data()->id,
+            'username' => $this->creator->getDisplayname(),
+            'topic' => [
+                'id' => $this->topic_id,
+                'title' => $this->topic_title
+            ],
+            'content' => $this->content,
+            'url' => URL::getSelfURL() . ltrim(URL::build('/forum/topic/' . urlencode($this->topic_id) . '-' . $forum->titleToURL($this->topic_title)), '/')
+        ];
     }
 
     public function toDiscordWebhook(): DiscordWebhookBuilder {

--- a/modules/Forum/classes/Events/TopicReplyCreatedEvent.php
+++ b/modules/Forum/classes/Events/TopicReplyCreatedEvent.php
@@ -31,6 +31,8 @@ class TopicReplyCreatedEvent extends AbstractEvent implements HasWebhookParams, 
     }
 
     function webhookParams(): array {
+        $forum = new Forum();
+
         return [
             'user_id' => $this->creator->data()->id,
             'username' => $this->creator->getDisplayname(),

--- a/modules/Forum/language/en_UK.json
+++ b/modules/Forum/language/en_UK.json
@@ -103,7 +103,6 @@
     "forum/new_reply_in_topic": "{{author}} has replied to topic {{topic}}",
     "forum/new_search": "New Search",
     "forum/new_topic": "New Topic",
-    "forum/new_topic_hook_info": "New topic",
     "forum/new_topic_text": "Topic created in {{forum}} by {{author}}",
     "forum/no_forums": "No forums",
     "forum/no_label_types_defined": "No label types have been defined yet.",

--- a/modules/Forum/pages/forum/new_topic.php
+++ b/modules/Forum/pages/forum/new_topic.php
@@ -2,7 +2,7 @@
 /*
  *  Made by Samerton
  *  https://github.com/NamelessMC/Nameless/
- *  NamelessMC version 2.0.0-pr13
+ *  NamelessMC version 2.1.0
  *
  *  License: MIT
  *
@@ -201,7 +201,7 @@ if (Input::exists()) {
 
                 // Execute hooks and pass $available_hooks
                 $available_hooks = DB::getInstance()->get('forums', ['id', $fid])->first();
-                $available_hooks = json_decode($available_hooks->hooks);
+                $available_hooks = json_decode($available_hooks->hooks) ?? [];
                 EventHandler::executeEvent(new TopicCreatedEvent(
                     $user,
                     $forum_title,

--- a/modules/Forum/pages/forum/view_topic.php
+++ b/modules/Forum/pages/forum/view_topic.php
@@ -2,7 +2,7 @@
 /*
  *  Made by Samerton
  *  https://github.com/NamelessMC/Nameless/
- *  NamelessMC version 2.0.0-pr13
+ *  NamelessMC version 2.1.0
  *
  *  License: MIT
  *
@@ -297,7 +297,7 @@ if (Input::exists()) {
             // Execute hooks and pass $available_hooks
             // TODO: This gets hooks only for this specific forum, not any of its parents...
             $available_hooks = DB::getInstance()->get('forums', ['id', $topic->forum_id])->first();
-            $available_hooks = json_decode($available_hooks->hooks);
+            $available_hooks = json_decode($available_hooks->hooks) ?? [];
             EventHandler::executeEvent(new TopicReplyCreatedEvent(
                 $user,
                 $topic->topic_title,


### PR DESCRIPTION
*Alongside https://github.com/NamelessMC/Nameless/pull/3226*

Allows events to set specific params to send when being transformed into a JSON object for webhooks.
This is useful for when events contain some params which are objects/classes, since they cannot be nicely formatted into JSON.

For example, if we want to be able to pass the users ID to a webhook when the `userRegistered` event is fired:
```php
class UserRegisteredEvent implements HasWebhookParams {
  public User $user;

  function __construct(User $user) {
    $this->user = $user;
  }

  function webhookParams(): array {
    return [
      'user_id' => $this->user->data()->id
    ];
  }
}
```

When previously this would have instead returned something like:
```php
['user' => User object]
```