### PR TITLE
Fix member module issues

### DIFF
--- a/core/classes/Database/DatabaseInitialiser.php
+++ b/core/classes/Database/DatabaseInitialiser.php
@@ -32,7 +32,6 @@ class DatabaseInitialiser {
             'name' => 'Member',
             'group_html' => '<span class="badge badge-success">Member</span>',
             'permissions' => '{"usercp.messaging":1,"usercp.signature":1,"usercp.nickname":1,"usercp.private_profile":1,"usercp.profile_banner":1}',
-            'default_group' => true,
             'order' => 3
         ]);
 
@@ -61,6 +60,7 @@ class DatabaseInitialiser {
             'group_html' => '<span class="badge badge-secondary">Unconfirmed Member</span>',
             'group_username_color' => '#6c757d',
             'permissions' => '{}',
+            'default_group' => true,
             'order' => 4
         ]);
 

--- a/custom/panel_templates/Default/members/member_lists.tpl
+++ b/custom/panel_templates/Default/members/member_lists.tpl
@@ -25,6 +25,7 @@
                     <h1 class="h3 mb-0 text-gray-800">{$MEMBER_LISTS}</h1>
                     <ol class="breadcrumb float-sm-right">
                         <li class="breadcrumb-item"><a href="{$PANEL_INDEX}">{$DASHBOARD}</a></li>
+                        <li class="breadcrumb-item active">{$MEMBERS}</li>
                         <li class="breadcrumb-item active">{$MEMBER_LISTS}</li>
                     </ol>
                 </div>

--- a/modules/Core/classes/Misc/RegisteredMembersListProvider.php
+++ b/modules/Core/classes/Misc/RegisteredMembersListProvider.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Registered members member list provider
  *

--- a/modules/Members/classes/MemberListProvider.php
+++ b/modules/Members/classes/MemberListProvider.php
@@ -168,16 +168,15 @@ abstract class MemberListProvider {
             return [];
         }
 
-        $bans = DB::getInstance()->query("SELECT id, isbanned FROM nl2_users WHERE id IN ($ids)")->results();
-
-        return array_filter($rows, static function ($row) use ($bans, $id_column) {
-            foreach ($bans as $ban) {
-                if ($ban->id == $row->{$id_column}) {
-                    return $ban->isbanned == 1;
+        $banned_users = DB::getInstance()->query("SELECT id, isbanned FROM nl2_users WHERE id IN ($ids) AND isbanned = 1")->results();
+        return array_filter($rows, static function ($row) use ($banned_users, $id_column) {
+            foreach ($banned_users as $banned_user) {
+                if ($banned_user->id == $row->{$id_column}) {
+                    return false;
                 }
             }
 
-            return false;
+            return true;
         });
     }
 }

--- a/modules/Members/pages/members.php
+++ b/modules/Members/pages/members.php
@@ -40,7 +40,12 @@ if (isset($_GET['group'])) {
 }
 
 $new_members = [];
-foreach (DB::getInstance()->query('SELECT id FROM nl2_users ORDER BY joined DESC LIMIT 12')->results() as $new_member) {
+if (Util::getSetting('member_list_hide_banned', false, 'Members')) {
+    $query = DB::getInstance()->query('SELECT id FROM nl2_users WHERE isbanned = 0 ORDER BY joined DESC LIMIT 12');
+} else {
+    $query = DB::getInstance()->query('SELECT id FROM nl2_users ORDER BY joined DESC LIMIT 12');
+}
+foreach ($query->results() as $new_member) {
     $new_members[] = new User($new_member->id);
 }
 

--- a/modules/Members/pages/panel/member_lists.php
+++ b/modules/Members/pages/panel/member_lists.php
@@ -6,8 +6,8 @@ if (!$user->handlePanelPageLoad('admincp.members')) {
 }
 
 const PAGE = 'panel';
-const PARENT_PAGE = 'core_configuration';
-const PANEL_PAGE = 'member_lists';
+const PARENT_PAGE = 'members';
+const PANEL_PAGE = 'member_lists_settings';
 
 $page_title = $members_language->get('members', 'member_lists');
 require_once(ROOT_PATH . '/core/templates/backend_init.php');
@@ -24,7 +24,7 @@ if (Input::exists()) {
             'list' => $list->getFriendlyName(),
         ]));
 
-        Redirect::to(URL::build('/panel/core/member_lists'));
+        Redirect::to(URL::build('/panel/members/member_lists'));
     } else {
         Session::flash('admin_member_lists_error', $language->get('general', 'invalid_token'));
     }
@@ -32,14 +32,14 @@ if (Input::exists()) {
 
 if (Session::exists('admin_member_lists_error')) {
     $smarty->assign([
-        'ERRORS' => Session::flash('admin_member_list_error'),
+        'ERRORS' => [Session::flash('admin_member_lists_error')],
         'ERRORS_TITLE' => $language->get('general', 'error'),
     ]);
 }
 
 if (Session::exists('admin_member_lists_success')) {
     $smarty->assign([
-        'SUCCESS' => Session::flash('admin_member_list_success'),
+        'SUCCESS' => Session::flash('admin_member_lists_success'),
         'SUCCESS_TITLE' => $language->get('general', 'success'),
     ]);
 }
@@ -47,6 +47,7 @@ if (Session::exists('admin_member_lists_success')) {
 $smarty->assign([
     'PARENT_PAGE' => PARENT_PAGE,
     'DASHBOARD' => $language->get('admin', 'dashboard'),
+    'MEMBERS' => $members_language->get('members', 'members'),
     'MEMBER_LISTS' => $members_language->get('members', 'member_lists'),
     'PAGE' => PANEL_PAGE,
     'MEMBER_LISTS_VALUES' => MemberListManager::getInstance()->allLists(),

--- a/modules/Members/pages/panel/settings.php
+++ b/modules/Members/pages/panel/settings.php
@@ -6,8 +6,9 @@ if (!$user->handlePanelPageLoad('admincp.members')) {
 }
 
 const PAGE = 'panel';
-const PARENT_PAGE = 'member_lists';
+const PARENT_PAGE = 'members';
 const PANEL_PAGE = 'members_settings';
+
 $page_title = $members_language->get('members', 'members');
 require_once(ROOT_PATH . '/core/templates/backend_init.php');
 
@@ -88,7 +89,7 @@ $smarty->assign([
     'HIDE_BANNED_USERS_VALUE' => Util::getSetting('member_list_hide_banned', false, 'Members'),
     'GROUPS' => $members_language->get('members', 'viewable_groups'),
     'GROUPS_ARRAY' => $group_array,
-    'GROUPS_VALUE' => json_decode(Util::getSetting('member_list_viewable_groups', '{}', 'Members'), true),
+    'GROUPS_VALUE' => json_decode(Util::getSetting('member_list_viewable_groups', '{}', 'Members'), true) ?: [],
     'NO_ITEM_SELECTED' => $language->get('admin', 'no_item_selected'),
     'PAGE' => PANEL_PAGE,
     'TOKEN' => Token::get(),


### PR DESCRIPTION
Fixes:
- Enable/disable list is redirecting to /core/members
- Removing all groups from listed groups breaks the page <in_array(): Argument # 2 ($haystack) must be of type array, string given>
- Hide banned members reversed