### PR TITLE
Fix recursive group add

### DIFF
--- a/core/classes/Core/User.php
+++ b/core/classes/Core/User.php
@@ -130,7 +130,7 @@ class User {
      * @return bool True on success, false if they already have it.
      */
     public function addGroup(int $group_id, int $expire = 0): bool {
-        if (array_key_exists($group_id, $this->getGroups())) {
+        if (array_key_exists($group_id, $this->_groups ?? [])) {
             return false;
         }
 


### PR DESCRIPTION
During the installer, when groups were trying to get added to the admin account, the code would try to get all the groups of the user to check if it already had it. Because the user had no role yet at all, it tried to add the group with id 1 to the user, which in term tried to check the user their groups... This caused an infinite loop which ended up in the process running out of memory.

This PR fixes it by just using the local _groups variable and falling back to an empty array if its not yet assigned.