### PR TITLE
Better handling of closures in exception frames

### DIFF
--- a/core/classes/Misc/ErrorHandler.php
+++ b/core/classes/Misc/ErrorHandler.php
@@ -100,6 +100,13 @@ class ErrorHandler {
                         continue;
                     }
 
+                    // Skip frame if it is a closure
+                    // @phpstan-ignore-next-line (it does not know that $frame['function'] is valid)
+                    if (isset($frame['function']) && $frame['function'] === '{closure}') {
+                        ++$skip_frames;
+                        continue;
+                    }
+
                     $frames[] = self::parseFrame($exception, $frame['file'], $frame['line'], $i);
                     $i--;
                 }


### PR DESCRIPTION
Finally fixes the rare, but very annoying "TypeError: parameter #2 of `parseFrame` must be string, null passed" 😄 