### PR TITLE
Allow correct webhook action types in endpoint

### DIFF
--- a/modules/Core/includes/endpoints/CreateWebhooksEndpoint.php
+++ b/modules/Core/includes/endpoints/CreateWebhooksEndpoint.php
@@ -49,7 +49,7 @@ class CreateWebhooksEndpoint extends KeyAuthEndpoint {
         $type = $_POST['type'];
         $events = $_POST['events'];
 
-        if (!in_array($type, ['normal', 'discord'])) {
+        if (!in_array($type, ['1', '2'])) {
             $api->throwError(CoreApiErrors::ERROR_WEBHOOK_INVALID_TYPE);
         }
 


### PR DESCRIPTION
The webhook types are numbers (1 = normal, 2 = discord) but these types were not accepted in the createwebhook endpoint. This fixes that