### PR TITLE
Fix missing event in regular webhook

### DIFF
--- a/modules/Core/hooks/WebHook.php
+++ b/modules/Core/hooks/WebHook.php
@@ -12,6 +12,9 @@ class WebHook implements WebhookDispatcher {
     public static function execute($event, string $webhook_url = ''): void {
         if ($event instanceof HasWebhookParams) {
             $params = $event->webhookParams();
+            if (!isset($params['event'])) {
+                $params['event'] = $event::name();
+            }
         } else if ($event instanceof AbstractEvent) {
             ErrorHandler::logWarning('Event ' . $event::name() . ' does not implement HasWebhookParams, using `params()` instead');
             $params = $event->params();
@@ -24,6 +27,7 @@ class WebHook implements WebhookDispatcher {
             : $params['webhook'];
 
         $return = $params;
+
         unset($return['webhook']);
 
         $json = json_encode($return, JSON_UNESCAPED_SLASHES);

--- a/modules/Core/hooks/WebHook.php
+++ b/modules/Core/hooks/WebHook.php
@@ -27,7 +27,6 @@ class WebHook implements WebhookDispatcher {
             : $params['webhook'];
 
         $return = $params;
-
         unset($return['webhook']);
 
         $json = json_encode($return, JSON_UNESCAPED_SLASHES);

--- a/modules/Core/includes/endpoints/CreateWebhooksEndpoint.php
+++ b/modules/Core/includes/endpoints/CreateWebhooksEndpoint.php
@@ -49,7 +49,7 @@ class CreateWebhooksEndpoint extends KeyAuthEndpoint {
         $type = $_POST['type'];
         $events = $_POST['events'];
 
-        if (!in_array($type, ['normal', 'discord'])) {
+        if (!in_array($type, ['1', '2'])) {
             $api->throwError(CoreApiErrors::ERROR_WEBHOOK_INVALID_TYPE);
         }
 


### PR DESCRIPTION
In the old system, normal webhooks included the event the data was from. This was removed in the event system overhaul though because of this, my discord bots do not know what event the data is actually from that it's receiving. 

This just adds that missing param back.