### PR TITLE
Fix default user template setting

### DIFF
--- a/custom/templates/DefaultRevamp/user/settings.tpl
+++ b/custom/templates/DefaultRevamp/user/settings.tpl
@@ -111,7 +111,7 @@
                             {/foreach}
                         </select>
                     </div>
-                    {if count($TEMPLATES) > 1}
+                    {if count($TEMPLATES) > 2}
                     <div class="field">
                         <label for="inputTemplate">{$ACTIVE_TEMPLATE}</label>
                         <select class="ui fluid dropdown" name="template" id="inputTemplate">

--- a/modules/Core/pages/panel/users_edit.php
+++ b/modules/Core/pages/panel/users_edit.php
@@ -2,7 +2,7 @@
 /*
  *  Made by Samerton
  *  https://github.com/NamelessMC/Nameless/
- *  NamelessMC version 2.0.0-pr13
+ *  NamelessMC version 2.1.0
  *
  *  License: MIT
  *
@@ -147,12 +147,16 @@ if (Input::exists()) {
                     }
 
                     // Template
-                    $new_template = DB::getInstance()->get('templates', ['id', Input::get('template')])->results();
+                    if (Input::get('template') != 0) {
+                        $new_template = DB::getInstance()->get('templates', ['id', Input::get('template')])->results();
 
-                    if (count($new_template)) {
-                        $new_template = $new_template[0]->id;
+                        if (count($new_template)) {
+                            $new_template = $new_template[0]->id;
+                        } else {
+                            $new_template = $user_query->theme_id;
+                        }
                     } else {
-                        $new_template = $user_query->theme_id;
+                        $new_template = null;
                     }
 
                     // Nicknames?
@@ -321,8 +325,13 @@ if ($user_query->id == 1 || ($user_query->id == $user->data()->id && !$user->has
 $private_profile = Util::getSetting('private_profile');
 
 $templates = [];
-$templates_query = DB::getInstance()->get('templates', ['id', '<>', 0])->results();
+$templates_query = DB::getInstance()->get('templates', ['enabled', 1])->results();
 
+$templates[] = [
+    'id' => 0,
+    'name' => $language->get('general', 'default'),
+    'active' => $user_query->theme_id === null
+];
 foreach ($templates_query as $item) {
     $templates[] = [
         'id' => Output::getClean($item->id),

--- a/modules/Core/pages/user/settings.php
+++ b/modules/Core/pages/user/settings.php
@@ -2,7 +2,7 @@
 /*
  *  Made by Samerton
  *  https://github.com/NamelessMC/Nameless/
- *  NamelessMC version 2.0.2
+ *  NamelessMC version 2.1.0
  *
  *  License: MIT
  *
@@ -229,12 +229,17 @@ if (isset($_GET['do'])) {
                             $new_language = $user->data()->language_id;
                         }
 
-                        $new_template = DB::getInstance()->get('templates', ['id', Input::get('template')])->results();
+                        // Template
+                        if (Input::get('template') != 0) {
+                            $new_template = DB::getInstance()->get('templates', ['id', Input::get('template')])->results();
 
-                        if (count($new_template)) {
-                            $new_template = $new_template[0]->id;
+                            if (count($new_template)) {
+                                $new_template = $new_template[0]->id;
+                            } else {
+                                $new_template = $user_query->theme_id;
+                            }
                         } else {
-                            $new_template = $user->data()->theme_id;
+                            $new_template = null;
                         }
 
                         // Check permissions
@@ -479,6 +484,11 @@ if (isset($_GET['do'])) {
     $templates = [];
     $templates_query = $user->getUserTemplates();
 
+    $templates[] = [
+        'id' => 0,
+        'name' => $language->get('general', 'default'),
+        'active' => $user->data()->theme_id === null
+    ];
     foreach ($templates_query as $item) {
         $templates[] = [
             'id' => Output::getClean($item->id),


### PR DESCRIPTION
In 2.1.0 the theme setting broke that it save the default template id when user wanna use site default

But instead of reverting to check if template id match site default, i made a new own option to use Default