### PR TITLE
Remove unable to update groups catch

### DIFF
--- a/modules/Core/classes/Misc/CoreApiErrors.php
+++ b/modules/Core/classes/Misc/CoreApiErrors.php
@@ -36,7 +36,6 @@ class CoreApiErrors {
     public const ERROR_USER_ALREADY_ACTIVE = 'core:user_already_active';
 
     public const ERROR_UNABLE_TO_UPDATE_USERNAME = 'core:unable_to_update_username';
-    public const ERROR_UNABLE_TO_UPDATE_GROUPS = 'core:unable_to_update_groups';
 
     public const ERROR_INTEGRATION_IDENTIFIER_ERRORS = 'core:integration_identifier_errors';
     public const ERROR_INTEGRATION_USERNAME_ERRORS = 'core:integration_username_errors';

--- a/modules/Core/includes/endpoints/UpdateGroupsEndpoint.php
+++ b/modules/Core/includes/endpoints/UpdateGroupsEndpoint.php
@@ -16,20 +16,16 @@ class UpdateGroupsEndpoint extends KeyAuthEndpoint {
         $group_sync_log = [];
 
         if (Util::getSetting('mc_integration') && $server_id == Util::getSetting('group_sync_mc_server')) {
-            try {
-                $integration = Integrations::getInstance()->getIntegration('Minecraft');
+            $integration = Integrations::getInstance()->getIntegration('Minecraft');
 
-                foreach ($_POST['player_groups'] as $uuid => $groups) {
-                    $integrationUser = new IntegrationUser($integration, str_replace('-', '', $uuid), 'identifier');
-                    if ($integrationUser->exists()) {
-                        $log = $this->updateGroups($integrationUser, $groups['groups']);
-                        if (count($log)) {
-                            $group_sync_log[] = $log;
-                        }
+            foreach ($_POST['player_groups'] as $uuid => $groups) {
+                $integrationUser = new IntegrationUser($integration, str_replace('-', '', $uuid), 'identifier');
+                if ($integrationUser->exists()) {
+                    $log = $this->updateGroups($integrationUser, $groups['groups']);
+                    if (count($log)) {
+                        $group_sync_log[] = $log;
                     }
                 }
-            } catch (Exception $e) {
-                $api->throwError(CoreApiErrors::ERROR_UNABLE_TO_UPDATE_GROUPS, $e->getMessage(), 500);
             }
 
             $api->returnArray(array_merge(['message' => $api->getLanguage()->get('api', 'groups_updates_successfully')], ['log' => $group_sync_log]));


### PR DESCRIPTION
Catching all exceptions and returning a custom 500 error doesn't seem to improve API usability, and it hides valuable debug info. If the API returns a stack trace, the plugin will show it to the user making bug reports easier.