### PR TITLE
Readd deleted term + fix discord oauth link success message

### DIFF
--- a/custom/languages/en_UK.json
+++ b/custom/languages/en_UK.json
@@ -1181,6 +1181,7 @@
     "user/incorrect_password": "Your password is incorrect.",
     "user/integration_identifier_already_linked": "{{integration}} identifier is already linked to another user.",
     "user/integration_required_to_continue": "Please connect and verify the required connections before continuing to use this website.",
+    "user/integration_linked": "You have successfully linked your {{integration}} account.",
     "user/integration_unlinked": "You have successfully unlinked your {{integration}} account.",
     "user/integration_username_already_linked": "{{integration}} username is already linked to another user.",
     "user/invalid_email": "Your email is invalid.",

--- a/modules/Discord Integration/classes/DiscordIntegration.php
+++ b/modules/Discord Integration/classes/DiscordIntegration.php
@@ -75,6 +75,7 @@ class DiscordIntegration extends IntegrationBase {
         }, $user->getAllGroupIds()));
 
         Discord::updateDiscordRoles($user, $roles, []);
+        Session::flash('connections_success', $this->_language->get('user', 'integration_linked', ['integration' => Output::getClean($this->_name)]));
     }
 
     public function validateUsername(string $username, int $integration_user_id = 0): bool {


### PR DESCRIPTION
Re-add deleted term used by other modules & fixing discord oauth link showing no success message