### PR TITLE
Fix single/double quote not working within member list username CSS

### DIFF
--- a/custom/templates/DefaultRevamp/members/members.tpl
+++ b/custom/templates/DefaultRevamp/members/members.tpl
@@ -167,7 +167,7 @@
                     {/if}
 
                     const nameDiv = document.createElement('span');
-                    nameDiv.style = member.group_style;
+                    nameDiv.style = member.group_style?.replace('&#039;', "'")?.replace('&quot;', '"');
                     {if $VIEWING_LIST != "overview"}
                         nameDiv.innerHTML = member.username + '&nbsp;' + member.group_html.join('');
                     {else}


### PR DESCRIPTION
If group username CSS includes a single quote `'` or double quote `"` it will be escaped meaning the CSS will not work correctly within a member list