### PR TITLE
Ignore group sync request instead of returning error

### DIFF
--- a/custom/languages/en_UK.json
+++ b/custom/languages/en_UK.json
@@ -757,6 +757,7 @@
     "api/finish_registration_link": "Please click on the following link to complete registration:",
     "api/group_updated": "Group updated successfully",
     "api/groups_updates_successfully": "Groups updated successfully",
+    "api/groups_updates_ignored": "Group sync request ignored, because the Minecraft integration is disabled or the server is not configured as the group sync server in StaffCP.",
     "api/integration_identifier_already_linked": "{{integration}} identifier is already linked to another user.",
     "api/integration_username_already_linked": "{{integration}} username is already linked to another user.",
     "api/report_created": "Report created successfully",

--- a/modules/Core/includes/endpoints/UpdateGroupsEndpoint.php
+++ b/modules/Core/includes/endpoints/UpdateGroupsEndpoint.php
@@ -14,7 +14,7 @@ class UpdateGroupsEndpoint extends KeyAuthEndpoint {
 
         $server_id = $_POST['server_id'];
 
-        if (!Settings::get('mc_integration') && $server_id != Settings::get('group_sync_mc_server')) {
+        if (!Settings::get('mc_integration') || $server_id != Settings::get('group_sync_mc_server')) {
             $api->returnArray(['message' => $api->getLanguage()->get('api', 'groups_updates_ignored')]);
             return;
         }

--- a/modules/Core/includes/endpoints/UpdateGroupsEndpoint.php
+++ b/modules/Core/includes/endpoints/UpdateGroupsEndpoint.php
@@ -16,7 +16,6 @@ class UpdateGroupsEndpoint extends KeyAuthEndpoint {
 
         if (!Settings::get('mc_integration') || $server_id != Settings::get('group_sync_mc_server')) {
             $api->returnArray(['message' => $api->getLanguage()->get('api', 'groups_updates_ignored')]);
-            return;
         }
 
         $group_sync_log = [];

--- a/modules/Core/includes/endpoints/UpdateGroupsEndpoint.php
+++ b/modules/Core/includes/endpoints/UpdateGroupsEndpoint.php
@@ -13,25 +13,29 @@ class UpdateGroupsEndpoint extends KeyAuthEndpoint {
         $api->validateParams($_POST, ['server_id', 'player_groups']);
 
         $server_id = $_POST['server_id'];
-        $group_sync_log = [];
 
-        if (Settings::get('mc_integration') && $server_id == Settings::get('group_sync_mc_server')) {
-            $integration = Integrations::getInstance()->getIntegration('Minecraft');
-
-            foreach ($_POST['player_groups'] as $uuid => $groups) {
-                $integrationUser = new IntegrationUser($integration, str_replace('-', '', $uuid), 'identifier');
-                if ($integrationUser->exists()) {
-                    $log = $this->updateGroups($integrationUser, $groups['groups']);
-                    if (count($log)) {
-                        $group_sync_log[] = $log;
-                    }
-                }
-            }
-
-            $api->returnArray(array_merge(['message' => $api->getLanguage()->get('api', 'groups_updates_successfully')], ['log' => $group_sync_log]));
+        if (!Settings::get('mc_integration') && $server_id != Settings::get('group_sync_mc_server')) {
+            $api->returnArray(['message' => $api->getLanguage()->get('api', 'groups_updates_ignored')]);
+            return;
         }
 
-        $api->throwError(CoreApiErrors::ERROR_INVALID_SERVER_ID, $server_id);
+        $group_sync_log = [];
+        $integration = Integrations::getInstance()->getIntegration('Minecraft');
+
+        foreach ($_POST['player_groups'] as $uuid => $groups) {
+            $integrationUser = new IntegrationUser($integration, str_replace('-', '', $uuid), 'identifier');
+            if ($integrationUser->exists()) {
+                $log = $this->updateGroups($integrationUser, $groups['groups']);
+                if (count($log)) {
+                    $group_sync_log[] = $log;
+                }
+            }
+        }
+
+        $api->returnArray([
+            'message' => $api->getLanguage()->get('api', 'groups_updates_successfully'),
+            'log' => $group_sync_log,
+        ]);
     }
 
     private function updateGroups(IntegrationUser $integrationUser, array $groups): array {


### PR DESCRIPTION
When NamelessMC received a group sync request while the Minecraft integration was disabled, or if it received the request from a different server than the selected group sync server, Nameless returned an API error.

I think "invalid server id" is not really an appropriate error for this situation, and simply ignoring the request would be a better user experience.

Example user confusion:
![image](https://github.com/NamelessMC/Nameless/assets/15892014/7914e708-f1d3-4c3e-9a05-2e6c64c98ef8)
