### PR TITLE
Prevent directory traversal using language parameter

### DIFF
--- a/install.php
+++ b/install.php
@@ -56,6 +56,9 @@ if (Config::exists() && Config::get('core.installed') === true) {
 }
 
 if (isset($_GET['language'])) {
+    if (str_contains($_GET['language'], '/')) {
+        die('Language code must not contain slash');
+    }
     // Set language
     if (is_file('custom/languages/' . $_GET['language'] . '.json')) {
         $_SESSION['installer_language'] = $_GET['language'];


### PR DESCRIPTION
Fixes a very minor security issue, where in the installer anyone could check whether arbitrary json files exist on the system.