### PR TITLE
Fix flag spammer not always updating last post correctly

### DIFF
--- a/modules/Forum/pages/forum/spam.php
+++ b/modules/Forum/pages/forum/spam.php
@@ -49,10 +49,13 @@ if ($forum->canModerateForum($post->forum_id, $user->getAllGroupIds())) {
         }
 
         // First get any forums where this user is the last user who posted
-        $latest_forums = [];
+        $latest_forums = [$post->forum_id];
         $latest_forums_query = DB::getInstance()->query('SELECT `id` FROM nl2_forums WHERE `last_user_posted` = ?', [$banned_user->data()->id]);
         if ($latest_forums_query->count()) {
             $latest_forums = array_map(fn($latest_forum) => $latest_forum->id, $latest_forums_query->results());
+            if (!in_array($post->forum_id, $latest_forums)) {
+                $latest_forums[] = $post->forum_id;
+            }
         }
 
         // Now get any topics where this user is the last user who posted


### PR DESCRIPTION
If, for example, the first post in a topic is marked as spam, but there are subsequent replies that are not marked as spam, the latest posts in the forum will not always be updated correctly leading to the forum index reporting that there are no topics or posts in that forum