### PR TITLE
Fix server status error if MOTD format contains string instead of array

### DIFF
--- a/core/classes/Minecraft/MCQuery.php
+++ b/core/classes/Minecraft/MCQuery.php
@@ -377,6 +377,10 @@ class MCQuery
 
         $motd = '';
         foreach ($modern_format as $word) {
+            if (!is_array($word)) {
+                continue;
+            }
+
             $motd .= self::COLOUR_CHAR . 'r';
             if (isset($word['color'])) {
                 $motd .= self::getColor($word['color']);


### PR DESCRIPTION
Quick fix, seems that MOTDs can include strings and arrays so we just ignore the strings as so far they appear to be empty and do not add any value to the MOTD parsing