### PR TITLE
Allow store module bypass maintenance

### DIFF
--- a/core/init.php
+++ b/core/init.php
@@ -476,6 +476,7 @@ if ($page != 'install') {
                 || str_contains($_GET['route'], '/api/')
                 || str_contains($_GET['route'], 'queries')
                 || str_contains($_GET['route'], 'oauth/')
+                || str_contains($_GET['route'], 'store/listener')
             )) {
                 // Can continue as normal
             } else {


### PR DESCRIPTION
Allow Store module listener to bypass maintenance mode

Temporary fix until we get a better system to whitelist pages to bypass maintenance, Many people testing their store in maintenance mode but the listeners don't work when its in maintenance mode