### PR TITLE
Fix array for not start with validation

### DIFF
--- a/core/classes/Core/Validate.php
+++ b/core/classes/Core/Validate.php
@@ -364,8 +364,8 @@ class Validate
                                     'rule' => self::NOT_START_WITH,
                                     'fallback' => "$item must not start with $denied_value.",
                                 ]);
+                                break;
                             }
-                            break;
                         }
                         break;
 


### PR DESCRIPTION
The foreach being breaked after the first check, It should only break when result is found