### PR TITLE
Add user account settings to available announcement pages

### DIFF
--- a/modules/Core/module.php
+++ b/modules/Core/module.php
@@ -63,14 +63,14 @@ class Core_Module extends Module {
         }
         $pages->add('Core', '/oauth', 'pages/oauth.php');
 
-        $pages->add('Core', '/user', 'pages/user/index.php');
-        $pages->add('Core', '/user/settings', 'pages/user/settings.php');
-        $pages->add('Core', '/user/messaging', 'pages/user/messaging.php');
-        $pages->add('Core', '/user/alerts', 'pages/user/alerts.php');
-        $pages->add('Core', '/user/notification_settings', 'pages/user/notification_settings.php');
-        $pages->add('Core', '/user/placeholders', 'pages/user/placeholders.php');
+        $pages->add('Core', '/user', 'pages/user/index.php', 'cc_overview');
+        $pages->add('Core', '/user/settings', 'pages/user/settings.php', 'cc_settings');
+        $pages->add('Core', '/user/messaging', 'pages/user/messaging.php', 'cc_messaging');
+        $pages->add('Core', '/user/alerts', 'pages/user/alerts.php', 'cc_alerts');
+        $pages->add('Core', '/user/notification_settings', 'pages/user/notification_settings.php', 'cc_notification_settings');
+        $pages->add('Core', '/user/placeholders', 'pages/user/placeholders.php', 'cc_placeholders');
         $pages->add('Core', '/user/acknowledge', 'pages/user/acknowledge.php');
-        $pages->add('Core', '/user/connections', 'pages/user/connections.php');
+        $pages->add('Core', '/user/connections', 'pages/user/connections.php', 'cc_connections');
 
         // Panel
         $pages->add('Core', '/panel', 'pages/panel/index.php');


### PR DESCRIPTION
Closes #3518 

Not an ideal solution as the page name is hardly user friendly, but until one of either announcements or pages are reworked, not sure what else we can do.

<img width="153" alt="Screenshot 2024-07-14 at 13 51 55" src="https://github.com/user-attachments/assets/d7384851-e299-4a35-b06a-cd2861904e8f">
