### PR TITLE
Fix missing report created term for alerts

### DIFF
--- a/modules/Core/language/en_UK.json
+++ b/modules/Core/language/en_UK.json
@@ -1083,6 +1083,7 @@
     "moderator/recent_registrations": "Recent Registrations",
     "moderator/recent_reports": "Recent Reports",
     "moderator/reopen_report": "Reopen report",
+    "moderator/report_alert": "New report created",
     "moderator/report_closed": "Report closed successfully.",
     "moderator/report_comment_invalid": "Invalid comment content. Please ensure you have entered a comment between 1 and 10,000 characters.",
     "moderator/report_reopened": "Report reopened successfully.",


### PR DESCRIPTION
Before/after

<img width="159" alt="Screenshot 2024-07-14 at 14 03 14" src="https://github.com/user-attachments/assets/8939593e-03ba-45f7-a2a4-2f8adf7bde08">
