### PR TITLE
 Add OAuth Displayname & Fixes

### DIFF
--- a/core/classes/Misc/NamelessOAuth.php
+++ b/core/classes/Misc/NamelessOAuth.php
@@ -179,7 +179,7 @@ class NamelessOAuth extends Instanceable
     {
         [$client_id, $client_secret] = $this->getCredentials($provider);
 
-        return $client_id !== '' && $client_secret !== '';
+        return $client_id !== null && $client_id !== '' && $client_secret !== '';
     }
 
     /**

--- a/core/classes/Misc/NamelessOAuth.php
+++ b/core/classes/Misc/NamelessOAuth.php
@@ -82,6 +82,7 @@ class NamelessOAuth extends Instanceable
                         'email',
                     ],
                 ]),
+                'display_name' => $provider_data['display_name'] ?? ucfirst($provider_name),
                 'icon' => $provider_data['icon'] ?? null,
                 'logo_url' => $provider_data['logo_url'] ?? null,
                 'logo_css' => isset($provider_data['logo_css'])

--- a/modules/Core/pages/login.php
+++ b/modules/Core/pages/login.php
@@ -265,7 +265,7 @@ foreach (NamelessOAuth::getInstance()->getProvidersAvailable() as $name => $prov
 
     $providers[$name] = $provider;
     $providers[$name]['log_in_with'] = $language->get('user', 'log_in_with', [
-        'provider' => ucfirst($name)
+        'provider' => Output::getClean($provider['display_name'])
     ]);
 }
 

--- a/modules/Core/pages/panel/integrations.php
+++ b/modules/Core/pages/panel/integrations.php
@@ -45,7 +45,7 @@ if (!isset($_GET['integration'])) {
             'name' => Output::getClean($integration->getName()),
             'icon' => Output::getClean($integration->getIcon()),
             'edit_link' => URL::build('/panel/core/integrations/', 'integration=' . $integration->getName()),
-            'enabled' => $integration->isEnabled(),
+            'enabled' => $integration->isEnabled() && $integration->allowLinking(),
             'can_unlink' => $integration->data()->can_unlink,
             'required' => $integration->data()->required,
         ];

--- a/modules/Core/pages/panel/integrations.php
+++ b/modules/Core/pages/panel/integrations.php
@@ -90,12 +90,13 @@ if (!isset($_GET['integration'])) {
 
                 $client_id = Input::get("client-id");
                 $client_secret = Input::get("client-secret");
+
+                NamelessOAuth::getInstance()->setCredentials($provider_name, $client_id, $client_secret);
                 if ($client_id && $client_secret) {
                     NamelessOAuth::getInstance()->setEnabled($provider_name, Input::get("enable") == 'on' ? 1 : 0);
                 } else {
                     NamelessOAuth::getInstance()->setEnabled($provider_name, 0);
                 }
-                NamelessOAuth::getInstance()->setCredentials($provider_name, $client_id, $client_secret);
 
                 Session::flash('integrations_success', $language->get('admin', 'integration_updated_successfully'));
                 Redirect::to(URL::build('/panel/core/integrations/', 'integration=' . $integration->getName()));

--- a/modules/Core/pages/register.php
+++ b/modules/Core/pages/register.php
@@ -404,7 +404,7 @@ foreach (NamelessOAuth::getInstance()->getProvidersAvailable() as $name => $prov
 
     $providers[$name] = $provider;
     $providers[$name]['continue_with'] = $language->get('user', 'continue_with', [
-        'provider' => ucfirst($name)
+        'provider' => Output::getClean($provider['display_name'])
     ]);
 }
 


### PR DESCRIPTION
Add ability to set Displayname, The current OAuth forcing lowercase name then it uppercase first but names such as NamelessMC and Minecraft Community will only the first letter be uppercase

Adding displayname fix this as its not a easy way to change existing name without alot of changes

Also fixes a bug where first time you setup OAuth it being instantly disabled even thought you selected to enable it