### PR TITLE
Don't hardcode oauth scopes

### DIFF
--- a/core/classes/Misc/NamelessOAuth.php
+++ b/core/classes/Misc/NamelessOAuth.php
@@ -77,7 +77,7 @@ class NamelessOAuth extends Instanceable
 
             $providers[$provider_name] = [
                 'url' => $provider->getAuthorizationUrl([
-                    'scope' => [
+                    'scope' => $provider_data['scopes'] ?? [
                         $provider_data['scope_id_name'],
                         'email',
                     ],


### PR DESCRIPTION
Don't hardcode oauth scopes, Such as email is forced for all but integrations such as twitch does not have that scope name when trying to auth it returns invalid scope

+ ability to add several scopes