### PR TITLE
Update phpdoc to fix CI builds

### DIFF
--- a/Dockerfile.phpdoc
+++ b/Dockerfile.phpdoc
@@ -1,4 +1,4 @@
-FROM phpdoc/phpdoc:3.4 as doc_builder
+FROM phpdoc/phpdoc:3.5 AS doc_builder
 
 COPY . /source
 


### PR DESCRIPTION
The phpdoc developers pushed an unstable development version to the :3.4 tag, breaking our CI builds. Updating to 3.5 fixes the issue. 