### PR TITLE
New group sync endpoints with separate add/remove lists

### DIFF
--- a/core/classes/Group_Sync/GroupSyncManager.php
+++ b/core/classes/Group_Sync/GroupSyncManager.php
@@ -373,34 +373,30 @@ final class GroupSyncManager extends Instanceable
         }
 
         foreach ($batched_changes as $injector_class => $data) {
-            $add = $data['add'];
-            $remove = $data['remove'];
-
             /** @var GroupSyncInjector&BatchableGroupSyncInjector $injector */
             $injector = $this->getInjectorByClass($injector_class);
             $injector_column = $injector->getColumnName();
 
-            if ($injector instanceof BatchableGroupSyncInjector) {
-                /** @var GroupSyncInjector&BatchableGroupSyncInjector $injector */
-                $batchable_injector = $injector;
-                if (count($add)) {
-                    $result = $injector->batchAddGroups($user, $add);
-                    if (is_array($result)) {
-                        foreach ($result as $res) {
-                            if ($res['status'] === 'added') {
-                                $logs['added'][] = "{$injector_column} -> {$res['group_id']}";
-                            }
+            $add = $data['add'];
+            $remove = $data['remove'];
+
+            if (count($add)) {
+                $result = $injector->batchAddGroups($user, $add);
+                if (is_array($result)) {
+                    foreach ($result as $res) {
+                        if ($res['status'] === 'added') {
+                            $logs['added'][] = "{$injector_column} -> {$res['group_id']}";
                         }
                     }
                 }
+            }
 
-                if (count($remove)) {
-                    $result = $injector->batchRemoveGroups($user, $remove);
-                    if (is_array($result)) {
-                        foreach ($result as $res) {
-                            if ($res['status'] === 'removed') {
-                                $logs['removed'][] = "{$injector_column} -> {$res['group_id']}";
-                            }
+            if (count($remove)) {
+                $result = $injector->batchRemoveGroups($user, $remove);
+                if (is_array($result)) {
+                    foreach ($result as $res) {
+                        if ($res['status'] === 'removed') {
+                            $logs['removed'][] = "{$injector_column} -> {$res['group_id']}";
                         }
                     }
                 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,9 @@
 # Reinstall:
 # docker compose exec php php -f dev/scripts/cli_install.php '--' '--iSwearIKnowWhatImDoing' '--reinstall'
 #
+# Run phpstan:
+# docker compose exec php vendor/bin/phpstan --configuration=dev/phpstan.neon
+#
 # Uninstall
 # docker compose down
 # rm -rf core/config.php cache/*

--- a/modules/Core/includes/endpoints/SyncMinecraftGroupsEndpoint.php
+++ b/modules/Core/includes/endpoints/SyncMinecraftGroupsEndpoint.php
@@ -3,14 +3,14 @@
 class SyncMinecraftGroupsEndpoint extends KeyAuthEndpoint {
 
     public function __construct() {
-        $this->_route = 'minecraft/sync-groups';
+        $this->_route = 'minecraft/{user}/sync-groups';
         $this->_module = 'Core';
         $this->_description = 'Update a users groups based on added or removed groups from the Minecraft server';
         $this->_method = 'POST';
     }
 
-    public function execute(Nameless2API $api): void {
-        $api->validateParams($_POST, ['server_id', 'user']);
+    public function execute(Nameless2API $api, User $user): void {
+        $api->validateParams($_POST, ['server_id']);
 
         $server_id = $_POST['server_id'];
         $integration = Integrations::getInstance()->getIntegration('Minecraft');
@@ -18,8 +18,6 @@ class SyncMinecraftGroupsEndpoint extends KeyAuthEndpoint {
         if (!$integration || $server_id != Settings::get('group_sync_mc_server')) {
             $api->returnArray(['message' => $api->getLanguage()->get('api', 'groups_updates_ignored')]);
         }
-
-        $user = $api->getUser('id', $_POST['user']);
 
         $log = GroupSyncManager::getInstance()->broadcastGroupChange(
             $user,

--- a/modules/Core/includes/endpoints/SyncMinecraftGroupsEndpoint.php
+++ b/modules/Core/includes/endpoints/SyncMinecraftGroupsEndpoint.php
@@ -1,0 +1,38 @@
+<?php
+
+class SyncMinecraftGroupsEndpoint extends KeyAuthEndpoint {
+
+    public function __construct() {
+        $this->_route = 'minecraft/sync-groups';
+        $this->_module = 'Core';
+        $this->_description = 'Update a users groups based on added or removed groups from the Minecraft server';
+        $this->_method = 'POST';
+    }
+
+    public function execute(Nameless2API $api): void {
+        $api->validateParams($_POST, ['server_id', 'user']);
+
+        $server_id = $_POST['server_id'];
+        $integration = Integrations::getInstance()->getIntegration('Minecraft');
+
+        if (!$integration || $server_id != Settings::get('group_sync_mc_server')) {
+            $api->returnArray(['message' => $api->getLanguage()->get('api', 'groups_updates_ignored')]);
+        }
+
+        $user = $api->getUser('id', $_POST['user']);
+
+        $log = GroupSyncManager::getInstance()->broadcastGroupChange(
+            $user,
+            MinecraftGroupSyncInjector::class,
+            $_POST['add'] ?? [],
+            $_POST['remove'] ?? [],
+        );
+
+        Log::getInstance()->log(Log::Action('mc_group_sync/role_set'), json_encode($log), $user->data()->id);
+
+        $api->returnArray([
+            'message' => $api->getLanguage()->get('api', 'groups_updates_successfully'),
+            'log' => $log,
+        ]);
+    }
+}

--- a/modules/Core/includes/endpoints/UpdateGroupsEndpoint.php
+++ b/modules/Core/includes/endpoints/UpdateGroupsEndpoint.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @deprecated SyncMinecraftGroupsEndpoint should be used instead
+ */
 class UpdateGroupsEndpoint extends KeyAuthEndpoint {
 
     public function __construct() {

--- a/modules/Discord Integration/includes/endpoints/SyncDiscordRolesEndpoint.php
+++ b/modules/Discord Integration/includes/endpoints/SyncDiscordRolesEndpoint.php
@@ -1,28 +1,20 @@
 <?php
 
-/**
- * @param int $user The NamelessMC user ID to edit
- * @param string $roles An array of Discord Role ID to give to the user
- *
- * @return string JSON Array
- */
 class SyncDiscordRolesEndpoint extends KeyAuthEndpoint {
 
     public function __construct() {
-        $this->_route = 'discord/sync-roles';
+        $this->_route = 'discord/{user}/sync-roles';
         $this->_module = 'Discord Integration';
         $this->_description = 'Set a NamelessMC user\'s according to the supplied Discord Role ID list';
         $this->_method = 'POST';
     }
 
-    public function execute(Nameless2API $api): void {
-        $api->validateParams($_POST, ['user']);
+    public function execute(Nameless2API $api, User $user): void {
+        $api->validateParams($_POST, []);
 
         if (!Discord::isBotSetup()) {
             $api->throwError(DiscordApiErrors::ERROR_DISCORD_INTEGRATION_DISABLED);
         }
-
-        $user = $api->getUser('id', $_POST['user']);
 
         $log_array = GroupSyncManager::getInstance()->broadcastGroupChange(
             $user,

--- a/modules/Discord Integration/includes/endpoints/SyncDiscordRolesEndpoint.php
+++ b/modules/Discord Integration/includes/endpoints/SyncDiscordRolesEndpoint.php
@@ -3,13 +3,13 @@
 /**
  * @param int $user The NamelessMC user ID to edit
  * @param string $roles An array of Discord Role ID to give to the user
- * @deprecated Use SyncDiscordRolesEndpoint instead
+ *
  * @return string JSON Array
  */
-class SetDiscordRolesEndpoint extends KeyAuthEndpoint {
+class SyncDiscordRolesEndpoint extends KeyAuthEndpoint {
 
     public function __construct() {
-        $this->_route = 'discord/set-roles';
+        $this->_route = 'discord/sync-roles';
         $this->_module = 'Discord Integration';
         $this->_description = 'Set a NamelessMC user\'s according to the supplied Discord Role ID list';
         $this->_method = 'POST';
@@ -24,10 +24,11 @@ class SetDiscordRolesEndpoint extends KeyAuthEndpoint {
 
         $user = $api->getUser('id', $_POST['user']);
 
-        $log_array = GroupSyncManager::getInstance()->broadcastChange(
+        $log_array = GroupSyncManager::getInstance()->broadcastGroupChange(
             $user,
             DiscordGroupSyncInjector::class,
-            $_POST['roles'] ?? []
+            $_POST['add'] ?? [],
+            $_POST['remove'] ?? []
         );
 
         if (count($log_array)) {


### PR DESCRIPTION
The current group sync system is based on an endpoint where the source (minecraft, discord) submits a list of current groups. I believe this is fundamentally flawed. The easiest to understand example of this is the first sync. What currently happens is, either Discord sends groups to the website or the website sends groups to Discord, whichever is first. One of the two sides decides, on the other side all previously set roles are lost.

See for example https://github.com/NamelessMC/Nameless-Link/issues/449, but this issue has also been brought up in Discord.

The website cannot distinguish between these two cases:
 - A group is not present in the request because it was removed -> The group should be removed
 - A group is not present in the request because it was always missing -> The group should remain on the website, and in fact be added in the opposite direction.

This can, I believe, be solved by an endpoint with separate `add` and `remove` lists. On the initial sync, both sides send all their current groups in the `add` list to the other side. Afterwards, every time a group is added or removed, the Minecraft server or Discord bot makes a request with the added or removed groups.

These endpoints were tested manually using curl, but not yet with the plugin or nameless-link. I first wanted to see if anyone had good ideas and feedback.

Disclosure: I am being paid to fix this group sync issue in Nameless-Link, which required me to add these new endpoints. It would be unfair to demand someone to review this PR for free, so I wil provide compensation to members of the Nameless team.