### PR TITLE
Fix misleading error logging in if the user is banned

### DIFF
--- a/modules/Core/pages/login.php
+++ b/modules/Core/pages/login.php
@@ -231,6 +231,11 @@ if (Input::exists()) {
             } else {
                 // Validation failed
                 $return_error = $validation->errors();
+
+                // If the account is banned, update the validation to only show this, and no others
+                if (in_array($language->get('user', 'account_banned'), $return_error)) {
+                    $return_error = [$language->get('user', 'account_banned')];
+                }
             }
         } else {
             // reCAPTCHA failed


### PR DESCRIPTION
Previously the login screen would show a message stating the user is banned, and a message stating the user's account is not active.

This change results in only the banned message being shown.

Closes #3038 