### PR TITLE
Fix mentions incorrectly parsed if preceded by forward slash

### DIFF
--- a/core/classes/Misc/MentionsParser.php
+++ b/core/classes/Misc/MentionsParser.php
@@ -23,7 +23,7 @@ class MentionsParser
      */
     public static function parse(int $author_id, string $value, string $link = null, array $alert_short = null, array $alert_full = null): string
     {
-        if (preg_match_all('/@([A-Za-z0-9\-_!.]+)/', $value, $matches)) {
+        if (preg_match_all('/(?<!\/)@([A-Za-z0-9\-_!.]+)/', $value, $matches)) {
             $matches = $matches[1];
 
             foreach ($matches as $possible_username) {
@@ -33,10 +33,10 @@ class MentionsParser
                     $user = new User($possible_username, 'nickname');
 
                     if ($user->exists()) {
-                        $value = preg_replace('/' . preg_quote("@$possible_username", '/') . '/', '[user]' . $user->data()->id . '[/user]', $value);
+                        $value = preg_replace('/(?<!\/)' . preg_quote("@$possible_username", '/') . '/', '[user]' . $user->data()->id . '[/user]', $value);
 
                         // Check if user is blocked by OP
-                        if ($link && ($alert_full && $alert_short) && ($user->data()->id != $author_id) && !$user->isBlocked($user->data()->id, $author_id)) {
+                        if ($value && $link && ($alert_full && $alert_short) && ($user->data()->id != $author_id) && !$user->isBlocked($user->data()->id, $author_id)) {
                             Alert::create($user->data()->id, 'tag', $alert_short, $alert_full, $link);
                             break;
                         }

--- a/core/classes/Misc/Text.php
+++ b/core/classes/Misc/Text.php
@@ -177,6 +177,9 @@ class Text
 
         $content = html_entity_decode($content);
 
+        // Also strip any mentions
+        $content = MentionsHook::stripPost(['content' => $content])['content'];
+
         return self::truncate($content, 512, [
             'html' => true,
         ]);


### PR DESCRIPTION
Maybe a slightly cheating method of fixing mentions in URLs as mentioned in #3454 

If the mention is immediately preceded by `/` we don't count it - thought this might suffice without needing to get into URL parsing within the regex which I didn't fancy doing.

Fixes #3454 

Also parses mentions correctly for Discord embeds