### PR TITLE
Remove seemingly useless sb-admin code

### DIFF
--- a/custom/panel_templates/Default/assets/js/sb-admin-2.js
+++ b/custom/panel_templates/Default/assets/js/sb-admin-2.js
@@ -7,20 +7,6 @@
 
 $('[data-toggle="tooltip"]').tooltip({
         trigger: 'hover'
-    })
+})
 
-    !(function (s) {
-        "use strict";
-        s(window).resize(function () {
-                s(window).width() < 768 && s(".sidebar .collapse").collapse("hide"),
-                    s(window).width() < 480 && !s(".sidebar").hasClass("toggled") && (s("body").addClass("sidebar-toggled"), s(".sidebar").addClass("toggled"), s(".sidebar .collapse").collapse("hide"));
-            }),
-            s("body.fixed-nav .sidebar").on("mousewheel DOMMouseScroll wheel", function (e) {
-                if (768 < s(window).width()) {
-                    var o = e.originalEvent,
-                        l = o.wheelDelta || -o.detail;
-                    (this.scrollTop += 30 * (l < 0 ? 1 : -1)), e.preventDefault();
-                }
-            });
-    })(jQuery);
 // @license-end


### PR DESCRIPTION
It looks like this code causes the sidebar to immediately collapse on small screen sizes upon scrolling. The resize method looks to toggle the sidebar but this is also handled by media queries in the css. This might be causing conflicts? I'm honestly not sure but removing this seems to fix that. I have yet to find problems due to this removed js...