### PR TITLE
Add button in users/edit to disable 2FA for a user

### DIFF
--- a/custom/panel_templates/Default/core/users_edit.tpl
+++ b/custom/panel_templates/Default/core/users_edit.tpl
@@ -43,7 +43,7 @@
                                 <div class="col-md-3">
                                     <span class="float-md-right">
                                         {if isset($DELETE_USER) || isset($RESEND_ACTIVATION_EMAIL) ||
-                                        isset($VALIDATE_USER)}
+                                        isset($VALIDATE_USER) || isset($DISABLE_TFA)}
                                         <div class="btn-group">
                                             <button type="button" class="btn btn-primary dropdown-toggle"
                                                 data-toggle="dropdown" aria-haspopup="true"
@@ -57,6 +57,8 @@
                                                     onclick="validateUser()">{$VALIDATE_USER}</a>{/if}
                                                 {if isset($CHANGE_PASSWORD)}<a class="dropdown-item" href="#"
                                                     onclick="changePassword()">{$CHANGE_PASSWORD}</a> {/if}
+                                                {if isset($DISABLE_TFA)}<a class="dropdown-item" href="#"
+                                                    onclick="disableTfa()">{$DISABLE_TFA}</a> {/if}
                                             </div>
                                         </div>
                                         {/if}
@@ -260,6 +262,10 @@
     <form style="display:none" action="{$VALIDATE_USER_LINK}" method="post" id="validateUserForm">
         <input type="hidden" name="token" value="{$TOKEN}" />
     </form>
+    <form style="display:none" action="{$DISABLE_TFA_LINK}" method="post" id="disableTfaForm">
+        <input type="hidden" name="token" value="{$TOKEN}" />
+    </form>
+
 
     {include file='scripts.tpl'}
 
@@ -279,6 +285,12 @@
         {if isset($CHANGE_PASSWORD)}
             function changePassword() {
                 $('#passwordModal').modal().show();
+            }
+        {/if}
+
+        {if isset($DISABLE_TFA)}
+            function disableTfa() {
+                $('#disableTfaForm').submit();
             }
         {/if}
 

--- a/modules/Core/language/en_UK.json
+++ b/modules/Core/language/en_UK.json
@@ -252,6 +252,8 @@
     "admin/force_tfa": "Force Two Factor Authentication for group members?",
     "admin/force_tfa_alert": "Your group requires you to have Two Factor Authentication enabled.",
     "admin/force_tfa_warning": "Please ensure you know what this does, or else you risk locking out yourself and all the group members.",
+    "admin/edit_user_tfa_disabled": "Two factor authentication has successfully been disabled for this user.",
+    "admin/disable_tfa": "Disable 2FA",
     "admin/force_www": "Force www?",
     "admin/forgot_password_email": "Forgot Password Email",
     "admin/forum_posts": "Display on Forum",

--- a/modules/Core/pages/panel/users_edit.php
+++ b/modules/Core/pages/panel/users_edit.php
@@ -58,6 +58,14 @@ if (isset($_GET['action'])) {
         } else {
             Session::flash('edit_user_error', $language->get('admin', 'email_resend_failed'));
         }
+    } else if ($_GET['action'] == 'disable_tfa') {
+        if (Token::check()) {
+            $view_user->update([
+                'tfa_enabled' => false
+            ]);
+
+            Session::flash('edit_user_success', $language->get('admin', 'edit_user_tfa_disabled'));
+        }
     } else {
         throw new InvalidArgumentException('Invalid action: ' . $_GET['action']);
     }
@@ -311,6 +319,9 @@ if ($user_query->id != 1 && !$view_user->canViewStaffCP()) {
         'NEW_PASSWORD' => $language->get('user', 'new_password'),
         'CONFIRM_NEW_PASSWORD' => $language->get('user', 'confirm_new_password'),
         'CHANGE_PASSWORD' => $language->get('user', 'change_password'),
+
+        'DISABLE_TFA' => $language->get('admin', 'disable_tfa'),
+        'DISABLE_TFA_LINK' => URL::build('/panel/users/edit/', 'id=' . urlencode($user_query->id) . '&action=disable_tfa')
     ]);
 }
 

--- a/modules/Core/pages/panel/users_edit.php
+++ b/modules/Core/pages/panel/users_edit.php
@@ -61,7 +61,10 @@ if (isset($_GET['action'])) {
     } else if ($_GET['action'] == 'disable_tfa') {
         if (Token::check()) {
             $view_user->update([
-                'tfa_enabled' => false
+                'tfa_enabled' => false,
+                'tfa_type' => 0,
+                'tfa_secret' => null,
+                'tfa_complete' => false
             ]);
 
             Session::flash('edit_user_success', $language->get('admin', 'edit_user_tfa_disabled'));


### PR DESCRIPTION
This PR closes #3529. There was currently no way to disable 2FA of a user without directly accessing the database. This PR changes that and adds a button administrators can click in the actions dropdown of the edit user screen in StaffCP.