### PR TITLE
Fix users being able to bypass email verification

### DIFF
--- a/core/classes/Core/Validate.php
+++ b/core/classes/Core/Validate.php
@@ -299,9 +299,9 @@ class Validate
                         break;
 
                     case self::IS_ACTIVE:
-                        $check = $validator->_db->get('users', [$item, $value]);
+                        $check = $validator->_db->query("SELECT * FROM nl2_users WHERE username = ? OR email = ?", [$value, $value]);
                         if (!$check->count()) {
-                            break;
+                            break; // Something went pretty fricking wrong but okay
                         }
 
                         $isuseractive = $check->first()->active;

--- a/core/classes/Core/Validate.php
+++ b/core/classes/Core/Validate.php
@@ -301,7 +301,7 @@ class Validate
                     case self::IS_ACTIVE:
                         $check = $validator->_db->query("SELECT * FROM nl2_users WHERE username = ? OR email = ?", [$value, $value]);
                         if (!$check->count()) {
-                            break; // Something went pretty fricking wrong but okay
+                            break;
                         }
 
                         $isuseractive = $check->first()->active;

--- a/core/classes/Core/Validate.php
+++ b/core/classes/Core/Validate.php
@@ -299,7 +299,7 @@ class Validate
                         break;
 
                     case self::IS_ACTIVE:
-                        $check = $validator->_db->query("SELECT * FROM nl2_users WHERE username = ? OR email = ?", [$value, $value]);
+                        $check = $validator->_db->query('SELECT * FROM nl2_users WHERE username = ? OR email = ?', [$value, $value]);
                         if (!$check->count()) {
                             break;
                         }


### PR DESCRIPTION
This PR closes #3463 which highlighted an issue that allowed users to bypass email verification if the username or email was chosen as a login method.