### PR TITLE
Cache 2fa code for 1min when setting it up

### DIFF
--- a/modules/Core/pages/user/settings.php
+++ b/modules/Core/pages/user/settings.php
@@ -34,12 +34,17 @@ if (isset($_GET['do'])) {
         $tfa = new \RobThree\Auth\TwoFactorAuth(Output::getClean(SITE_NAME));
 
         if (!isset($_GET['s'])) {
-            // Generate secret
-            $secret = $tfa->createSecret();
 
-            $user->update([
-                'tfa_secret' => $secret
-            ]);
+            // Generate secret
+            $cache->setCache("users_tfa");
+            $secret = $cache->retrieve($user->data()->id);
+            if (!$secret) {
+                $secret = $tfa->createSecret();
+                $cache->store($user->data()->id, $secret, 60);
+                $user->update([
+                    'tfa_secret' => $secret
+                ]);
+            }
 
             if (Session::exists('force_tfa_alert')) {
                 $errors[] = Session::get('force_tfa_alert');

--- a/modules/Core/pages/user/settings.php
+++ b/modules/Core/pages/user/settings.php
@@ -36,7 +36,7 @@ if (isset($_GET['do'])) {
         if (!isset($_GET['s'])) {
 
             // Generate secret
-            $cache->setCache("users_tfa");
+            $cache->setCache('users_tfa');
             $secret = $cache->retrieve($user->data()->id);
             if (!$secret) {
                 $secret = $tfa->createSecret();


### PR DESCRIPTION
While this should normally not be needed, there is currently an issue when force 2fa is enabled for a group that causes every request to be redirected to this page. A side effect of this is that every page load, the 2fa code gets regenerated and thus is no longer valid when the user enters their code. To address this, I cache the code for a minute to make sure that they have managed to enter the code and no query has overridden it. It is not a perfect solution but should at least help fix the issue for the time being.