### PR TITLE
Fix cookie_url causes fatal error

### DIFF
--- a/modules/Cookie Consent/module.php
+++ b/modules/Cookie Consent/module.php
@@ -52,6 +52,7 @@ class CookieConsent_Module extends Module {
 
     public function onPageLoad(User $user, Pages $pages, Cache $cache, $smarty, $navs, Widgets $widgets, TemplateBase $template) {
         $language = $this->_language;
+        $cookie_url = URL::build('/cookies');
 
         // AdminCP
         PermissionHandler::registerPermissions($language->get('moderator', 'staff_cp'), [
@@ -70,8 +71,6 @@ class CookieConsent_Module extends Module {
             } else {
                 $options = $cache->retrieve('options');
             }
-
-            $cookie_url = URL::build('/cookies');
 
             // Add JS script
             $template->addCSSFiles([


### PR DESCRIPTION
cookie url is only defined when viewing frontend causing fatal error when viewing panel or other pages due of navigation link and variables being null