### PR TITLE
Revert removal of enable debugbar

### DIFF
--- a/core/init.php
+++ b/core/init.php
@@ -136,6 +136,7 @@ if ($page != 'install') {
 
     if ((defined('DEBUGGING') && DEBUGGING) && class_exists('DebugBar\DebugBar')) {
         define('PHPDEBUGBAR', true);
+        DebugBarHelper::getInstance()->enable();
     }
 
     // Get the Nameless version


### PR DESCRIPTION
Revert the change of enable debugBar, the function required smartly variable before but the smarty param was removed but looks like the entire enable line was removed making it never being executed