### PR TITLE
Fix no falsy check when retrieving forum banned terms

### DIFF
--- a/modules/Forum/classes/Forum.php
+++ b/modules/Forum/classes/Forum.php
@@ -804,7 +804,12 @@ class Forum {
      * @return array Array of banned terms
      */
     public static function getBannedTerms(): array {
-        $terms = Settings::get('banned_terms', '', 'forum');
+        $terms = Settings::get('banned_terms', null, 'forum');
+
+        if (!$terms) {
+            return [];
+        }
+
         return explode("\n", $terms);
     }
 


### PR DESCRIPTION
This bug means forum banned terms are effectively required - without any defined, all forum posts will fail validation