### PR TITLE
Revert deletion of homepage_news term

### DIFF
--- a/custom/templates/DefaultRevamp/portal.tpl
+++ b/custom/templates/DefaultRevamp/portal.tpl
@@ -1,5 +1,5 @@
-'Homepage Type' is set to 'Portal', which means NamelessMC renders the 'custom/templates/DefaultRevamp/portal.tpl' template file.<br>
+'Default Homepage' is set to 'Portal', which means NamelessMC renders the 'custom/templates/DefaultRevamp/portal.tpl' template file.<br>
 <br>
 This is a placeholder page, use this template for your own custom portal.<br>
 <br>
-<strong>To revert this change, go to <a href="{$GENERAL_SETTINGS_URL}">StaffCP > Configuration > General Settings</a> and change 'Homepage Type' to 'News'.</strong>
+<strong>To revert this change, go to <a href="{$GENERAL_SETTINGS_URL}">StaffCP > Configuration > General Settings</a> and change 'Default Homepage' to 'News'.</strong>

--- a/modules/Core/language/en_UK.json
+++ b/modules/Core/language/en_UK.json
@@ -292,6 +292,7 @@
     "admin/header": "Header",
     "admin/header_required": "Header is required.",
     "admin/home_custom_content": "Home Custom Content",
+    "admin/homepage_news": "News",
     "admin/default_homepage": "Default Homepage",
     "admin/hook_created": "Hook created successfully.",
     "admin/hook_deleted": "Hook deleted successfully.",


### PR DESCRIPTION
Revert deletion of homepage_news term from the pr https://github.com/NamelessMC/Nameless/commit/5562710d772f39f4dd6553ea315f362c31d7cd73

The term is still used in the settings list also rename portal to use the new setting name