### PR TITLE
fix group sync rules

### DIFF
--- a/custom/panel_templates/Default/core/api_group_sync.tpl
+++ b/custom/panel_templates/Default/core/api_group_sync.tpl
@@ -63,7 +63,7 @@
                                             {if in_array($injector, $ENABLED_GROUP_SYNC_INJECTORS)}
                                             <select name="existing[{$group_sync['id']}][{$column_name}]"
                                                 class="form-control" id="input_{$column_name}">
-                                                <option value="0" {if {$group_sync[$column_name]} eq null} selected
+                                                <option value="none" {if {$group_sync[$column_name]} eq null} selected
                                                     {/if}>{$NONE} ({$DISABLED})</option>
                                                 {foreach from=$injector->getSelectionOptions() item=group}
                                                 <option value="{$group['id']}" {if $group_sync[$column_name] eq
@@ -107,7 +107,7 @@
                                             <select name="{$column_name}" class="form-control"
                                                 id="input_{$column_name}">
                                                 {if $column_name != $NAMELESS_INJECTOR_COLUMN}
-                                                <option value="0">{$NONE} ({$DISABLED})</option>
+                                                <option value="none">{$NONE} ({$DISABLED})</option>
                                                 {/if}
                                                 {foreach from=$injector->getSelectionOptions() item=group}
                                                 <option value="{$group['id']}">{$group['name']}</option>

--- a/modules/Core/pages/panel/api.php
+++ b/modules/Core/pages/panel/api.php
@@ -66,6 +66,7 @@ if (!isset($_GET['view'])) {
     if (Input::exists()) {
         if (Token::check()) {
             if ($_POST['action'] == 'create') {
+                $_POST = array_map(fn($value) => $value === "none" ? null : $value, $_POST);
                 $validation = GroupSyncManager::getInstance()->makeValidator($_POST, $language);
 
                 $errors = [];
@@ -103,6 +104,7 @@ if (!isset($_GET['view'])) {
                     foreach ($_POST['existing'] as $group_sync_id => $values) {
                         $errors = [];
 
+                        $values = array_map(fn($value) => $value === "none" ? null : $value, $values);
                         $validator = GroupSyncManager::getInstance()->makeValidator($values, $language);
 
                         if (!$validator->passed()) {


### PR DESCRIPTION
The recent change from https://github.com/NamelessMC/Nameless/commit/9b112c0beab346a38b6f5a51e7773b38c6fc52e7 validate class broke the group sync rules selection as 0 for none does not pass validation anymore

Also fixes updating a rule set the value from null to 0 when its supposed to be null

Also changed 0 to none because 0 might be a used id for some group sync applications