### PR TITLE
Remove NamelessMC from error message

### DIFF
--- a/modules/Core/language/en_UK.json
+++ b/modules/Core/language/en_UK.json
@@ -1288,7 +1288,7 @@
     "user/notification_settings": "Notification Settings",
     "user/notification_settings_updated_successfully": "Notification settings updated successfully.",
     "user/overview": "Overview",
-    "user/oauth_already_linked": "Another NamelessMC user is already linked to that {{provider}} account.",
+    "user/oauth_already_linked": "Another user is already linked to that {{provider}} account.",
     "user/oauth_login_success": "You have logged in with your {{provider}} account.",
     "user/one_or_more_users_blocked": "You cannot send private messages to at least one member of the conversation.",
     "user/participants": "Participants",


### PR DESCRIPTION
Remove NamelessMC word from error message, Could replaced with site name but looks better like this well