### PR TITLE
Fix type error for widgets on newer php versions

### DIFF
--- a/core/classes/Widgets/WidgetData.php
+++ b/core/classes/Widgets/WidgetData.php
@@ -14,6 +14,6 @@ class WidgetData
             ? []
             : (is_array($data->pages)
                 ? $data->pages
-                : json_decode($data->pages));
+                : json_decode($data->pages, true));
     }
 }


### PR DESCRIPTION
Property $page is typed as array but json_decode returns an object not an array which throws an error in recent php version (8 and newer). Setting the second parameter to true makes it return an associated array instead of an object to match the type declaration of the property.
Fixes: `Uncaught TypeError: Cannot assign stdClass to property WidgetData::$pages of type array`