### PR TITLE
Remove redundant try/catch blocks

### DIFF
--- a/core/classes/Core/Validate.php
+++ b/core/classes/Core/Validate.php
@@ -112,30 +112,11 @@ class Validate
      */
     public const CUSTOM = 'custom';
 
-    private DB $_db;
-
     private ?string $_message = null;
     private array $_messages = [];
     private bool $_passed = false;
     private array $_to_convert = [];
     private array $_errors = [];
-
-    /**
-     * Create new `Validate` instance.
-     */
-    private function __construct()
-    {
-        // Connect to database for rules which need DB access
-        try {
-            $host = Config::get('mysql.host');
-        } catch (Exception $e) {
-            $host = null;
-        }
-
-        if (!empty($host)) {
-            $this->_db = DB::getInstance();
-        }
-    }
 
     /**
      * Validate an array of inputs.
@@ -265,10 +246,10 @@ class Validate
                                   AND $ignore_col <> ?
                                 SQL;
 
-                            $check = $validator->_db->query($sql, [$value, $ignore_val]);
+                            $check = DB::getInstance()->query($sql, [$value, $ignore_val]);
                         } else {
                             $table = $rule_value;
-                            $check = $validator->_db->get($table, [$item, $value]);
+                            $check = DB::getInstance()->get($table, [$item, $value]);
                         }
                         if ($check->count()) {
                             $validator->addError([
@@ -300,7 +281,7 @@ class Validate
                         break;
 
                     case self::IS_ACTIVE:
-                        $check = $validator->_db->query('SELECT * FROM nl2_users WHERE username = ? OR email = ?', [$value, $value]);
+                        $check = DB::getInstance()->query('SELECT * FROM nl2_users WHERE username = ? OR email = ?', [$value, $value]);
                         if (!$check->count()) {
                             break;
                         }
@@ -316,7 +297,7 @@ class Validate
                         break;
 
                     case self::IS_BANNED:
-                        $check = $validator->_db->get('users', [$item, $value]);
+                        $check = DB::getInstance()->get('users', [$item, $value]);
                         if (!$check->count()) {
                             break;
                         }

--- a/core/classes/Endpoints/Endpoints.php
+++ b/core/classes/Endpoints/Endpoints.php
@@ -112,19 +112,13 @@ class Endpoints
 
             $endpoint_class_name = str_replace('.php', '', $file->getFilename());
 
-            try {
-                /** @var EndpointBase $endpoint */
-                $endpoint = new $endpoint_class_name();
+            /** @var EndpointBase $endpoint */
+            $endpoint = new $endpoint_class_name();
 
-                $key = $endpoint->getRoute() . '-' . $endpoint->getMethod();
+            $key = $endpoint->getRoute() . '-' . $endpoint->getMethod();
 
-                if (!isset($this->_endpoints[$key])) {
-                    $this->_endpoints[$key] = $endpoint;
-                }
-            } catch (Error $error) {
-                // Silently ignore errors caused by invalid endpoint files,
-                // but make a log entry for debugging purposes.
-                ErrorHandler::logCustomError($error->getMessage());
+            if (!isset($this->_endpoints[$key])) {
+                $this->_endpoints[$key] = $endpoint;
             }
         }
     }

--- a/core/templates/frontend_init.php
+++ b/core/templates/frontend_init.php
@@ -112,11 +112,7 @@ if ($user->isLoggedIn()) {
     if ($cache->isCached('default_group')) {
         $default_group = $cache->retrieve('default_group');
     } else {
-        try {
-            $default_group = Group::find(1, 'default_group')->id;
-        } catch (Exception $e) {
-            $default_group = 1;
-        }
+        $default_group = Group::find(1, 'default_group')->id;
 
         $cache->store('default_group', $default_group);
     }

--- a/modules/Cookie Consent/pages/panel/cookies.php
+++ b/modules/Cookie Consent/pages/panel/cookies.php
@@ -44,25 +44,21 @@ if (Input::exists()) {
         ]);
 
         if ($validation->passed()) {
-            try {
-                $cookie_id = DB::getInstance()->get('privacy_terms', ['name', 'cookies'])->results();
-                if (count($cookie_id)) {
-                    $cookie_id = $cookie_id[0]->id;
+            $cookie_id = DB::getInstance()->get('privacy_terms', ['name', 'cookies'])->results();
+            if (count($cookie_id)) {
+                $cookie_id = $cookie_id[0]->id;
 
-                    DB::getInstance()->update('privacy_terms', $cookie_id, [
-                        'value' => Input::get('cookies')
-                    ]);
-                } else {
-                    DB::getInstance()->insert('privacy_terms', [
-                        'name' => 'cookies',
-                        'value' => Input::get('cookies')
-                    ]);
-                }
-
-                $success = $cookie_language->get('cookie', 'cookie_notice_success');
-            } catch (Exception $e) {
-                $errors[] = $e->getMessage();
+                DB::getInstance()->update('privacy_terms', $cookie_id, [
+                    'value' => Input::get('cookies')
+                ]);
+            } else {
+                DB::getInstance()->insert('privacy_terms', [
+                    'name' => 'cookies',
+                    'value' => Input::get('cookies')
+                ]);
             }
+
+            $success = $cookie_language->get('cookie', 'cookie_notice_success');
         } else {
             $errors = $validation->errors();
         }

--- a/modules/Core/pages/forgot_password.php
+++ b/modules/Core/pages/forgot_password.php
@@ -152,17 +152,13 @@ if (empty($_GET['c'])) {
             if ($validation->passed()) {
                 if (strcasecmp($target_user->data()->email, $_POST['email']) == 0) {
                     $new_password = password_hash(Input::get('password'), PASSWORD_BCRYPT, ['cost' => 13]);
-                    try {
-                        $target_user->update([
-                            'password' => $new_password,
-                            'reset_code' => null
-                        ]);
+                    $target_user->update([
+                        'password' => $new_password,
+                        'reset_code' => null
+                    ]);
 
-                        Session::flash('login_success', $language->get('user', 'forgot_password_change_successful'));
-                        Redirect::to(URL::build('/login'));
-                    } catch (Exception $e) {
-                        $errors = [$e->getMessage()];
-                    }
+                    Session::flash('login_success', $language->get('user', 'forgot_password_change_successful'));
+                    Redirect::to(URL::build('/login'));
                 } else {
                     $errors = [$language->get('user', 'incorrect_email')];
                 }

--- a/modules/Core/pages/panel/api.php
+++ b/modules/Core/pages/panel/api.php
@@ -127,11 +127,7 @@ if (!isset($_GET['view'])) {
                         }
 
                         if (!count($errors)) {
-                            try {
-                                DB::getInstance()->update('group_sync', $group_sync_id, $values);
-                            } catch (Exception $e) {
-                                $errors[] = $e->getMessage();
-                            }
+                            DB::getInstance()->update('group_sync', $group_sync_id, $values);
                         }
                     }
 
@@ -141,12 +137,8 @@ if (!isset($_GET['view'])) {
                 } else {
                     if ($_POST['action'] == 'delete') {
                         if (isset($_POST['id'])) {
-                            try {
-                                DB::getInstance()->delete('group_sync', ['id', $_POST['id']]);
-                                Session::flash('api_success', $language->get('admin', 'group_sync_rule_deleted_successfully'));
-                            } catch (Exception $e) {
-                                // Redirect anyway
-                            }
+                            DB::getInstance()->delete('group_sync', ['id', $_POST['id']]);
+                            Session::flash('api_success', $language->get('admin', 'group_sync_rule_deleted_successfully'));
                         }
                         die();
                     }

--- a/modules/Core/pages/panel/avatars.php
+++ b/modules/Core/pages/panel/avatars.php
@@ -33,31 +33,21 @@ require_once ROOT_PATH . '/core/templates/backend_init.php';
 if (Input::exists()) {
     if (Token::check()) {
         if (isset($_POST['avatar_source'])) {
-            try {
-                Settings::set('user_avatars', $custom_avatars = (isset($_POST['custom_avatars']) && $_POST['custom_avatars']) ? '1' : '0');
-                Settings::set('default_avatar_type', Input::get('default_avatar'));
-                Settings::set('avatar_site', Input::get('avatar_source'));
-                Settings::set('avatar_type', Input::get('avatar_perspective'));
+            Settings::set('user_avatars', $custom_avatars = (isset($_POST['custom_avatars']) && $_POST['custom_avatars']) ? '1' : '0');
+            Settings::set('default_avatar_type', Input::get('default_avatar'));
+            Settings::set('avatar_site', Input::get('avatar_source'));
+            Settings::set('avatar_type', Input::get('avatar_perspective'));
 
-                $cache->setCache('avatar_settings_cache');
-                $cache->store('custom_avatars', $custom_avatars);
-                $cache->store('default_avatar_type', Input::get('default_avatar'));
-                $cache->store('avatar_source', Input::get('avatar_source'));
-                $cache->store('avatar_perspective', Input::get('avatar_perspective'));
-            } catch (Exception $e) {
-                $errors = [$e->getMessage()];
-            }
-        } else {
-            if (isset($_POST['avatar'])) {
-                // Selecting a new default avatar
-                try {
-                    Settings::set('custom_default_avatar', Input::get('avatar'));
-                    $cache->setCache('avatar_settings_cache');
-                    $cache->store('default_avatar_image', Input::get('avatar'));
-                } catch (Exception $e) {
-                    $errors = [$e->getMessage()];
-                }
-            }
+            $cache->setCache('avatar_settings_cache');
+            $cache->store('custom_avatars', $custom_avatars);
+            $cache->store('default_avatar_type', Input::get('default_avatar'));
+            $cache->store('avatar_source', Input::get('avatar_source'));
+            $cache->store('avatar_perspective', Input::get('avatar_perspective'));
+        } else if (isset($_POST['avatar'])) {
+            // Selecting a new default avatar
+            Settings::set('custom_default_avatar', Input::get('avatar'));
+            $cache->setCache('avatar_settings_cache');
+            $cache->store('default_avatar_image', Input::get('avatar'));
         }
 
         //Log::getInstance()->log(Log::Action('admin/core/avatar'));

--- a/modules/Core/pages/panel/general_settings.php
+++ b/modules/Core/pages/panel/general_settings.php
@@ -113,11 +113,7 @@ if (Input::exists()) {
             $cache->store('language', $language_short_code);
 
             // Timezone
-            try {
-                Settings::set('timezone', $_POST['timezone']);
-            } catch (Exception $e) {
-                $errors = [$e->getMessage()];
-            }
+            Settings::set('timezone', $_POST['timezone']);
 
             // Default Homepage
             Settings::set('home_type', $_POST['homepage']);

--- a/modules/Core/pages/panel/groups.php
+++ b/modules/Core/pages/panel/groups.php
@@ -67,60 +67,56 @@ if (isset($_GET['action'])) {
                     ]);
 
                     if ($validation->passed()) {
-                        try {
-                            if (isset($_POST['default']) && $_POST['default'] == 1) {
-                                $default = 1;
-                            } else {
-                                $default = 0;
-                            }
-
-                            // If this is the new default group, update old default group
-                            $default_group = Group::find(1, 'default_group');
-                            if (!$default_group && $default == 0) {
-                                $default = 1;
-                            }
-
-                            $last_group_order = DB::getInstance()->query('SELECT `order` FROM nl2_groups ORDER BY `order` DESC LIMIT 1')->results();
-                            if (count($last_group_order)) {
-                                $last_group_order = $last_group_order[0]->order;
-                            } else {
-                                $last_group_order = 0;
-                            }
-
-                            DB::getInstance()->insert('groups', [
-                                'name' => Input::get('groupname'),
-                                'group_html' => Input::get('html'),
-                                'group_username_color' => ($_POST['username_style'] ? Input::get('username_style') : null),
-                                'group_username_css' => ($_POST['username_css'] ? Input::get('username_css') : null),
-                                'admin_cp' => Input::get('staffcp'),
-                                'staff' => Input::get('staff'),
-                                'default_group' => $default,
-                                'order' => (Input::get('order') == 5 ? $last_group_order + 1 : Input::get('order')),
-                                'force_tfa' => Input::get('tfa'),
-                                'permissions' => '{}',
-                            ]);
-
-                            $group_id = DB::getInstance()->lastId();
-
-                            if ($default == 1) {
-                                if ($default_group && $default_group->id != $group_id) {
-                                    DB::getInstance()->update('groups', $default_group->id, [
-                                        'default_group' => false
-                                    ]);
-                                }
-
-                                $cache->setCache('default_group');
-                                $cache->store('default_group', $group_id);
-                            }
-
-                            $cache->setCache('groups_tfa_' . $group_id);
-                            $cache->store('enabled', Input::get('tfa'));
-
-                            Session::flash('admin_groups', $language->get('admin', 'group_created_successfully'));
-                            Redirect::to(URL::build('/panel/core/groups'));
-                        } catch (Exception $e) {
-                            $errors[] = $e->getMessage();
+                        if (isset($_POST['default']) && $_POST['default'] == 1) {
+                            $default = 1;
+                        } else {
+                            $default = 0;
                         }
+
+                        // If this is the new default group, update old default group
+                        $default_group = Group::find(1, 'default_group');
+                        if (!$default_group && $default == 0) {
+                            $default = 1;
+                        }
+
+                        $last_group_order = DB::getInstance()->query('SELECT `order` FROM nl2_groups ORDER BY `order` DESC LIMIT 1')->results();
+                        if (count($last_group_order)) {
+                            $last_group_order = $last_group_order[0]->order;
+                        } else {
+                            $last_group_order = 0;
+                        }
+
+                        DB::getInstance()->insert('groups', [
+                            'name' => Input::get('groupname'),
+                            'group_html' => Input::get('html'),
+                            'group_username_color' => ($_POST['username_style'] ? Input::get('username_style') : null),
+                            'group_username_css' => ($_POST['username_css'] ? Input::get('username_css') : null),
+                            'admin_cp' => Input::get('staffcp'),
+                            'staff' => Input::get('staff'),
+                            'default_group' => $default,
+                            'order' => (Input::get('order') == 5 ? $last_group_order + 1 : Input::get('order')),
+                            'force_tfa' => Input::get('tfa'),
+                            'permissions' => '{}',
+                        ]);
+
+                        $group_id = DB::getInstance()->lastId();
+
+                        if ($default == 1) {
+                            if ($default_group && $default_group->id != $group_id) {
+                                DB::getInstance()->update('groups', $default_group->id, [
+                                    'default_group' => false
+                                ]);
+                            }
+
+                            $cache->setCache('default_group');
+                            $cache->store('default_group', $group_id);
+                        }
+
+                        $cache->setCache('groups_tfa_' . $group_id);
+                        $cache->store('enabled', Input::get('tfa'));
+
+                        Session::flash('admin_groups', $language->get('admin', 'group_created_successfully'));
+                        Redirect::to(URL::build('/panel/core/groups'));
                     } else {
                         $errors = $validation->errors();
                     }
@@ -200,76 +196,68 @@ if (isset($_GET['action'])) {
                         ]);
 
                         if ($validation->passed()) {
-                            try {
-                                if (isset($_POST['default']) && $_POST['default'] == 1) {
-                                    $default = 1;
-                                    $cache->setCache('default_group');
-                                    $cache->store('default_group', $_GET['group']);
-                                } else {
-                                    $default = 0;
-                                }
-
-                                // If this is the new default group, update old default group
-                                $default_group = Group::find(1, 'default_group');
-                                if ($default_group && $default == 1 && $default_group->id != $_GET['group']) {
-                                    DB::getInstance()->update('groups', $default_group->id, [
-                                        'default_group' => false
-                                    ]);
-                                } else {
-                                    if (!$default_group && $default == 0) {
-                                        $default = 1;
-                                    }
-                                }
-
-                                if ($group->id == 2) {
-                                    $staff_cp = 1;
-                                } else {
-                                    $staff_cp = Input::get('staffcp');
-                                }
-
-                                DB::getInstance()->update('groups', $_GET['group'], [
-                                    'name' => Input::get('groupname'),
-                                    'group_html' => Input::get('html'),
-                                    'group_username_color' => ($_POST['username_style'] ? Input::get('username_style') : null),
-                                    'group_username_css' => ($_POST['username_css'] ? Input::get('username_css') : null),
-                                    'admin_cp' => $staff_cp,
-                                    'staff' => Input::get('staff'),
-                                    'default_group' => $default,
-                                    'order' => Input::get('order'),
-                                    'force_tfa' => Input::get('tfa')
-                                ]);
-
-                                $cache->setCache('groups_tfa_' . $_GET['group']);
-                                $cache->store('enabled', Input::get('tfa'));
-
-                                Session::flash('admin_groups', $language->get('admin', 'group_updated_successfully'));
-                                Redirect::to(URL::build('/panel/core/groups/', 'action=edit&group=' . urlencode($_GET['group'])));
-                            } catch (Exception $e) {
-                                $errors[] = $e->getMessage();
+                            if (isset($_POST['default']) && $_POST['default'] == 1) {
+                                $default = 1;
+                                $cache->setCache('default_group');
+                                $cache->store('default_group', $_GET['group']);
+                            } else {
+                                $default = 0;
                             }
+
+                            // If this is the new default group, update old default group
+                            $default_group = Group::find(1, 'default_group');
+                            if ($default_group && $default == 1 && $default_group->id != $_GET['group']) {
+                                DB::getInstance()->update('groups', $default_group->id, [
+                                    'default_group' => false
+                                ]);
+                            } else {
+                                if (!$default_group && $default == 0) {
+                                    $default = 1;
+                                }
+                            }
+
+                            if ($group->id == 2) {
+                                $staff_cp = 1;
+                            } else {
+                                $staff_cp = Input::get('staffcp');
+                            }
+
+                            DB::getInstance()->update('groups', $_GET['group'], [
+                                'name' => Input::get('groupname'),
+                                'group_html' => Input::get('html'),
+                                'group_username_color' => ($_POST['username_style'] ? Input::get('username_style') : null),
+                                'group_username_css' => ($_POST['username_css'] ? Input::get('username_css') : null),
+                                'admin_cp' => $staff_cp,
+                                'staff' => Input::get('staff'),
+                                'default_group' => $default,
+                                'order' => Input::get('order'),
+                                'force_tfa' => Input::get('tfa')
+                            ]);
+
+                            $cache->setCache('groups_tfa_' . $_GET['group']);
+                            $cache->store('enabled', Input::get('tfa'));
+
+                            Session::flash('admin_groups', $language->get('admin', 'group_updated_successfully'));
+                            Redirect::to(URL::build('/panel/core/groups/', 'action=edit&group=' . urlencode($_GET['group'])));
                         } else {
                             $errors = $validation->errors();
                         }
                     } else {
                         if (Input::get('action') == 'delete') {
-                            try {
-                                $default_group = Group::find(1, 'default_group');
+                            $default_group = Group::find(1, 'default_group');
 
-                                if ($default_group) {
-                                    if ($group->id == 2 || $default_group->id == Input::get('id') || $group->admin_cp == 1) {
-                                        // Can't delete default group/admin group
-                                        Session::flash('admin_groups_error', $language->get('admin', 'unable_to_delete_group'));
-                                    } else {
-                                        DB::getInstance()->delete('groups', ['id', Input::get('id')]);
-                                        DB::getInstance()->delete('users_groups', ['group_id', Input::get('id')]);
-                                        Session::flash('admin_groups', $language->get('admin', 'group_deleted_successfully'));
-                                    }
+                            if ($default_group) {
+                                if ($group->id == 2 || $default_group->id == Input::get('id') || $group->admin_cp == 1) {
+                                    // Can't delete default group/admin group
+                                    Session::flash('admin_groups_error', $language->get('admin', 'unable_to_delete_group'));
+                                } else {
+                                    DB::getInstance()->delete('groups', ['id', Input::get('id')]);
+                                    DB::getInstance()->delete('users_groups', ['group_id', Input::get('id')]);
+                                    Session::flash('admin_groups', $language->get('admin', 'group_deleted_successfully'));
                                 }
-
-                                Redirect::to(URL::build('/panel/core/groups'));
-                            } catch (Exception $e) {
-                                $errors[] = $e->getMessage();
                             }
+
+                            Redirect::to(URL::build('/panel/core/groups'));
                         }
                     }
                 } else {
@@ -343,55 +331,51 @@ if (isset($_GET['action'])) {
                         ]);
 
                         if ($validation->passed()) {
-                            try {
-                                if (isset($_POST['default']) && $_POST['default'] == 1) {
-                                    $default = 1;
-                                } else {
-                                    $default = 0;
-                                }
-
-                                // If this is the new default group, update old default group
-                                $default_group = Group::find(1, 'default_group');
-                                if (!$default_group && $default == 0) {
-                                    $default = 1;
-                                }
-
-                                DB::getInstance()->insert('groups', [
-                                    'name' => Input::get('groupname'),
-                                    'group_html' => Input::get('html'),
-                                    'group_username_color' => ($_POST['username_style'] ? Input::get('username_style') : null),
-                                    'group_username_css' => ($_POST['username_css'] ? Input::get('username_css') : null),
-                                    'admin_cp' => Input::get('staff'),
-                                    'staff' => Input::get('staff'),
-                                    'permissions' => $group->permissions,
-                                    'default_group' => $default,
-                                    'order' => Input::get('order'),
-                                    'force_tfa' => Input::get('tfa')
-                                ]);
-
-                                $group_id = DB::getInstance()->lastId();
-
-                                EventHandler::executeEvent(new GroupClonedEvent($group_id, $group->id));
-
-                                if ($default == 1) {
-                                    if ($default_group && $default_group->id != $group_id) {
-                                        DB::getInstance()->update('groups', $default_group->id, [
-                                            'default_group' => false
-                                        ]);
-                                    }
-
-                                    $cache->setCache('default_group');
-                                    $cache->store('default_group', $group_id);
-                                }
-
-                                $cache->setCache('groups_tfa_' . $group_id);
-                                $cache->store('enabled', Input::get('tfa'));
-
-                                Session::flash('admin_groups', $language->get('admin', 'group_cloned_successfully'));
-                                Redirect::to(URL::build('/panel/core/groups/', 'action=edit&group=' . urlencode($group_id)));
-                            } catch (Exception $e) {
-                                $errors[] = $e->getMessage();
+                            if (isset($_POST['default']) && $_POST['default'] == 1) {
+                                $default = 1;
+                            } else {
+                                $default = 0;
                             }
+
+                            // If this is the new default group, update old default group
+                            $default_group = Group::find(1, 'default_group');
+                            if (!$default_group && $default == 0) {
+                                $default = 1;
+                            }
+
+                            DB::getInstance()->insert('groups', [
+                                'name' => Input::get('groupname'),
+                                'group_html' => Input::get('html'),
+                                'group_username_color' => ($_POST['username_style'] ? Input::get('username_style') : null),
+                                'group_username_css' => ($_POST['username_css'] ? Input::get('username_css') : null),
+                                'admin_cp' => Input::get('staff'),
+                                'staff' => Input::get('staff'),
+                                'permissions' => $group->permissions,
+                                'default_group' => $default,
+                                'order' => Input::get('order'),
+                                'force_tfa' => Input::get('tfa')
+                            ]);
+
+                            $group_id = DB::getInstance()->lastId();
+
+                            EventHandler::executeEvent(new GroupClonedEvent($group_id, $group->id));
+
+                            if ($default == 1) {
+                                if ($default_group && $default_group->id != $group_id) {
+                                    DB::getInstance()->update('groups', $default_group->id, [
+                                        'default_group' => false
+                                    ]);
+                                }
+
+                                $cache->setCache('default_group');
+                                $cache->store('default_group', $group_id);
+                            }
+
+                            $cache->setCache('groups_tfa_' . $group_id);
+                            $cache->store('enabled', Input::get('tfa'));
+
+                            Session::flash('admin_groups', $language->get('admin', 'group_cloned_successfully'));
+                            Redirect::to(URL::build('/panel/core/groups/', 'action=edit&group=' . urlencode($group_id)));
                         } else {
                             $errors = $validation->errors();
                         }
@@ -464,14 +448,10 @@ if (isset($_GET['action'])) {
                     }
                     $perms_json = json_encode($perms);
 
-                    try {
-                        DB::getInstance()->update('groups', $group->id, ['permissions' => $perms_json]);
+                    DB::getInstance()->update('groups', $group->id, ['permissions' => $perms_json]);
 
-                        Session::flash('admin_groups', $language->get('admin', 'permissions_updated_successfully'));
-                        Redirect::to(URL::build('/panel/core/groups/', 'action=edit&group=' . urlencode($group->id)));
-                    } catch (Exception $e) {
-                        $errors[] = $e->getMessage();
-                    }
+                    Session::flash('admin_groups', $language->get('admin', 'permissions_updated_successfully'));
+                    Redirect::to(URL::build('/panel/core/groups/', 'action=edit&group=' . urlencode($group->id)));
                 } else {
                     $errors[] = $language->get('general', 'invalid_token');
                 }

--- a/modules/Core/pages/panel/minecraft_server_banners.php
+++ b/modules/Core/pages/panel/minecraft_server_banners.php
@@ -92,19 +92,13 @@ if (!isset($_GET['server']) && !isset($_GET['edit'])) {
             // Check token
             if (Token::check()) {
                 // Valid token
-                try {
-                    if (file_exists(ROOT_PATH . '/uploads/banners/' . Input::get('banner'))) {
-                        DB::getInstance()->update('mc_servers', $_GET['edit'], [
-                            'banner_background' => Output::getClean(Input::get('banner'))
-                        ]);
+                if (file_exists(ROOT_PATH . '/uploads/banners/' . Input::get('banner'))) {
+                    DB::getInstance()->update('mc_servers', $_GET['edit'], [
+                        'banner_background' => Output::getClean(Input::get('banner'))
+                    ]);
 
-                        $success = $language->get('admin', 'banner_updated_successfully');
-                    }
-                } catch (Exception $e) {
-                    $errors = [$e->getMessage()];
+                    $success = $language->get('admin', 'banner_updated_successfully');
                 }
-
-
             } else {
                 // Invalid token
                 $errors = [$language->get('general', 'invalid_token')];

--- a/modules/Core/pages/panel/minecraft_servers.php
+++ b/modules/Core/pages/panel/minecraft_servers.php
@@ -81,103 +81,98 @@ if (isset($_GET['action'])) {
 
                     if ($validation->passed()) {
                         // Handle input
-                        try {
-                            // Bedrock selected?
-                            if (isset($_POST['bedrock']) && $_POST['bedrock'] == 1) {
-                                $bedrock = 1;
-                            } else {
-                                $bedrock = 0;
-                            }
-
-                            // BungeeCord selected?
-                            if (isset($_POST['bungee_instance']) && $_POST['bungee_instance'] == 1) {
-                                $bungee = 1;
-                            } else {
-                                $bungee = 0;
-                            }
-
-                            // Pre 1.7?
-                            if (isset($_POST['pre_17']) && $_POST['pre_17'] == 1) {
-                                $pre = 1;
-                            } else {
-                                $pre = 0;
-                            }
-
-                            // Status enabled?
-                            if (isset($_POST['status_query_enabled']) && $_POST['status_query_enabled'] == 1) {
-                                $status = 1;
-                            } else {
-                                $status = 0;
-                            }
-
-                            // Show IP enabled?
-                            if (isset($_POST['show_ip_enabled']) && $_POST['show_ip_enabled'] == 1) {
-                                $show_ip = 1;
-                            } else {
-                                $show_ip = 0;
-                            }
-
-                            // Player list enabled?
-                            if (isset($_POST['query_enabled']) && $_POST['query_enabled'] == 1) {
-                                $query = 1;
-                            } else {
-                                $query = 0;
-                            }
-
-                            // Parent server
-                            if ($_POST['parent_server'] == 'none') {
-                                $parent = 0;
-                            } else {
-                                $parent = $_POST['parent_server'];
-                            }
-
-                            // Validate server port
-                            if (is_numeric(Input::get('server_port'))) {
-                                $port = Input::get('server_port');
-                            } else {
-                                if (!isset($_POST['server_port']) || empty($_POST['server_port'])) {
-                                    $port = null;
-                                } else {
-                                    $port = 25565;
-                                }
-                            }
-
-                            // Validate server query port
-                            if (is_numeric(Input::get('query_port'))) {
-                                $query_port = Input::get('query_port');
-                            } else {
-                                $query_port = 25565;
-                            }
-
-                            $last_server_order = DB::getInstance()->query('SELECT `order` FROM nl2_mc_servers ORDER BY `order` DESC LIMIT 1')->results();
-                            if (count($last_server_order)) {
-                                $last_server_order = $last_server_order[0]->order;
-                            } else {
-                                $last_server_order = 0;
-                            }
-
-                            DB::getInstance()->insert('mc_servers', [
-                                'ip' => Input::get('server_address'),
-                                'query_ip' => Input::get('server_address'),
-                                'name' => Input::get('server_name'),
-                                'display' => $status,
-                                'pre' => $pre,
-                                'player_list' => $query,
-                                'parent_server' => $parent,
-                                'bungee' => $bungee,
-                                'bedrock' => $bedrock,
-                                'port' => $port,
-                                'query_port' => $query_port,
-                                'show_ip' => $show_ip,
-                                'order' => $last_server_order + 1
-                            ]);
-
-                            Session::flash('admin_mc_servers_success', $language->get('admin', 'server_created'));
-                            Redirect::to(URL::build('/panel/minecraft/servers'));
-
-                        } catch (Exception $e) {
-                            $errors = [$e->getMessage()];
+                        // Bedrock selected?
+                        if (isset($_POST['bedrock']) && $_POST['bedrock'] == 1) {
+                            $bedrock = 1;
+                        } else {
+                            $bedrock = 0;
                         }
+
+                        // BungeeCord selected?
+                        if (isset($_POST['bungee_instance']) && $_POST['bungee_instance'] == 1) {
+                            $bungee = 1;
+                        } else {
+                            $bungee = 0;
+                        }
+
+                        // Pre 1.7?
+                        if (isset($_POST['pre_17']) && $_POST['pre_17'] == 1) {
+                            $pre = 1;
+                        } else {
+                            $pre = 0;
+                        }
+
+                        // Status enabled?
+                        if (isset($_POST['status_query_enabled']) && $_POST['status_query_enabled'] == 1) {
+                            $status = 1;
+                        } else {
+                            $status = 0;
+                        }
+
+                        // Show IP enabled?
+                        if (isset($_POST['show_ip_enabled']) && $_POST['show_ip_enabled'] == 1) {
+                            $show_ip = 1;
+                        } else {
+                            $show_ip = 0;
+                        }
+
+                        // Player list enabled?
+                        if (isset($_POST['query_enabled']) && $_POST['query_enabled'] == 1) {
+                            $query = 1;
+                        } else {
+                            $query = 0;
+                        }
+
+                        // Parent server
+                        if ($_POST['parent_server'] == 'none') {
+                            $parent = 0;
+                        } else {
+                            $parent = $_POST['parent_server'];
+                        }
+
+                        // Validate server port
+                        if (is_numeric(Input::get('server_port'))) {
+                            $port = Input::get('server_port');
+                        } else {
+                            if (!isset($_POST['server_port']) || empty($_POST['server_port'])) {
+                                $port = null;
+                            } else {
+                                $port = 25565;
+                            }
+                        }
+
+                        // Validate server query port
+                        if (is_numeric(Input::get('query_port'))) {
+                            $query_port = Input::get('query_port');
+                        } else {
+                            $query_port = 25565;
+                        }
+
+                        $last_server_order = DB::getInstance()->query('SELECT `order` FROM nl2_mc_servers ORDER BY `order` DESC LIMIT 1')->results();
+                        if (count($last_server_order)) {
+                            $last_server_order = $last_server_order[0]->order;
+                        } else {
+                            $last_server_order = 0;
+                        }
+
+                        DB::getInstance()->insert('mc_servers', [
+                            'ip' => Input::get('server_address'),
+                            'query_ip' => Input::get('server_address'),
+                            'name' => Input::get('server_name'),
+                            'display' => $status,
+                            'pre' => $pre,
+                            'player_list' => $query,
+                            'parent_server' => $parent,
+                            'bungee' => $bungee,
+                            'bedrock' => $bedrock,
+                            'port' => $port,
+                            'query_port' => $query_port,
+                            'show_ip' => $show_ip,
+                            'order' => $last_server_order + 1
+                        ]);
+
+                        Session::flash('admin_mc_servers_success', $language->get('admin', 'server_created'));
+                        Redirect::to(URL::build('/panel/minecraft/servers'));
                     } else {
                         // Validation failed
                         $errors = $validation->errors();
@@ -297,95 +292,90 @@ if (isset($_GET['action'])) {
 
                     if ($validation->passed()) {
                         // Handle input
-                        try {
-                            // Bedrock selected?
-                            if (isset($_POST['bedrock']) && $_POST['bedrock'] == 1) {
-                                $bedrock = 1;
-                            } else {
-                                $bedrock = 0;
-                            }
-
-                            // BungeeCord selected?
-                            if (isset($_POST['bungee_instance']) && $_POST['bungee_instance'] == 1) {
-                                $bungee = 1;
-                            } else {
-                                $bungee = 0;
-                            }
-
-                            // Pre 1.7?
-                            if (isset($_POST['pre_17']) && $_POST['pre_17'] == 1) {
-                                $pre = 1;
-                            } else {
-                                $pre = 0;
-                            }
-
-                            // Status enabled?
-                            if (isset($_POST['status_query_enabled']) && $_POST['status_query_enabled'] == 1) {
-                                $status = 1;
-                            } else {
-                                $status = 0;
-                            }
-
-                            // Show IP enabled?
-                            if (isset($_POST['show_ip_enabled']) && $_POST['show_ip_enabled'] == 1) {
-                                $show_ip = 1;
-                            } else {
-                                $show_ip = 0;
-                            }
-
-                            // Player list enabled?
-                            if (isset($_POST['query_enabled']) && $_POST['query_enabled'] == 1) {
-                                $query = 1;
-                            } else {
-                                $query = 0;
-                            }
-
-                            // Parent server
-                            if ($_POST['parent_server'] == 'none') {
-                                $parent = 0;
-                            } else {
-                                $parent = $_POST['parent_server'];
-                            }
-
-                            // Validate server port
-                            if (is_numeric(Input::get('server_port'))) {
-                                $port = Input::get('server_port');
-                            } else {
-                                if (!isset($_POST['server_port']) || empty($_POST['server_port'])) {
-                                    $port = null;
-                                } else {
-                                    $port = 25565;
-                                }
-                            }
-
-                            // Validate server query port
-                            if (is_numeric(Input::get('query_port'))) {
-                                $query_port = Input::get('query_port');
-                            } else {
-                                $query_port = 25565;
-                            }
-
-                            DB::getInstance()->update('mc_servers', $server_editing->id, [
-                                'ip' => Output::getClean(Input::get('server_address')),
-                                'query_ip' => Output::getClean(Input::get('server_address')),
-                                'name' => Output::getClean(Input::get('server_name')),
-                                'display' => $status,
-                                'pre' => $pre,
-                                'player_list' => $query,
-                                'parent_server' => $parent,
-                                'bungee' => $bungee,
-                                'bedrock' => $bedrock,
-                                'port' => $port,
-                                'query_port' => $query_port,
-                                'show_ip' => $show_ip
-                            ]);
-
-                            Session::flash('admin_mc_servers_success', $language->get('admin', 'server_updated'));
-                            Redirect::to(URL::build('/panel/minecraft/servers/', 'action=edit&id=' . urlencode($server_editing->id)));
-
-                        } catch (Exception $e) {
-                            $errors = [$e->getMessage()];
+                        // Bedrock selected?
+                        if (isset($_POST['bedrock']) && $_POST['bedrock'] == 1) {
+                            $bedrock = 1;
+                        } else {
+                            $bedrock = 0;
                         }
+
+                        // BungeeCord selected?
+                        if (isset($_POST['bungee_instance']) && $_POST['bungee_instance'] == 1) {
+                            $bungee = 1;
+                        } else {
+                            $bungee = 0;
+                        }
+
+                        // Pre 1.7?
+                        if (isset($_POST['pre_17']) && $_POST['pre_17'] == 1) {
+                            $pre = 1;
+                        } else {
+                            $pre = 0;
+                        }
+
+                        // Status enabled?
+                        if (isset($_POST['status_query_enabled']) && $_POST['status_query_enabled'] == 1) {
+                            $status = 1;
+                        } else {
+                            $status = 0;
+                        }
+
+                        // Show IP enabled?
+                        if (isset($_POST['show_ip_enabled']) && $_POST['show_ip_enabled'] == 1) {
+                            $show_ip = 1;
+                        } else {
+                            $show_ip = 0;
+                        }
+
+                        // Player list enabled?
+                        if (isset($_POST['query_enabled']) && $_POST['query_enabled'] == 1) {
+                            $query = 1;
+                        } else {
+                            $query = 0;
+                        }
+
+                        // Parent server
+                        if ($_POST['parent_server'] == 'none') {
+                            $parent = 0;
+                        } else {
+                            $parent = $_POST['parent_server'];
+                        }
+
+                        // Validate server port
+                        if (is_numeric(Input::get('server_port'))) {
+                            $port = Input::get('server_port');
+                        } else {
+                            if (!isset($_POST['server_port']) || empty($_POST['server_port'])) {
+                                $port = null;
+                            } else {
+                                $port = 25565;
+                            }
+                        }
+
+                        // Validate server query port
+                        if (is_numeric(Input::get('query_port'))) {
+                            $query_port = Input::get('query_port');
+                        } else {
+                            $query_port = 25565;
+                        }
+
+                        DB::getInstance()->update('mc_servers', $server_editing->id, [
+                            'ip' => Output::getClean(Input::get('server_address')),
+                            'query_ip' => Output::getClean(Input::get('server_address')),
+                            'name' => Output::getClean(Input::get('server_name')),
+                            'display' => $status,
+                            'pre' => $pre,
+                            'player_list' => $query,
+                            'parent_server' => $parent,
+                            'bungee' => $bungee,
+                            'bedrock' => $bedrock,
+                            'port' => $port,
+                            'query_port' => $query_port,
+                            'show_ip' => $show_ip
+                        ]);
+
+                        Session::flash('admin_mc_servers_success', $language->get('admin', 'server_updated'));
+                        Redirect::to(URL::build('/panel/minecraft/servers/', 'action=edit&id=' . urlencode($server_editing->id)));
                     } else {
                         // Validation failed
                         $errors = $validation->errors();
@@ -522,49 +512,42 @@ if (isset($_GET['action'])) {
             }
 
             // Update database and cache
-            try {
-                // Default server
-                if ($new_default > 0) {
-                    $current_default = DB::getInstance()->get('mc_servers', ['is_default', true])->results();
-                    if (count($current_default) && $current_default[0]->id != $new_default) {
-                        DB::getInstance()->update('mc_servers', $current_default[0]->id, [
-                            'is_default' => false,
-                        ]);
-                    }
-
-                    if (!count($current_default) || $current_default[0]->id != $new_default) {
-                        DB::getInstance()->update('mc_servers', $new_default, [
-                            'is_default' => true,
-                        ]);
-                    }
+            // Default server
+            if ($new_default > 0) {
+                $current_default = DB::getInstance()->get('mc_servers', ['is_default', true])->results();
+                if (count($current_default) && $current_default[0]->id != $new_default) {
+                    DB::getInstance()->update('mc_servers', $current_default[0]->id, [
+                        'is_default' => false,
+                    ]);
                 }
 
-                // Group sync server
-                Settings::set('group_sync_mc_server', $new_group_sync_server);
-
-                // Query type
-                Settings::set('query_type', $query_type);
-
-                // Player list limit
-                if ($player_list_limit != null) { // In case the field is hidden, we don't want to change this value
-                    Settings::set('player_list_limit', $player_list_limit);
+                if (!count($current_default) || $current_default[0]->id != $new_default) {
+                    DB::getInstance()->update('mc_servers', $new_default, [
+                        'is_default' => true,
+                    ]);
                 }
-
-                // Status page
-                Settings::set('status_page', $status);
-                // Query interval
-
-                if (isset($_POST['interval']) && is_numeric($_POST['interval']) && $_POST['interval'] <= 60 && $_POST['interval'] >= 5) {
-                    Settings::set('minecraft_query_interval', $_POST['interval']);
-                }
-
-                $success = $language->get('admin', 'minecraft_settings_updated_successfully');
-
-            } catch (Exception $e) {
-                // Error
-                $errors[] = $e->getMessage();
             }
 
+            // Group sync server
+            Settings::set('group_sync_mc_server', $new_group_sync_server);
+
+            // Query type
+            Settings::set('query_type', $query_type);
+
+            // Player list limit
+            if ($player_list_limit != null) { // In case the field is hidden, we don't want to change this value
+                Settings::set('player_list_limit', $player_list_limit);
+            }
+
+            // Status page
+            Settings::set('status_page', $status);
+            // Query interval
+
+            if (isset($_POST['interval']) && is_numeric($_POST['interval']) && $_POST['interval'] <= 60 && $_POST['interval'] >= 5) {
+                Settings::set('minecraft_query_interval', $_POST['interval']);
+            }
+
+            $success = $language->get('admin', 'minecraft_settings_updated_successfully');
         } else {
             $errors[] = $language->get('general', 'invalid_token');
         }

--- a/modules/Core/pages/panel/pages.php
+++ b/modules/Core/pages/panel/pages.php
@@ -110,81 +110,76 @@ if (!isset($_GET['action'])) {
                     ]);
 
                     if ($validation->passed()) {
-                        try {
-                            // Get link location
-                            if (isset($_POST['link_location'])) {
-                                switch ($_POST['link_location']) {
-                                    case 1:
-                                    case 2:
-                                    case 3:
-                                    case 4:
-                                        $location = $_POST['link_location'];
-                                        break;
-                                    default:
-                                        $location = 1;
-                                }
-                            } else {
-                                $location = 1;
+                        // Get link location
+                        if (isset($_POST['link_location'])) {
+                            switch ($_POST['link_location']) {
+                                case 1:
+                                case 2:
+                                case 3:
+                                case 4:
+                                    $location = $_POST['link_location'];
+                                    break;
+                                default:
+                                    $location = 1;
                             }
-
-                            $redirect = intval(isset($_POST['redirect_page']) && $_POST['redirect_page'] == 'on');
-                            $target = intval(isset($_POST['target']) && $_POST['target'] == 'on');
-                            $link = $_POST['redirect_link'] ?? '';
-                            $unsafe = intval(isset($_POST['unsafe_html']) && $_POST['unsafe_html'] == 'on');
-                            $sitemap = intval(isset($_POST['sitemap']) && $_POST['sitemap'] == 'on');
-                            $basic = intval(isset($_POST['basic']) && $_POST['basic'] == 'on');
-
-                            $event = new PreCustomPageCreateEvent(
-                                Input::get('content'),
-                                $user
-                            );
-                            EventHandler::executeEvent($event);
-
-                            DB::getInstance()->insert('custom_pages', [
-                                'url' => rtrim(Input::get('page_url'), '/'),
-                                'title' => Input::get('page_title'),
-                                'content' => $event->content,
-                                'link_location' => $location,
-                                'redirect' => $redirect,
-                                'link' => $link,
-                                'target' => $target,
-                                'all_html' => $unsafe,
-                                'sitemap' => $sitemap,
-                                'basic' => $basic,
-                            ]);
-
-                            $last_id = DB::getInstance()->lastId();
-
-                            // Permissions
-                            $perms = [];
-                            if (isset($_POST['perm-view-0']) && $_POST['perm-view-0'] == 1) {
-                                $perms[0] = 1;
-                            } else {
-                                $perms[0] = 0;
-                            }
-
-                            foreach (Group::all() as $group) {
-                                if (isset($_POST['perm-view-' . $group->id]) && $_POST['perm-view-' . $group->id] == 1) {
-                                    $perms[$group->id] = 1;
-                                } else {
-                                    $perms[$group->id] = 0;
-                                }
-                            }
-
-                            foreach ($perms as $key => $perm) {
-                                DB::getInstance()->insert('custom_pages_permissions', [
-                                    'page_id' => $last_id,
-                                    'group_id' => $key,
-                                    'view' => $perm
-                                ]);
-                            }
-
-                            Session::flash('admin_pages', $language->get('admin', 'page_created_successfully'));
-                            Redirect::to(URL::build('/panel/core/pages'));
-                        } catch (Exception $e) {
-                            $errors[] = $e->getMessage();
+                        } else {
+                            $location = 1;
                         }
 
+                        $redirect = intval(isset($_POST['redirect_page']) && $_POST['redirect_page'] == 'on');
+                        $target = intval(isset($_POST['target']) && $_POST['target'] == 'on');
+                        $link = $_POST['redirect_link'] ?? '';
+                        $unsafe = intval(isset($_POST['unsafe_html']) && $_POST['unsafe_html'] == 'on');
+                        $sitemap = intval(isset($_POST['sitemap']) && $_POST['sitemap'] == 'on');
+                        $basic = intval(isset($_POST['basic']) && $_POST['basic'] == 'on');
+
+                        $event = new PreCustomPageCreateEvent(
+                            Input::get('content'),
+                            $user
+                        );
+                        EventHandler::executeEvent($event);
+
+                        DB::getInstance()->insert('custom_pages', [
+                            'url' => rtrim(Input::get('page_url'), '/'),
+                            'title' => Input::get('page_title'),
+                            'content' => $event->content,
+                            'link_location' => $location,
+                            'redirect' => $redirect,
+                            'link' => $link,
+                            'target' => $target,
+                            'all_html' => $unsafe,
+                            'sitemap' => $sitemap,
+                            'basic' => $basic,
+                        ]);
+
+                        $last_id = DB::getInstance()->lastId();
+
+                        // Permissions
+                        $perms = [];
+                        if (isset($_POST['perm-view-0']) && $_POST['perm-view-0'] == 1) {
+                            $perms[0] = 1;
+                        } else {
+                            $perms[0] = 0;
+                        }
+
+                        foreach (Group::all() as $group) {
+                            if (isset($_POST['perm-view-' . $group->id]) && $_POST['perm-view-' . $group->id] == 1) {
+                                $perms[$group->id] = 1;
+                            } else {
+                                $perms[$group->id] = 0;
+                            }
+                        }
+
+                        foreach ($perms as $key => $perm) {
+                            DB::getInstance()->insert('custom_pages_permissions', [
+                                'page_id' => $last_id,
+                                'group_id' => $key,
+                                'view' => $perm
+                            ]);
+                        }
+
+                        Session::flash('admin_pages', $language->get('admin', 'page_created_successfully'));
+                        Redirect::to(URL::build('/panel/core/pages'));
                     } else {
                         $errors = $validation->errors();
                     }
@@ -311,92 +306,125 @@ if (!isset($_GET['action'])) {
                     ]);
 
                     if ($validation->passed()) {
-                        try {
-                            // Get link location
-                            if (isset($_POST['link_location'])) {
-                                switch ($_POST['link_location']) {
-                                    case 1:
-                                    case 2:
-                                    case 3:
-                                    case 4:
-                                        $location = $_POST['link_location'];
-                                        break;
-                                    default:
-                                        $location = 1;
-                                }
-                            } else {
-                                $location = 1;
+                        // Get link location
+                        if (isset($_POST['link_location'])) {
+                            switch ($_POST['link_location']) {
+                                case 1:
+                                case 2:
+                                case 3:
+                                case 4:
+                                    $location = $_POST['link_location'];
+                                    break;
+                                default:
+                                    $location = 1;
                             }
+                        } else {
+                            $location = 1;
+                        }
 
-                            $redirect = intval(isset($_POST['redirect_page']) && $_POST['redirect_page'] == 'on');
-                            $target = intval(isset($_POST['target']) && $_POST['target'] == 'on');
-                            $link = $_POST['redirect_link'] ?? '';
-                            $unsafe = intval(isset($_POST['unsafe_html']) && $_POST['unsafe_html'] == 'on');
-                            $sitemap = intval(isset($_POST['sitemap']) && $_POST['sitemap'] == 'on');
-                            $basic = intval(isset($_POST['basic']) && $_POST['basic'] == 'on');
+                        $redirect = intval(isset($_POST['redirect_page']) && $_POST['redirect_page'] == 'on');
+                        $target = intval(isset($_POST['target']) && $_POST['target'] == 'on');
+                        $link = $_POST['redirect_link'] ?? '';
+                        $unsafe = intval(isset($_POST['unsafe_html']) && $_POST['unsafe_html'] == 'on');
+                        $sitemap = intval(isset($_POST['sitemap']) && $_POST['sitemap'] == 'on');
+                        $basic = intval(isset($_POST['basic']) && $_POST['basic'] == 'on');
 
-                            $event = new PreCustomPageEditEvent(
-                                Input::get('content'),
-                                $user,
-                            );
-                            EventHandler::executeEvent($event);
+                        $event = new PreCustomPageEditEvent(
+                            Input::get('content'),
+                            $user,
+                        );
+                        EventHandler::executeEvent($event);
 
-                            DB::getInstance()->update('custom_pages', $page->id, [
-                                'url' => rtrim(Input::get('page_url'), '/'),
-                                'title' => Input::get('page_title'),
-                                'content' => $event->content,
-                                'link_location' => $location,
-                                'redirect' => $redirect,
-                                'link' => $link,
-                                'target' => $target,
-                                'all_html' => $unsafe,
-                                'sitemap' => $sitemap,
-                                'basic' => $basic
+                        DB::getInstance()->update('custom_pages', $page->id, [
+                            'url' => rtrim(Input::get('page_url'), '/'),
+                            'title' => Input::get('page_title'),
+                            'content' => $event->content,
+                            'link_location' => $location,
+                            'redirect' => $redirect,
+                            'link' => $link,
+                            'target' => $target,
+                            'all_html' => $unsafe,
+                            'sitemap' => $sitemap,
+                            'basic' => $basic
+                        ]);
+
+                        // Update all widget and announcement page arrays with the custom pages' new name
+                        $widget_query = DB::getInstance()->get('widgets', ['id', '<>', 0])->results();
+                        if (count($widget_query)) {
+                            foreach ($widget_query as $widget_row) {
+                                $pages = json_decode($widget_row->pages, true);
+                                $new_pages = [];
+                                if (is_array($pages) && count($pages)) {
+                                    foreach ($pages as $widget_page) {
+                                        if ($page->title == $widget_page) {
+                                            $new_pages[] = Input::get('page_title');
+                                        } else {
+                                            $new_pages[] = $widget_page;
+                                        }
+                                    }
+                                    DB::getInstance()->update('widgets', $widget_row->id, [
+                                        'pages' => json_encode($new_pages)
+                                    ]);
+                                }
+                            }
+                        }
+                        $announcement_query = DB::getInstance()->get('custom_announcements', ['id', '<>', 0])->results();
+                        if (count($announcement_query)) {
+                            foreach ($announcement_query as $announcement_row) {
+                                $pages = json_decode($announcement_row->pages, true);
+                                $new_pages = [];
+                                if (count($pages)) {
+                                    foreach ($pages as $announcement_page) {
+                                        if ($page->title == $announcement_page) {
+                                            $new_pages[] = Input::get('page_title');
+                                        } else {
+                                            $new_pages[] = $announcement_page;
+                                        }
+                                    }
+                                    DB::getInstance()->update('custom_announcements', $announcement_row->id, [
+                                        'pages' => json_encode($new_pages)
+                                    ]);
+                                }
+                            }
+                        }
+
+                        // Permissions
+                        // Guest first
+                        $view = Input::get('perm-view-0');
+
+                        if (!($view)) {
+                            $view = 0;
+                        }
+
+                        $page_perm_exists = 0;
+
+                        $page_perm_query = DB::getInstance()->get('custom_pages_permissions', ['page_id', $page->id])->results();
+                        if (count($page_perm_query)) {
+                            foreach ($page_perm_query as $query) {
+                                if ($query->group_id == 0) {
+                                    $page_perm_exists = 1;
+                                    $update_id = $query->id;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if ($page_perm_exists != 0) { // Permission already exists, update
+                            // Update the category
+                            DB::getInstance()->update('custom_pages_permissions', $update_id, [
+                                'view' => $view
                             ]);
+                        } else { // Permission doesn't exist, create
+                            DB::getInstance()->insert('custom_pages_permissions', [
+                                'group_id' => 0,
+                                'page_id' => $page->id,
+                                'view' => $view
+                            ]);
+                        }
 
-                            // Update all widget and announcement page arrays with the custom pages' new name
-                            $widget_query = DB::getInstance()->get('widgets', ['id', '<>', 0])->results();
-                            if (count($widget_query)) {
-                                foreach ($widget_query as $widget_row) {
-                                    $pages = json_decode($widget_row->pages, true);
-                                    $new_pages = [];
-                                    if (is_array($pages) && count($pages)) {
-                                        foreach ($pages as $widget_page) {
-                                            if ($page->title == $widget_page) {
-                                                $new_pages[] = Input::get('page_title');
-                                            } else {
-                                                $new_pages[] = $widget_page;
-                                            }
-                                        }
-                                        DB::getInstance()->update('widgets', $widget_row->id, [
-                                            'pages' => json_encode($new_pages)
-                                        ]);
-                                    }
-                                }
-                            }
-                            $announcement_query = DB::getInstance()->get('custom_announcements', ['id', '<>', 0])->results();
-                            if (count($announcement_query)) {
-                                foreach ($announcement_query as $announcement_row) {
-                                    $pages = json_decode($announcement_row->pages, true);
-                                    $new_pages = [];
-                                    if (count($pages)) {
-                                        foreach ($pages as $announcement_page) {
-                                            if ($page->title == $announcement_page) {
-                                                $new_pages[] = Input::get('page_title');
-                                            } else {
-                                                $new_pages[] = $announcement_page;
-                                            }
-                                        }
-                                        DB::getInstance()->update('custom_announcements', $announcement_row->id, [
-                                            'pages' => json_encode($new_pages)
-                                        ]);
-                                    }
-                                }
-                            }
-
-                            // Permissions
-                            // Guest first
-                            $view = Input::get('perm-view-0');
+                        // Group category permissions
+                        foreach (Group::all() as $group) {
+                            $view = Input::get('perm-view-' . $group->id);
 
                             if (!($view)) {
                                 $view = 0;
@@ -404,10 +432,9 @@ if (!isset($_GET['action'])) {
 
                             $page_perm_exists = 0;
 
-                            $page_perm_query = DB::getInstance()->get('custom_pages_permissions', ['page_id', $page->id])->results();
                             if (count($page_perm_query)) {
                                 foreach ($page_perm_query as $query) {
-                                    if ($query->group_id == 0) {
+                                    if ($query->group_id == $group->id) {
                                         $page_perm_exists = 1;
                                         $update_id = $query->id;
                                         break;
@@ -415,69 +442,22 @@ if (!isset($_GET['action'])) {
                                 }
                             }
 
-                            try {
-                                if ($page_perm_exists != 0) { // Permission already exists, update
-                                    // Update the category
-                                    DB::getInstance()->update('custom_pages_permissions', $update_id, [
-                                        'view' => $view
-                                    ]);
-                                } else { // Permission doesn't exist, create
-                                    DB::getInstance()->insert('custom_pages_permissions', [
-                                        'group_id' => 0,
-                                        'page_id' => $page->id,
-                                        'view' => $view
-                                    ]);
-                                }
-
-                            } catch (Exception $e) {
-                                $errors[] = $e->getMessage();
+                            if ($page_perm_exists != 0) { // Permission already exists, update
+                                // Update the category
+                                DB::getInstance()->update('custom_pages_permissions', $update_id, [
+                                    'view' => $view
+                                ]);
+                            } else { // Permission doesn't exist, create
+                                DB::getInstance()->insert('custom_pages_permissions', [
+                                    'group_id' => $group->id,
+                                    'page_id' => $page->id,
+                                    'view' => $view
+                                ]);
                             }
-
-                            // Group category permissions
-                            foreach (Group::all() as $group) {
-                                $view = Input::get('perm-view-' . $group->id);
-
-                                if (!($view)) {
-                                    $view = 0;
-                                }
-
-                                $page_perm_exists = 0;
-
-                                if (count($page_perm_query)) {
-                                    foreach ($page_perm_query as $query) {
-                                        if ($query->group_id == $group->id) {
-                                            $page_perm_exists = 1;
-                                            $update_id = $query->id;
-                                            break;
-                                        }
-                                    }
-                                }
-
-                                try {
-                                    if ($page_perm_exists != 0) { // Permission already exists, update
-                                        // Update the category
-                                        DB::getInstance()->update('custom_pages_permissions', $update_id, [
-                                            'view' => $view
-                                        ]);
-                                    } else { // Permission doesn't exist, create
-                                        DB::getInstance()->insert('custom_pages_permissions', [
-                                            'group_id' => $group->id,
-                                            'page_id' => $page->id,
-                                            'view' => $view
-                                        ]);
-                                    }
-
-                                } catch (Exception $e) {
-                                    $errors[] = $e->getMessage();
-                                }
-                            }
-
-                            Session::flash('admin_pages', $language->get('admin', 'page_updated_successfully'));
-                            Redirect::to(URL::build('/panel/core/pages'));
-                        } catch (Exception $e) {
-                            $errors[] = $e->getMessage();
                         }
 
+                        Session::flash('admin_pages', $language->get('admin', 'page_updated_successfully'));
+                        Redirect::to(URL::build('/panel/core/pages'));
                     } else {
                         $errors = $validation->errors();
                     }

--- a/modules/Core/pages/panel/panel_templates.php
+++ b/modules/Core/pages/panel/panel_templates.php
@@ -202,31 +202,27 @@ if (!isset($_GET['action'])) {
             if (Token::check()) {
                 $item = $_GET['template'];
 
-                try {
-                    // Ensure template is not default or active
-                    $template = DB::getInstance()->get('panel_templates', ['id', $item])->results();
-                    if (count($template)) {
-                        $template = $template[0];
-                        if ($template->name == 'Default' || $template->id == 1 || $template->enabled == 1 || $template->is_default == 1) {
-                            Redirect::to(URL::build('/panel/core/panel_templates'));
-                        }
-
-                        $item = $template->name;
-                    } else {
+                // Ensure template is not default or active
+                $template = DB::getInstance()->get('panel_templates', ['id', $item])->results();
+                if (count($template)) {
+                    $template = $template[0];
+                    if ($template->name == 'Default' || $template->id == 1 || $template->enabled == 1 || $template->is_default == 1) {
                         Redirect::to(URL::build('/panel/core/panel_templates'));
                     }
 
-                    if (!Util::recursiveRemoveDirectory(ROOT_PATH . '/custom/panel_templates/' . $item)) {
-                        Session::flash('admin_templates_error', $language->get('admin', 'unable_to_delete_template'));
-                    } else {
-                        Session::flash('admin_templates', $language->get('admin', 'template_deleted_successfully'));
-                    }
-
-                    // Delete from database
-                    DB::getInstance()->delete('templates', ['name', $item]);
-                } catch (Exception $e) {
-                    Session::flash('admin_templates_error', $e->getMessage());
+                    $item = $template->name;
+                } else {
+                    Redirect::to(URL::build('/panel/core/panel_templates'));
                 }
+
+                if (!Util::recursiveRemoveDirectory(ROOT_PATH . '/custom/panel_templates/' . $item)) {
+                    Session::flash('admin_templates_error', $language->get('admin', 'unable_to_delete_template'));
+                } else {
+                    Session::flash('admin_templates', $language->get('admin', 'template_deleted_successfully'));
+                }
+
+                // Delete from database
+                DB::getInstance()->delete('templates', ['name', $item]);
             } else {
                 Session::flash('admin_templates_error', $language->get('general', 'invalid_token'));
             }

--- a/modules/Core/pages/panel/privacy_and_terms.php
+++ b/modules/Core/pages/panel/privacy_and_terms.php
@@ -48,39 +48,35 @@ if (Input::exists()) {
         ]);
 
         if ($validation->passed()) {
-            try {
-                $privacy_id = DB::getInstance()->get('privacy_terms', ['name', 'privacy'])->results();
-                if (count($privacy_id)) {
-                    $privacy_id = $privacy_id[0]->id;
+            $privacy_id = DB::getInstance()->get('privacy_terms', ['name', 'privacy'])->results();
+            if (count($privacy_id)) {
+                $privacy_id = $privacy_id[0]->id;
 
-                    DB::getInstance()->update('privacy_terms', $privacy_id, [
-                        'value' => Input::get('privacy')
-                    ]);
-                } else {
-                    DB::getInstance()->insert('privacy_terms', [
-                        'name' => 'privacy',
-                        'value' => Input::get('privacy')
-                    ]);
-                }
-
-                $terms_id = DB::getInstance()->get('privacy_terms', ['name', 'terms'])->results();
-                if (count($terms_id)) {
-                    $terms_id = $terms_id[0]->id;
-
-                    DB::getInstance()->update('privacy_terms', $terms_id, [
-                        'value' => Input::get('terms')
-                    ]);
-                } else {
-                    DB::getInstance()->insert('privacy_terms', [
-                        'name' => 'terms',
-                        'value' => Input::get('terms')
-                    ]);
-                }
-
-                $success = $language->get('admin', 'terms_updated');
-            } catch (Exception $e) {
-                $errors[] = $e->getMessage();
+                DB::getInstance()->update('privacy_terms', $privacy_id, [
+                    'value' => Input::get('privacy')
+                ]);
+            } else {
+                DB::getInstance()->insert('privacy_terms', [
+                    'name' => 'privacy',
+                    'value' => Input::get('privacy')
+                ]);
             }
+
+            $terms_id = DB::getInstance()->get('privacy_terms', ['name', 'terms'])->results();
+            if (count($terms_id)) {
+                $terms_id = $terms_id[0]->id;
+
+                DB::getInstance()->update('privacy_terms', $terms_id, [
+                    'value' => Input::get('terms')
+                ]);
+            } else {
+                DB::getInstance()->insert('privacy_terms', [
+                    'name' => 'terms',
+                    'value' => Input::get('terms')
+                ]);
+            }
+
+            $success = $language->get('admin', 'terms_updated');
         } else {
             $errors = $validation->errors();
         }

--- a/modules/Core/pages/panel/profile_fields.php
+++ b/modules/Core/pages/panel/profile_fields.php
@@ -53,51 +53,47 @@ if (isset($_GET['action'])) {
 
                 if ($validation->passed()) {
                     // Input into database
-                    try {
-                        // Get whether required/public/editable/forum post options are enabled or not
-                        if (isset($_POST['required']) && $_POST['required'] == 'on') {
-                            $required = 1;
-                        } else {
-                            $required = 0;
-                        }
-
-                        if (isset($_POST['public']) && $_POST['public'] == 'on') {
-                            $public = 1;
-                        } else {
-                            $public = 0;
-                        }
-
-                        if (isset($_POST['forum']) && $_POST['forum'] == 'on') {
-                            $forum_posts = 1;
-                        } else {
-                            $forum_posts = 0;
-                        }
-
-                        if (isset($_POST['editable']) && $_POST['editable'] == 'on') {
-                            $editable = 1;
-                        } else {
-                            $editable = 0;
-                        }
-
-                        // Insert into database
-                        DB::getInstance()->insert('profile_fields', [
-                            'name' => Input::get('name'),
-                            'type' => Input::get('type'),
-                            'public' => $public,
-                            'required' => $required,
-                            'description' => Input::get('description'),
-                            'forum_posts' => $forum_posts,
-                            'editable' => $editable
-                        ]);
-
-                        //Log::getInstance()->log(Log::Action('admin/core/profile/new'), Output::getClean(Input::get('name')));
-
-                        // Redirect
-                        Session::flash('profile_field_success', $language->get('admin', 'profile_field_created_successfully'));
-                        Redirect::to(URL::build('/panel/core/profile_fields'));
-                    } catch (Exception $e) {
-                        $errors[] = $e->getMessage();
+                    // Get whether required/public/editable/forum post options are enabled or not
+                    if (isset($_POST['required']) && $_POST['required'] == 'on') {
+                        $required = 1;
+                    } else {
+                        $required = 0;
                     }
+
+                    if (isset($_POST['public']) && $_POST['public'] == 'on') {
+                        $public = 1;
+                    } else {
+                        $public = 0;
+                    }
+
+                    if (isset($_POST['forum']) && $_POST['forum'] == 'on') {
+                        $forum_posts = 1;
+                    } else {
+                        $forum_posts = 0;
+                    }
+
+                    if (isset($_POST['editable']) && $_POST['editable'] == 'on') {
+                        $editable = 1;
+                    } else {
+                        $editable = 0;
+                    }
+
+                    // Insert into database
+                    DB::getInstance()->insert('profile_fields', [
+                        'name' => Input::get('name'),
+                        'type' => Input::get('type'),
+                        'public' => $public,
+                        'required' => $required,
+                        'description' => Input::get('description'),
+                        'forum_posts' => $forum_posts,
+                        'editable' => $editable
+                    ]);
+
+                    //Log::getInstance()->log(Log::Action('admin/core/profile/new'), Output::getClean(Input::get('name')));
+
+                    // Redirect
+                    Session::flash('profile_field_success', $language->get('admin', 'profile_field_created_successfully'));
+                    Redirect::to(URL::build('/panel/core/profile_fields'));
                 } else {
                     // Display errors
                     $errors = $validation->errors();
@@ -167,51 +163,47 @@ if (isset($_GET['action'])) {
 
                         if ($validation->passed()) {
                             // Update database
-                            try {
-                                // Get whether required/public/editable/forum post options are enabled or not
-                                if (isset($_POST['required']) && $_POST['required'] == 'on') {
-                                    $required = 1;
-                                } else {
-                                    $required = 0;
-                                }
-
-                                if (isset($_POST['public']) && $_POST['public'] == 'on') {
-                                    $public = 1;
-                                } else {
-                                    $public = 0;
-                                }
-
-                                if (isset($_POST['forum']) && $_POST['forum'] == 'on') {
-                                    $forum_posts = 1;
-                                } else {
-                                    $forum_posts = 0;
-                                }
-
-                                if (isset($_POST['editable']) && $_POST['editable'] == 'on') {
-                                    $editable = 1;
-                                } else {
-                                    $editable = 0;
-                                }
-
-                                // Update database
-                                DB::getInstance()->update('profile_fields', $field->id, [
-                                    'name' => Output::getClean(Input::get('name')),
-                                    'type' => Input::get('type'),
-                                    'public' => $public,
-                                    'required' => $required,
-                                    'description' => Output::getClean(Input::get('description')),
-                                    'forum_posts' => $forum_posts,
-                                    'editable' => $editable
-                                ]);
-
-                                //Log::getInstance()->log(Log::Action('admin/core/profile/update'), Output::getClean(Input::get('name')));
-
-                                // Redirect
-                                Session::flash('profile_field_success', $language->get('admin', 'profile_field_updated_successfully'));
-                                Redirect::to(URL::build('/panel/core/profile_fields/', 'action=edit&id=' . urlencode($field->id)));
-                            } catch (Exception $e) {
-                                $errors[] = $e->getMessage();
+                            // Get whether required/public/editable/forum post options are enabled or not
+                            if (isset($_POST['required']) && $_POST['required'] == 'on') {
+                                $required = 1;
+                            } else {
+                                $required = 0;
                             }
+
+                            if (isset($_POST['public']) && $_POST['public'] == 'on') {
+                                $public = 1;
+                            } else {
+                                $public = 0;
+                            }
+
+                            if (isset($_POST['forum']) && $_POST['forum'] == 'on') {
+                                $forum_posts = 1;
+                            } else {
+                                $forum_posts = 0;
+                            }
+
+                            if (isset($_POST['editable']) && $_POST['editable'] == 'on') {
+                                $editable = 1;
+                            } else {
+                                $editable = 0;
+                            }
+
+                            // Update database
+                            DB::getInstance()->update('profile_fields', $field->id, [
+                                'name' => Output::getClean(Input::get('name')),
+                                'type' => Input::get('type'),
+                                'public' => $public,
+                                'required' => $required,
+                                'description' => Output::getClean(Input::get('description')),
+                                'forum_posts' => $forum_posts,
+                                'editable' => $editable
+                            ]);
+
+                            //Log::getInstance()->log(Log::Action('admin/core/profile/update'), Output::getClean(Input::get('name')));
+
+                            // Redirect
+                            Session::flash('profile_field_success', $language->get('admin', 'profile_field_updated_successfully'));
+                            Redirect::to(URL::build('/panel/core/profile_fields/', 'action=edit&id=' . urlencode($field->id)));
                         } else {
                             // Error
                             $errors = $validation->errors();

--- a/modules/Core/pages/panel/templates.php
+++ b/modules/Core/pages/panel/templates.php
@@ -262,31 +262,27 @@ if (!isset($_GET['action'])) {
             if (Token::check()) {
                 $item = $_GET['template'];
 
-                try {
-                    // Ensure template is not default or active
-                    $template = DB::getInstance()->get('templates', ['id', $item])->results();
-                    if (count($template)) {
-                        $template = $template[0];
-                        if ($template->name == 'DefaultRevamp' || $template->id == 1 || $template->enabled == 1 || $template->is_default == 1) {
-                            Redirect::to(URL::build('/panel/core/templates'));
-                        }
-
-                        $item = $template->name;
-                    } else {
+                // Ensure template is not default or active
+                $template = DB::getInstance()->get('templates', ['id', $item])->results();
+                if (count($template)) {
+                    $template = $template[0];
+                    if ($template->name == 'DefaultRevamp' || $template->id == 1 || $template->enabled == 1 || $template->is_default == 1) {
                         Redirect::to(URL::build('/panel/core/templates'));
                     }
 
-                    if (!Util::recursiveRemoveDirectory(ROOT_PATH . '/custom/templates/' . $item)) {
-                        Session::flash('admin_templates_error', $language->get('admin', 'unable_to_delete_template'));
-                    } else {
-                        Session::flash('admin_templates', $language->get('admin', 'template_deleted_successfully'));
-                    }
-
-                    // Delete from database
-                    DB::getInstance()->delete('templates', ['name', $item]);
-                } catch (Exception $e) {
-                    Session::flash('admin_templates_error', $e->getMessage());
+                    $item = $template->name;
+                } else {
+                    Redirect::to(URL::build('/panel/core/templates'));
                 }
+
+                if (!Util::recursiveRemoveDirectory(ROOT_PATH . '/custom/templates/' . $item)) {
+                    Session::flash('admin_templates_error', $language->get('admin', 'unable_to_delete_template'));
+                } else {
+                    Session::flash('admin_templates', $language->get('admin', 'template_deleted_successfully'));
+                }
+
+                // Delete from database
+                DB::getInstance()->delete('templates', ['name', $item]);
             } else {
                 Session::flash('admin_templates_error', $language->get('general', 'invalid_token'));
             }
@@ -416,21 +412,17 @@ if (!isset($_GET['action'])) {
                         }
                     }
 
-                    try {
-                        if ($perm_exists != 0) { // Permission already exists, update
-                            // Update the permission
-                            DB::getInstance()->update('groups_templates', $update_id, [
-                                'can_use_template' => $can_use_template
-                            ]);
-                        } else { // Permission doesn't exist, create
-                            DB::getInstance()->insert('groups_templates', [
-                                'group_id' => 0,
-                                'template_id' => $template_query->id,
-                                'can_use_template' => $can_use_template,
-                            ]);
-                        }
-                    } catch (Exception $e) {
-                        $errors[] = $e->getMessage();
+                    if ($perm_exists != 0) { // Permission already exists, update
+                        // Update the permission
+                        DB::getInstance()->update('groups_templates', $update_id, [
+                            'can_use_template' => $can_use_template
+                        ]);
+                    } else { // Permission doesn't exist, create
+                        DB::getInstance()->insert('groups_templates', [
+                            'group_id' => 0,
+                            'template_id' => $template_query->id,
+                            'can_use_template' => $can_use_template,
+                        ]);
                     }
 
                     // Group template permissions
@@ -453,21 +445,17 @@ if (!isset($_GET['action'])) {
                             }
                         }
 
-                        try {
-                            if ($perm_exists != 0) { // Permission already exists, update
-                                // Update the permission
-                                DB::getInstance()->update('groups_templates', $update_id, [
-                                    'can_use_template' => $can_use_template,
-                                ]);
-                            } else { // Permission doesn't exist, create
-                                DB::getInstance()->insert('groups_templates', [
-                                    'group_id' => $group->id,
-                                    'template_id' => $template_query->id,
-                                    'can_use_template' => $can_use_template,
-                                ]);
-                            }
-                        } catch (Exception $e) {
-                            $errors[] = $e->getMessage();
+                        if ($perm_exists != 0) { // Permission already exists, update
+                            // Update the permission
+                            DB::getInstance()->update('groups_templates', $update_id, [
+                                'can_use_template' => $can_use_template,
+                            ]);
+                        } else { // Permission doesn't exist, create
+                            DB::getInstance()->insert('groups_templates', [
+                                'group_id' => $group->id,
+                                'template_id' => $template_query->id,
+                                'can_use_template' => $can_use_template,
+                            ]);
                         }
                     }
 

--- a/modules/Core/pages/panel/users_edit.php
+++ b/modules/Core/pages/panel/users_edit.php
@@ -157,87 +157,83 @@ if (Input::exists()) {
             }
 
             if ($validation->passed() && $passed) {
-                try {
-                    $private_profile_active = Settings::get('private_profile');
-                    $private_profile = 0;
+                $private_profile_active = Settings::get('private_profile');
+                $private_profile = 0;
 
-                    if ($private_profile_active) {
-                        $private_profile = Input::get('privateProfile');
-                    }
-
-                    // Template
-                    if (Input::get('template') != 0) {
-                        $new_template = DB::getInstance()->get('templates', ['id', Input::get('template')])->results();
-
-                        if (count($new_template)) {
-                            $new_template = $new_template[0]->id;
-                        } else {
-                            $new_template = $user_query->theme_id;
-                        }
-                    } else {
-                        $new_template = null;
-                    }
-
-                    // Nicknames?
-                    $username = Input::get('username');
-                    if (Settings::get('displaynames') === '1') {
-                        $nickname = Input::get('nickname');
-                    } else {
-                        $nickname = Input::get('username');
-                    }
-
-                    $view_user->update([
-                        'nickname' => Output::getClean($nickname),
-                        'email' => Output::getClean(Input::get('email')),
-                        'username' => Output::getClean($username),
-                        'user_title' => Output::getClean(Input::get('title')),
-                        'signature' => $signature,
-                        'private_profile' => $private_profile,
-                        'language_id' => Output::getClean(Input::get('language')),
-                        'timezone' => Output::getClean(Input::get('timezone')),
-                        'theme_id' => $new_template
-                    ]);
-
-                    $group_sync_log = [];
-                    if ($view_user->data()->id != $user->data()->id || $user->hasPermission('admincp.groups.self')) {
-                        if ($view_user->data()->id == 1 || (isset($_POST['groups']) && count($_POST['groups']))) {
-                            $groups_added = [];
-                            $groups_removed = [];
-
-                            $user_group_ids = $view_user->getAllGroupIds();
-                            $form_groups = $_POST['groups'] ?? [];
-
-                            // Check for new groups to give them which they don't already have
-                            foreach ($form_groups as $group_id) {
-                                if (!in_array($group_id, $user_group_ids)) {
-                                    $groups_added[] = $group_id;
-                                    $view_user->addGroup($group_id);
-                                }
-                            }
-
-                            // Check for groups they had, but weren't in the $_POST groups
-                            foreach ($user_group_ids as $group_id) {
-                                if (!in_array($group_id, $form_groups)) {
-                                    $groups_removed[] = $group_id;
-                                    $view_user->removeGroup($group_id);
-                                }
-                            }
-
-                            // Dispatch groupsync with all of their groups
-                            GroupSyncManager::getInstance()->broadcastGroupChange(
-                                $view_user,
-                                NamelessMCGroupSyncInjector::class,
-                                $groups_added,
-                                $groups_removed,
-                            );
-                        }
-                    }
-
-                    Session::flash('edit_user_success', $language->get('admin', 'user_updated_successfully'));
-                    Redirect::to(URL::build('/panel/users/edit/', 'id=' . urlencode($user_query->id)));
-                } catch (Exception $e) {
-                    $errors[] = $e->getMessage();
+                if ($private_profile_active) {
+                    $private_profile = Input::get('privateProfile');
                 }
+
+                // Template
+                if (Input::get('template') != 0) {
+                    $new_template = DB::getInstance()->get('templates', ['id', Input::get('template')])->results();
+
+                    if (count($new_template)) {
+                        $new_template = $new_template[0]->id;
+                    } else {
+                        $new_template = $user_query->theme_id;
+                    }
+                } else {
+                    $new_template = null;
+                }
+
+                // Nicknames?
+                $username = Input::get('username');
+                if (Settings::get('displaynames') === '1') {
+                    $nickname = Input::get('nickname');
+                } else {
+                    $nickname = Input::get('username');
+                }
+
+                $view_user->update([
+                    'nickname' => Output::getClean($nickname),
+                    'email' => Output::getClean(Input::get('email')),
+                    'username' => Output::getClean($username),
+                    'user_title' => Output::getClean(Input::get('title')),
+                    'signature' => $signature,
+                    'private_profile' => $private_profile,
+                    'language_id' => Output::getClean(Input::get('language')),
+                    'timezone' => Output::getClean(Input::get('timezone')),
+                    'theme_id' => $new_template
+                ]);
+
+                $group_sync_log = [];
+                if ($view_user->data()->id != $user->data()->id || $user->hasPermission('admincp.groups.self')) {
+                    if ($view_user->data()->id == 1 || (isset($_POST['groups']) && count($_POST['groups']))) {
+                        $groups_added = [];
+                        $groups_removed = [];
+
+                        $user_group_ids = $view_user->getAllGroupIds();
+                        $form_groups = $_POST['groups'] ?? [];
+
+                        // Check for new groups to give them which they don't already have
+                        foreach ($form_groups as $group_id) {
+                            if (!in_array($group_id, $user_group_ids)) {
+                                $groups_added[] = $group_id;
+                                $view_user->addGroup($group_id);
+                            }
+                        }
+
+                        // Check for groups they had, but weren't in the $_POST groups
+                        foreach ($user_group_ids as $group_id) {
+                            if (!in_array($group_id, $form_groups)) {
+                                $groups_removed[] = $group_id;
+                                $view_user->removeGroup($group_id);
+                            }
+                        }
+
+                        // Dispatch groupsync with all of their groups
+                        GroupSyncManager::getInstance()->broadcastGroupChange(
+                            $view_user,
+                            NamelessMCGroupSyncInjector::class,
+                            $groups_added,
+                            $groups_removed,
+                        );
+                    }
+                }
+
+                Session::flash('edit_user_success', $language->get('admin', 'user_updated_successfully'));
+                Redirect::to(URL::build('/panel/users/edit/', 'id=' . urlencode($user_query->id)));
             } else {
                 $errors = $validation->errors();
                 if (!$passed) {

--- a/modules/Core/pages/panel/users_punishments.php
+++ b/modules/Core/pages/panel/users_punishments.php
@@ -54,42 +54,27 @@ if (isset($_GET['user'])) {
             // Unban user/IP
             if ($infraction->type == 1) {
                 // Unban user
-                try {
+                DB::getInstance()->update('users', $query->id, [
+                    'isbanned' => false,
+                    'active' => true,
+                ]);
+            } else {
+                if ($infraction->type == 3) {
                     DB::getInstance()->update('users', $query->id, [
                         'isbanned' => false,
                         'active' => true,
                     ]);
-                } catch (Exception $e) {
-                    // Error
-                    $errors = [$e->getMessage()];
-                }
-            } else {
-                if ($infraction->type == 3) {
-                    try {
-                        DB::getInstance()->update('users', $query->id, [
-                            'isbanned' => false,
-                            'active' => true,
-                        ]);
 
-                        DB::getInstance()->delete('ip_bans', ['ip', $query->lastip]);
-                    } catch (Exception $e) {
-                        // Error
-                        $errors = [$e->getMessage()];
-                    }
+                    DB::getInstance()->delete('ip_bans', ['ip', $query->lastip]);
                 }
             }
 
-            try {
-                DB::getInstance()->update('infractions', $infraction->id, [
-                    'acknowledged' => true,
-                    'revoked' => true,
-                    'revoked_by' => $user->data()->id,
-                    'revoked_at' => date('U')
-                ]);
-            } catch (Exception $e) {
-                // Error
-                $errors = [$e->getMessage()];
-            }
+            DB::getInstance()->update('infractions', $infraction->id, [
+                'acknowledged' => true,
+                'revoked' => true,
+                'revoked_by' => $user->data()->id,
+                'revoked_at' => date('U')
+            ]);
 
             Session::flash('user_punishment_success', $language->get('moderator', 'punishment_revoked'));
 
@@ -141,147 +126,143 @@ if (isset($_GET['user'])) {
 
                 // Check reason
                 if (isset($_POST['reason']) && strlen($_POST['reason']) >= 5 && strlen($_POST['reason']) <= 5000) {
-                    try {
-                        // Ensure user is not an admin
-                        $banned_user = new User($query->id);
-                        $is_admin = $banned_user->canViewStaffCP();
+                    // Ensure user is not an admin
+                    $banned_user = new User($query->id);
+                    $is_admin = $banned_user->canViewStaffCP();
 
-                        // Ensure user is not admin
-                        if (!$is_admin) {
-                            // Prevent ip banning if target ip match the user ip
-                            // TODO: Change message for when IP matches
-                            if ($type != 3 || $user->data()->lastip != $banned_user->data()->lastip) {
-                                DB::getInstance()->insert('infractions', [
-                                    'type' => $type,
-                                    'punished' => $query->id,
-                                    'staff' => $user->data()->id,
-                                    'reason' => $_POST['reason'],
-                                    'infraction_date' => date('Y-m-d H:i:s'),
-                                    'created' => date('U'),
-                                    'acknowledged' => ($type == 2) ? 0 : 1,
-                                ]);
+                    // Ensure user is not admin
+                    if (!$is_admin) {
+                        // Prevent ip banning if target ip match the user ip
+                        // TODO: Change message for when IP matches
+                        if ($type != 3 || $user->data()->lastip != $banned_user->data()->lastip) {
+                            DB::getInstance()->insert('infractions', [
+                                'type' => $type,
+                                'punished' => $query->id,
+                                'staff' => $user->data()->id,
+                                'reason' => $_POST['reason'],
+                                'infraction_date' => date('Y-m-d H:i:s'),
+                                'created' => date('U'),
+                                'acknowledged' => ($type == 2) ? 0 : 1,
+                            ]);
 
-                                switch($type) {
-                                    case 1:
-                                    case 3:
-                                        // Ban the user
-                                        DB::getInstance()->update('users', $query->id, [
-                                            'isbanned' => true,
-                                            'active' => false
+                            switch($type) {
+                                case 1:
+                                case 3:
+                                    // Ban the user
+                                    DB::getInstance()->update('users', $query->id, [
+                                        'isbanned' => true,
+                                        'active' => false
+                                    ]);
+
+                                    $banned_user_ip = $banned_user->data()->lastip;
+
+                                    DB::getInstance()->delete('users_session', ['user_id', $query->id]);
+
+                                    if ($type == 3) {
+                                        // Ban IP
+                                        DB::getInstance()->insert('ip_bans', [
+                                            'ip' => $banned_user_ip,
+                                            'banned_by' => $user->data()->id,
+                                            'banned_at' => date('U'),
+                                            'reason' => $_POST['reason']
                                         ]);
-
-                                        $banned_user_ip = $banned_user->data()->lastip;
-
-                                        DB::getInstance()->delete('users_session', ['user_id', $query->id]);
-
-                                        if ($type == 3) {
-                                            // Ban IP
-                                            DB::getInstance()->insert('ip_bans', [
-                                                'ip' => $banned_user_ip,
-                                                'banned_by' => $user->data()->id,
-                                                'banned_at' => date('U'),
-                                                'reason' => $_POST['reason']
-                                            ]);
-                                        }
-
-                                        // Fire userBanned event
-                                        EventHandler::executeEvent(new UserBannedEvent(
-                                            $banned_user,
-                                            $user,
-                                            $_POST['reason'],
-                                            $type == 3
-                                        ));
-                                        break;
-                                    case 2:
-                                        // Fire userWarned event
-                                        EventHandler::executeEvent(new UserWarnedEvent(
-                                            $banned_user,
-                                            $user,
-                                            $_POST['reason']
-                                        ));
-                                        break;
-                                    case 4:
-                                        // Need to delete any other avatars
-                                        $to_remove = [];
-                                        foreach (['jpg', 'jpeg', 'png', 'gif'] as $extension) {
-                                            $to_remove += glob(ROOT_PATH . '/uploads/avatars/' . $query->id . '.' . $extension);
-                                        }
-
-                                        foreach ($to_remove as $item) {
-                                            unlink($item);
-                                        }
-
-                                        DB::getInstance()->update('users', $query->id, [
-                                            'has_avatar' => false,
-                                            'avatar_updated' => date('U')
-                                        ]);
-                                        break;
-                                    default:
-                                        throw new InvalidArgumentException("Unexpected type $type");
-                                }
-
-                                // Send alerts
-                                $groups_query = DB::getInstance()->query('SELECT id FROM nl2_groups WHERE permissions LIKE \'%"modcp.punishments":1%\'');
-                                if ($groups_query->count()) {
-                                    $groups_query = $groups_query->results();
-
-                                    $groups = '(';
-                                    foreach ($groups_query as $group) {
-                                        if (is_numeric($group->id)) {
-                                            $groups .= ((int)$group->id) . ',';
-                                        }
                                     }
-                                    $groups = rtrim($groups, ',') . ')';
 
-                                    // Get users in this group
-                                    $users = DB::getInstance()->query('SELECT DISTINCT(nl2_users.id) AS id FROM nl2_users LEFT JOIN nl2_users_groups ON nl2_users.id = nl2_users_groups.user_id WHERE group_id in ' . $groups);
-
-                                    if ($users->count()) {
-                                        $users = $users->results();
-
-                                        foreach ($users as $item) {
-                                            if ($user->data()->id == $item->id) {
-                                                continue;
-                                            }
-
-                                            // Send alert
-                                            Alert::create(
-                                                $item->id,
-                                                'punishment',
-                                                [
-                                                    'path' => 'core',
-                                                    'file' => 'moderator',
-                                                    'term' => 'user_punished_alert',
-                                                    'replace' => ['{{staffUser}}', '{{user}}'],
-                                                    'replace_with' => [
-                                                        Output::getClean($user->data()->nickname),
-                                                        Output::getClean($query->nickname),
-                                                    ],
-                                                ],
-                                                [
-                                                    'path' => 'core',
-                                                    'file' => 'moderator',
-                                                    'term' => 'user_punished_alert',
-                                                    'replace' => ['{{staffUser}}', '{{user}}'],
-                                                    'replace_with' => [
-                                                        Output::getClean($user->data()->nickname),
-                                                        Output::getClean($query->nickname)
-                                                    ],
-                                                ],
-                                                URL::build('/panel/users/punishments/', 'user=' . urlencode($query->id))
-                                            );
-                                        }
+                                    // Fire userBanned event
+                                    EventHandler::executeEvent(new UserBannedEvent(
+                                        $banned_user,
+                                        $user,
+                                        $_POST['reason'],
+                                        $type == 3
+                                    ));
+                                    break;
+                                case 2:
+                                    // Fire userWarned event
+                                    EventHandler::executeEvent(new UserWarnedEvent(
+                                        $banned_user,
+                                        $user,
+                                        $_POST['reason']
+                                    ));
+                                    break;
+                                case 4:
+                                    // Need to delete any other avatars
+                                    $to_remove = [];
+                                    foreach (['jpg', 'jpeg', 'png', 'gif'] as $extension) {
+                                        $to_remove += glob(ROOT_PATH . '/uploads/avatars/' . $query->id . '.' . $extension);
                                     }
-                                }
-                                Redirect::to(URL::build('/panel/users/punishments/', 'user=' . urlencode($query->id)));
-                            } else {
-                                $errors[] = $language->get('moderator', 'cant_punish_admin');
+
+                                    foreach ($to_remove as $item) {
+                                        unlink($item);
+                                    }
+
+                                    DB::getInstance()->update('users', $query->id, [
+                                        'has_avatar' => false,
+                                        'avatar_updated' => date('U')
+                                    ]);
+                                    break;
+                                default:
+                                    throw new InvalidArgumentException("Unexpected type $type");
                             }
+
+                            // Send alerts
+                            $groups_query = DB::getInstance()->query('SELECT id FROM nl2_groups WHERE permissions LIKE \'%"modcp.punishments":1%\'');
+                            if ($groups_query->count()) {
+                                $groups_query = $groups_query->results();
+
+                                $groups = '(';
+                                foreach ($groups_query as $group) {
+                                    if (is_numeric($group->id)) {
+                                        $groups .= ((int)$group->id) . ',';
+                                    }
+                                }
+                                $groups = rtrim($groups, ',') . ')';
+
+                                // Get users in this group
+                                $users = DB::getInstance()->query('SELECT DISTINCT(nl2_users.id) AS id FROM nl2_users LEFT JOIN nl2_users_groups ON nl2_users.id = nl2_users_groups.user_id WHERE group_id in ' . $groups);
+
+                                if ($users->count()) {
+                                    $users = $users->results();
+
+                                    foreach ($users as $item) {
+                                        if ($user->data()->id == $item->id) {
+                                            continue;
+                                        }
+
+                                        // Send alert
+                                        Alert::create(
+                                            $item->id,
+                                            'punishment',
+                                            [
+                                                'path' => 'core',
+                                                'file' => 'moderator',
+                                                'term' => 'user_punished_alert',
+                                                'replace' => ['{{staffUser}}', '{{user}}'],
+                                                'replace_with' => [
+                                                    Output::getClean($user->data()->nickname),
+                                                    Output::getClean($query->nickname),
+                                                ],
+                                            ],
+                                            [
+                                                'path' => 'core',
+                                                'file' => 'moderator',
+                                                'term' => 'user_punished_alert',
+                                                'replace' => ['{{staffUser}}', '{{user}}'],
+                                                'replace_with' => [
+                                                    Output::getClean($user->data()->nickname),
+                                                    Output::getClean($query->nickname)
+                                                ],
+                                            ],
+                                            URL::build('/panel/users/punishments/', 'user=' . urlencode($query->id))
+                                        );
+                                    }
+                                }
+                            }
+                            Redirect::to(URL::build('/panel/users/punishments/', 'user=' . urlencode($query->id)));
                         } else {
                             $errors[] = $language->get('moderator', 'cant_punish_admin');
                         }
-                    } catch (Exception $e) {
-                        $errors[] = $e->getMessage();
+                    } else {
+                        $errors[] = $language->get('moderator', 'cant_punish_admin');
                     }
                 } else {
                     $errors[] = $language->get('moderator', 'enter_valid_punishment_reason');

--- a/modules/Core/pages/panel/widgets.php
+++ b/modules/Core/pages/panel/widgets.php
@@ -157,37 +157,33 @@ if (!isset($_GET['action'])) {
 
         if (Input::exists()) {
             if (Token::check()) {
-                try {
-                    // Profile widgets cannot be on specific pages
-                    if (!$is_profile_widget) {
-                        // Updated pages list
-                        if (isset($_POST['pages']) && count($_POST['pages'])) {
-                            $active_pages = $_POST['pages'];
-                        } else {
-                            $active_pages = [];
-                        }
+                // Profile widgets cannot be on specific pages
+                if (!$is_profile_widget) {
+                    // Updated pages list
+                    if (isset($_POST['pages']) && count($_POST['pages'])) {
+                        $active_pages = $_POST['pages'];
+                    } else {
+                        $active_pages = [];
                     }
-
-                    $active_pages_string = json_encode($active_pages);
-                    $order = ($_POST['order'] ?? 10);
-
-                    $location = Input::get('location');
-                    if (!in_array($location, ['left', 'right', 'top', 'footer'])) {
-                        $location = 'right';
-                    }
-
-                    DB::getInstance()->update('widgets', $widget->id, [
-                        'pages' => $active_pages_string,
-                        'location' => $location,
-                        'order' => $order,
-                    ]);
-                    $widget_instance->clearCache();
-
-                    Session::flash('admin_widgets', $language->get('admin', 'widget_updated'));
-                    Redirect::to(URL::build('/panel/core/widgets/', 'action=edit&w=' . urlencode($widget->id)));
-                } catch (Exception $e) {
-                    $errors = [$e->getMessage()];
                 }
+
+                $active_pages_string = json_encode($active_pages);
+                $order = ($_POST['order'] ?? 10);
+
+                $location = Input::get('location');
+                if (!in_array($location, ['left', 'right', 'top', 'footer'])) {
+                    $location = 'right';
+                }
+
+                DB::getInstance()->update('widgets', $widget->id, [
+                    'pages' => $active_pages_string,
+                    'location' => $location,
+                    'order' => $order,
+                ]);
+                $widget_instance->clearCache();
+
+                Session::flash('admin_widgets', $language->get('admin', 'widget_updated'));
+                Redirect::to(URL::build('/panel/core/widgets/', 'action=edit&w=' . urlencode($widget->id)));
             } else {
                 $errors = [$language->get('general', 'invalid_token')];
             }

--- a/modules/Core/pages/profile.php
+++ b/modules/Core/pages/profile.php
@@ -363,13 +363,9 @@ if (count($profile) >= 3 && ($profile[count($profile) - 1] != 'profile' || $prof
                                 $post = $post[0];
                                 if ($user->canViewStaffCP() || $post->author_id == $user->data()->id) {
                                     if (isset($_POST['content']) && strlen($_POST['content']) < 10000 && strlen($_POST['content']) >= 1) {
-                                        try {
-                                            DB::getInstance()->update('user_profile_wall_posts', $_POST['post_id'], [
-                                                'content' => $_POST['content']
-                                            ]);
-                                        } catch (Exception $e) {
-                                            $error = $e->getMessage();
-                                        }
+                                        DB::getInstance()->update('user_profile_wall_posts', $_POST['post_id'], [
+                                            'content' => $_POST['content']
+                                        ]);
                                     } else {
                                         $error = $language->get('user', 'invalid_wall_post');
                                     }
@@ -389,12 +385,8 @@ if (count($profile) >= 3 && ($profile[count($profile) - 1] != 'profile' || $prof
                             if (count($post)) {
                                 $post = $post[0];
                                 if ($user->canViewStaffCP() || $post->author_id == $user->data()->id) {
-                                    try {
-                                        DB::getInstance()->delete('user_profile_wall_posts', ['id', $_POST['post_id']]);
-                                        DB::getInstance()->delete('user_profile_wall_posts_replies', ['post_id', $_POST['post_id']]);
-                                    } catch (Exception $e) {
-                                        $error = $e->getMessage();
-                                    }
+                                    DB::getInstance()->delete('user_profile_wall_posts', ['id', $_POST['post_id']]);
+                                    DB::getInstance()->delete('user_profile_wall_posts_replies', ['post_id', $_POST['post_id']]);
                                 }
                             }
                         }
@@ -411,11 +403,7 @@ if (count($profile) >= 3 && ($profile[count($profile) - 1] != 'profile' || $prof
                             if (count($post)) {
                                 $post = $post[0];
                                 if ($user->canViewStaffCP() || $post->author_id == $user->data()->id) {
-                                    try {
-                                        DB::getInstance()->delete('user_profile_wall_posts_replies', ['id', $_POST['post_id']]);
-                                    } catch (Exception $e) {
-                                        $error = $e->getMessage();
-                                    }
+                                    DB::getInstance()->delete('user_profile_wall_posts_replies', ['id', $_POST['post_id']]);
                                 }
                             }
                         }

--- a/modules/Core/pages/user/settings.php
+++ b/modules/Core/pages/user/settings.php
@@ -230,118 +230,112 @@ if (isset($_GET['do'])) {
                 ]);
 
                 if ($validation->passed()) {
-                    try {
-                        // Update language, template and timezone
-                        $new_language_results = DB::getInstance()->get('languages', ['name', Input::get('language')])->results();
+                    // Update language, template and timezone
+                    $new_language_results = DB::getInstance()->get('languages', ['name', Input::get('language')])->results();
 
-                        if (count($new_language_results)) {
-                            $new_language = $new_language_results[0]->id;
-                            $language = new Language('core', $new_language_results[0]->short_code);
+                    if (count($new_language_results)) {
+                        $new_language = $new_language_results[0]->id;
+                        $language = new Language('core', $new_language_results[0]->short_code);
+                    } else {
+                        $new_language = $user->data()->language_id;
+                    }
+
+                    // Template
+                    if (Input::get('template') != 0) {
+                        $new_template = DB::getInstance()->get('templates', ['id', Input::get('template')])->results();
+
+                        if (count($new_template)) {
+                            $new_template = $new_template[0]->id;
                         } else {
-                            $new_language = $user->data()->language_id;
+                            $new_template = $user_query->theme_id;
                         }
+                    } else {
+                        $new_template = null;
+                    }
 
-                        // Template
-                        if (Input::get('template') != 0) {
-                            $new_template = DB::getInstance()->get('templates', ['id', Input::get('template')])->results();
+                    // Check permissions
+                    $available_templates = $user->getUserTemplates();
 
-                            if (count($new_template)) {
-                                $new_template = $new_template[0]->id;
-                            } else {
-                                $new_template = $user_query->theme_id;
-                            }
+                    foreach ($available_templates as $available_template) {
+                        if ($available_template->id == $new_template) {
+                            $can_update = true;
+                            break;
+                        }
+                    }
+
+                    if (!isset($can_update)) {
+                        $new_template = $user->data()->theme_id;
+                    }
+
+                    $timezone = Input::get('timezone');
+
+                    if ($user->hasPermission('usercp.signature')) {
+                        $signature = Input::get('signature');
+                    } else {
+                        $signature = '';
+                    }
+
+                    // Private profiles enabled?
+                    $private_profiles = Settings::get('private_profile');
+                    if ($private_profiles === '1') {
+                        if ($user->canPrivateProfile() && $_POST['privateProfile'] == 1) {
+                            $privateProfile = 1;
                         } else {
-                            $new_template = null;
+                            $privateProfile = 0;
+                        }
+                    } else {
+                        $privateProfile = $user->data()->private_profile;
+                    }
+
+                    $gravatar = $_POST['gravatar'] == '1' ? 1 : 0;
+
+                    $data = [
+                        'language_id' => $new_language,
+                        'timezone' => $timezone,
+                        'signature' => $signature,
+                        'nickname' => $displayname,
+                        'private_profile' => $privateProfile,
+                        'theme_id' => $new_template,
+                        'gravatar' => $gravatar,
+                    ];
+
+                    if ($user->data()->register_method === 'authme' && Settings::get('authme')) {
+                        $data['authme_sync_password'] = Input::get('authmeSync');
+                    }
+
+                    $user->update($data);
+
+                    Log::getInstance()->log(Log::Action('user/ucp/update'));
+
+                    foreach ($_POST['profile_fields'] as $field_id => $value) {
+                        // Check field exists
+                        $field = ProfileField::find($field_id);
+                        if (!$field) {
+                            continue;
                         }
 
-                        // Check permissions
-                        $available_templates = $user->getUserTemplates();
-
-                        foreach ($available_templates as $available_template) {
-                            if ($available_template->id == $new_template) {
-                                $can_update = true;
-                                break;
-                            }
-                        }
-
-                        if (!isset($can_update)) {
-                            $new_template = $user->data()->theme_id;
-                        }
-
-                        $timezone = Input::get('timezone');
-
-                        if ($user->hasPermission('usercp.signature')) {
-                            $signature = Input::get('signature');
-                        } else {
-                            $signature = '';
-                        }
-
-                        // Private profiles enabled?
-                        $private_profiles = Settings::get('private_profile');
-                        if ($private_profiles === '1') {
-                            if ($user->canPrivateProfile() && $_POST['privateProfile'] == 1) {
-                                $privateProfile = 1;
-                            } else {
-                                $privateProfile = 0;
-                            }
-                        } else {
-                            $privateProfile = $user->data()->private_profile;
-                        }
-
-                        $gravatar = $_POST['gravatar'] == '1' ? 1 : 0;
-
-                        $data = [
-                            'language_id' => $new_language,
-                            'timezone' => $timezone,
-                            'signature' => $signature,
-                            'nickname' => $displayname,
-                            'private_profile' => $privateProfile,
-                            'theme_id' => $new_template,
-                            'gravatar' => $gravatar,
-                        ];
-
-                        if ($user->data()->register_method === 'authme' && Settings::get('authme')) {
-                            $data['authme_sync_password'] = Input::get('authmeSync');
-                        }
-
-                        $user->update($data);
-
-                        Log::getInstance()->log(Log::Action('user/ucp/update'));
-
-                        foreach ($_POST['profile_fields'] as $field_id => $value) {
-                            // Check field exists
-                            $field = ProfileField::find($field_id);
-                            if (!$field) {
-                                continue;
-                            }
-
-                            $user_profile_fields = $user->getProfileFields(true);
-                            if (array_key_exists($field->id, $user_profile_fields) && $user_profile_fields[$field->id]->value !== null) {
-                                // Update field value if it has changed
-                                if ($value !== $user_profile_fields[$field->id]->value) {
-                                    DB::getInstance()->update('users_profile_fields', $user_profile_fields[$field->id]->upf_id, [
-                                        'value' => $value,
-                                        'updated' => date('U'),
-                                    ]);
-                                }
-                            } else {
-                                // Create new field value
-                                DB::getInstance()->insert('users_profile_fields', [
-                                    'user_id' => $user->data()->id,
-                                    'field_id' => $field->id,
+                        $user_profile_fields = $user->getProfileFields(true);
+                        if (array_key_exists($field->id, $user_profile_fields) && $user_profile_fields[$field->id]->value !== null) {
+                            // Update field value if it has changed
+                            if ($value !== $user_profile_fields[$field->id]->value) {
+                                DB::getInstance()->update('users_profile_fields', $user_profile_fields[$field->id]->upf_id, [
                                     'value' => $value,
                                     'updated' => date('U'),
                                 ]);
                             }
+                        } else {
+                            // Create new field value
+                            DB::getInstance()->insert('users_profile_fields', [
+                                'user_id' => $user->data()->id,
+                                'field_id' => $field->id,
+                                'value' => $value,
+                                'updated' => date('U'),
+                            ]);
                         }
-
-                        Session::flash('settings_success', $language->get('user', 'settings_updated_successfully'));
-                        Redirect::to(URL::build('/user/settings'));
-
-                    } catch (Exception $e) {
-                        Session::flash('settings_error', $e->getMessage());
                     }
 
+                    Session::flash('settings_success', $language->get('user', 'settings_updated_successfully'));
+                    Redirect::to(URL::build('/user/settings'));
                 } else {
                     $errors = $validation->errors();
                 }

--- a/modules/Core/widgets/StatsWidget.php
+++ b/modules/Core/widgets/StatsWidget.php
@@ -65,13 +65,8 @@ class StatsWidget extends WidgetBase {
         }
 
         if (!$this->_cache->isCached('online_guests')) {
-            try {
-                $online_guests = DB::getInstance()->query('SELECT COUNT(*) as c FROM nl2_online_guests WHERE last_seen > ?', [strtotime('-5 minutes')])->first()->c;
-                $this->_cache->store('online_guests', $online_guests, 60);
-            } catch (Exception $e) {
-                // Upgrade script hasn't been run
-                $online_guests = 0;
-            }
+            $online_guests = DB::getInstance()->query('SELECT COUNT(*) as c FROM nl2_online_guests WHERE last_seen > ?', [strtotime('-5 minutes')])->first()->c;
+            $this->_cache->store('online_guests', $online_guests, 60);
         } else {
             $online_guests = $this->_cache->retrieve('online_guests');
         }

--- a/modules/Forum/pages/panel/forums.php
+++ b/modules/Forum/pages/panel/forums.php
@@ -120,30 +120,26 @@ if (!isset($_GET['action']) && !isset($_GET['forum'])) {
 
                             if ($validation->passed()) {
                                 // Create the forum
-                                try {
-                                    $description = Input::get('forumdesc');
+                                $description = Input::get('forumdesc');
 
-                                    $last_forum_order = DB::getInstance()->orderAll('forums', 'forum_order', 'DESC')->results();
-                                    if (count($last_forum_order)) {
-                                        $last_forum_order = $last_forum_order[0]->forum_order;
-                                    } else {
-                                        $last_forum_order = 0;
-                                    }
-
-                                    DB::getInstance()->insert('forums', [
-                                        'forum_title' => Input::get('forumname'),
-                                        'forum_description' => $description,
-                                        'forum_order' => $last_forum_order + 1,
-                                        'forum_type' => Input::get('forum_type'),
-                                        'icon' => Input::get('forum_icon')
-                                    ]);
-
-                                    $forum_id = DB::getInstance()->lastId();
-
-                                    Redirect::to(URL::build('/panel/forums/', 'action=new&step=2&forum=' . $forum_id));
-                                } catch (Exception $e) {
-                                    $errors[] = $e->getMessage();
+                                $last_forum_order = DB::getInstance()->orderAll('forums', 'forum_order', 'DESC')->results();
+                                if (count($last_forum_order)) {
+                                    $last_forum_order = $last_forum_order[0]->forum_order;
+                                } else {
+                                    $last_forum_order = 0;
                                 }
+
+                                DB::getInstance()->insert('forums', [
+                                    'forum_title' => Input::get('forumname'),
+                                    'forum_description' => $description,
+                                    'forum_order' => $last_forum_order + 1,
+                                    'forum_type' => Input::get('forum_type'),
+                                    'icon' => Input::get('forum_icon')
+                                ]);
+
+                                $forum_id = DB::getInstance()->lastId();
+
+                                Redirect::to(URL::build('/panel/forums/', 'action=new&step=2&forum=' . $forum_id));
                             } else {
                                 $errors = $validation->errors();
                             }
@@ -190,43 +186,39 @@ if (!isset($_GET['action']) && !isset($_GET['forum'])) {
                         $errors = [];
 
                         if (Token::check()) {
-                            try {
-                                if (isset($_POST['redirect']) && $_POST['redirect'] == 1) {
-                                    $redirect = 1;
-                                    if (isset($_POST['redirect_url']) && strlen($_POST['redirect_url']) > 0 && strlen($_POST['redirect_url']) <= 512) {
-                                        $redirect_url = Output::getClean($_POST['redirect_url']);
-                                    } else {
-                                        $redirect_error = true;
-                                    }
+                            if (isset($_POST['redirect']) && $_POST['redirect'] == 1) {
+                                $redirect = 1;
+                                if (isset($_POST['redirect_url']) && strlen($_POST['redirect_url']) > 0 && strlen($_POST['redirect_url']) <= 512) {
+                                    $redirect_url = Output::getClean($_POST['redirect_url']);
                                 } else {
-                                    $redirect = 0;
-                                    $redirect_url = null;
+                                    $redirect_error = true;
                                 }
-
-                                if (isset($_POST['hooks']) && count($_POST['hooks'])) {
-                                    $hooks = json_encode($_POST['hooks']);
-                                } else {
-                                    $hooks = null;
-                                }
-
-                                if (!isset($redirect_error)) {
-                                    $parent = $_POST['parent'] ?? 0;
-
-                                    DB::getInstance()->update('forums', $forum->id, [
-                                        'parent' => $parent,
-                                        'news' => Input::get('news_forum'),
-                                        'redirect_forum' => $redirect,
-                                        'redirect_url' => $redirect_url,
-                                        'hooks' => $hooks
-                                    ]);
-
-                                    Redirect::to(URL::build('/panel/forums/', 'forum=' . $forum->id));
-                                }
-
-                                $errors[] = $forum_language->get('forum', 'invalid_redirect_url');
-                            } catch (Exception $e) {
-                                $errors[] = $e->getMessage();
+                            } else {
+                                $redirect = 0;
+                                $redirect_url = null;
                             }
+
+                            if (isset($_POST['hooks']) && count($_POST['hooks'])) {
+                                $hooks = json_encode($_POST['hooks']);
+                            } else {
+                                $hooks = null;
+                            }
+
+                            if (!isset($redirect_error)) {
+                                $parent = $_POST['parent'] ?? 0;
+
+                                DB::getInstance()->update('forums', $forum->id, [
+                                    'parent' => $parent,
+                                    'news' => Input::get('news_forum'),
+                                    'redirect_forum' => $redirect,
+                                    'redirect_url' => $redirect_url,
+                                    'hooks' => $hooks
+                                ]);
+
+                                Redirect::to(URL::build('/panel/forums/', 'forum=' . $forum->id));
+                            }
+
+                            $errors[] = $forum_language->get('forum', 'invalid_redirect_url');
                         } else {
                             $errors[] = $language->get('general', 'invalid_token');
                         }
@@ -322,17 +314,13 @@ if (!isset($_GET['action']) && !isset($_GET['forum'])) {
                             $n++;
                         }
 
-                        try {
-                            if (isset($previous_fid, $previous_f_order)) {
-                                DB::getInstance()->update('forums', $forum_id, [
-                                    'forum_order' => $previous_f_order
-                                ]);
-                                DB::getInstance()->update('forums', $previous_fid, [
-                                    'forum_order' => $previous_f_order + 1
-                                ]);
-                            }
-                        } catch (Exception $e) {
-                            $errors = [$e->getMessage()];
+                        if (isset($previous_fid, $previous_f_order)) {
+                            DB::getInstance()->update('forums', $forum_id, [
+                                'forum_order' => $previous_f_order
+                            ]);
+                            DB::getInstance()->update('forums', $previous_fid, [
+                                'forum_order' => $previous_f_order + 1
+                            ]);
                         }
 
                         Redirect::to(URL::build('/panel/forums'));
@@ -348,17 +336,14 @@ if (!isset($_GET['action']) && !isset($_GET['forum'])) {
                             }
                             $n++;
                         }
-                        try {
-                            if (isset($previous_fid, $previous_f_order)) {
-                                DB::getInstance()->update('forums', $forum_id, [
-                                    'forum_order' => $previous_f_order
-                                ]);
-                                DB::getInstance()->update('forums', $previous_fid, [
-                                    'forum_order' => $previous_f_order - 1
-                                ]);
-                            }
-                        } catch (Exception $e) {
-                            $errors = [$e->getMessage()];
+
+                        if (isset($previous_fid, $previous_f_order)) {
+                            DB::getInstance()->update('forums', $forum_id, [
+                                'forum_order' => $previous_f_order
+                            ]);
+                            DB::getInstance()->update('forums', $previous_fid, [
+                                'forum_order' => $previous_f_order - 1
+                            ]);
                         }
 
                         Redirect::to(URL::build('/panel/forums'));
@@ -517,57 +502,53 @@ if (!isset($_GET['action']) && !isset($_GET['forum'])) {
                         ]);
 
                         if ($validation->passed()) {
-                            try {
-                                if (isset($_POST['redirect']) && $_POST['redirect'] == 1) {
-                                    $redirect = 1;
-                                    if (isset($_POST['redirect_url']) && strlen($_POST['redirect_url']) > 0 && strlen($_POST['redirect_url']) <= 512) {
-                                        $redirect_url = Output::getClean($_POST['redirect_url']);
-                                    } else {
-                                        $redirect = 0;
-                                        $redirect_url = null;
-                                        $redirect_error = true;
-                                    }
+                            if (isset($_POST['redirect']) && $_POST['redirect'] == 1) {
+                                $redirect = 1;
+                                if (isset($_POST['redirect_url']) && strlen($_POST['redirect_url']) > 0 && strlen($_POST['redirect_url']) <= 512) {
+                                    $redirect_url = Output::getClean($_POST['redirect_url']);
                                 } else {
                                     $redirect = 0;
                                     $redirect_url = null;
+                                    $redirect_error = true;
                                 }
-
-                                $parent = $_POST['parent_forum'] ?? 0;
-
-                                if (isset($_POST['hooks']) && count($_POST['hooks'])) {
-                                    $hooks = json_encode($_POST['hooks']);
-                                } else {
-                                    $hooks = null;
-                                }
-
-                                if (isset($_POST['default_labels']) && count($_POST['default_labels'])) {
-                                    $default_labels = implode(',', $_POST['default_labels']);
-                                } else {
-                                    $default_labels = null;
-                                }
-
-                                // Update the forum
-                                $to_update = [
-                                    'forum_title' => Input::get('title'),
-                                    'forum_description' => Input::get('description'),
-                                    'news' => Input::get('display'),
-                                    'parent' => $parent,
-                                    'redirect_forum' => $redirect,
-                                    'icon' => Input::get('icon'),
-                                    'forum_type' => Input::get('forum_type'),
-                                    'topic_placeholder' => Input::get('topic_placeholder'),
-                                    'hooks' => $hooks,
-                                    'default_labels' => $default_labels
-                                ];
-
-                                if (!isset($redirect_error)) {
-                                    $to_update['redirect_url'] = $redirect_url;
-                                }
-
-                                DB::getInstance()->update('forums', $_GET['forum'], $to_update);
-                            } catch (Exception $e) {
-                                $errors[] = $e->getMessage();
+                            } else {
+                                $redirect = 0;
+                                $redirect_url = null;
                             }
+
+                            $parent = $_POST['parent_forum'] ?? 0;
+
+                            if (isset($_POST['hooks']) && count($_POST['hooks'])) {
+                                $hooks = json_encode($_POST['hooks']);
+                            } else {
+                                $hooks = null;
+                            }
+
+                            if (isset($_POST['default_labels']) && count($_POST['default_labels'])) {
+                                $default_labels = implode(',', $_POST['default_labels']);
+                            } else {
+                                $default_labels = null;
+                            }
+
+                            // Update the forum
+                            $to_update = [
+                                'forum_title' => Input::get('title'),
+                                'forum_description' => Input::get('description'),
+                                'news' => Input::get('display'),
+                                'parent' => $parent,
+                                'redirect_forum' => $redirect,
+                                'icon' => Input::get('icon'),
+                                'forum_type' => Input::get('forum_type'),
+                                'topic_placeholder' => Input::get('topic_placeholder'),
+                                'hooks' => $hooks,
+                                'default_labels' => $default_labels
+                            ];
+
+                            if (!isset($redirect_error)) {
+                                $to_update['redirect_url'] = $redirect_url;
+                            }
+
+                            DB::getInstance()->update('forums', $_GET['forum'], $to_update);
 
                             // Guest forum permissions
                             $view = Input::get('perm-view-0');
@@ -594,31 +575,27 @@ if (!isset($_GET['action']) && !isset($_GET['forum'])) {
                                 }
                             }
 
-                            try {
-                                if ($forum_perm_exists != 0) { // Permission already exists, update
-                                    // Update the forum
-                                    DB::getInstance()->update('forums_permissions', $update_id, [
-                                        'view' => $view,
-                                        'create_topic' => $create,
-                                        'edit_topic' => $edit,
-                                        'create_post' => $post,
-                                        'view_other_topics' => $view_others,
-                                        'moderate' => $moderate
-                                    ]);
-                                } else { // Permission doesn't exist, create
-                                    DB::getInstance()->insert('forums_permissions', [
-                                        'group_id' => 0,
-                                        'forum_id' => $_GET['forum'],
-                                        'view' => $view,
-                                        'create_topic' => $create,
-                                        'edit_topic' => $edit,
-                                        'create_post' => $post,
-                                        'view_other_topics' => $view_others,
-                                        'moderate' => $moderate
-                                    ]);
-                                }
-                            } catch (Exception $e) {
-                                $errors[] = $e->getMessage();
+                            if ($forum_perm_exists != 0) { // Permission already exists, update
+                                // Update the forum
+                                DB::getInstance()->update('forums_permissions', $update_id, [
+                                    'view' => $view,
+                                    'create_topic' => $create,
+                                    'edit_topic' => $edit,
+                                    'create_post' => $post,
+                                    'view_other_topics' => $view_others,
+                                    'moderate' => $moderate
+                                ]);
+                            } else { // Permission doesn't exist, create
+                                DB::getInstance()->insert('forums_permissions', [
+                                    'group_id' => 0,
+                                    'forum_id' => $_GET['forum'],
+                                    'view' => $view,
+                                    'create_topic' => $create,
+                                    'edit_topic' => $edit,
+                                    'create_post' => $post,
+                                    'view_other_topics' => $view_others,
+                                    'moderate' => $moderate
+                                ]);
                             }
 
                             // Group forum permissions
@@ -661,31 +638,27 @@ if (!isset($_GET['action']) && !isset($_GET['forum'])) {
                                     }
                                 }
 
-                                try {
-                                    if ($forum_perm_exists != 0) { // Permission already exists, update
-                                        // Update the forum
-                                        DB::getInstance()->update('forums_permissions', $update_id, [
-                                            'view' => $view,
-                                            'create_topic' => $create,
-                                            'edit_topic' => $edit,
-                                            'create_post' => $post,
-                                            'view_other_topics' => $view_others,
-                                            'moderate' => $moderate
-                                        ]);
-                                    } else { // Permission doesn't exist, create
-                                        DB::getInstance()->insert('forums_permissions', [
-                                            'group_id' => $group->id,
-                                            'forum_id' => $_GET['forum'],
-                                            'view' => $view,
-                                            'create_topic' => $create,
-                                            'edit_topic' => $edit,
-                                            'create_post' => $post,
-                                            'view_other_topics' => $view_others,
-                                            'moderate' => $moderate
-                                        ]);
-                                    }
-                                } catch (Exception $e) {
-                                    $errors[] = $e->getMessage();
+                                if ($forum_perm_exists != 0) { // Permission already exists, update
+                                    // Update the forum
+                                    DB::getInstance()->update('forums_permissions', $update_id, [
+                                        'view' => $view,
+                                        'create_topic' => $create,
+                                        'edit_topic' => $edit,
+                                        'create_post' => $post,
+                                        'view_other_topics' => $view_others,
+                                        'moderate' => $moderate
+                                    ]);
+                                } else { // Permission doesn't exist, create
+                                    DB::getInstance()->insert('forums_permissions', [
+                                        'group_id' => $group->id,
+                                        'forum_id' => $_GET['forum'],
+                                        'view' => $view,
+                                        'create_topic' => $create,
+                                        'edit_topic' => $edit,
+                                        'create_post' => $post,
+                                        'view_other_topics' => $view_others,
+                                        'moderate' => $moderate
+                                    ]);
                                 }
                             }
 

--- a/modules/Forum/pages/panel/labels.php
+++ b/modules/Forum/pages/panel/labels.php
@@ -126,20 +126,15 @@ if (!isset($_GET['action'])) {
 
                         $group_string = rtrim($group_string, ',');
 
-                        try {
-                            DB::getInstance()->insert('forums_topic_labels', [
-                                'fids' => $forum_string,
-                                'name' => Output::getClean(Input::get('label_name')),
-                                'label' => Input::get('label_id'),
-                                'gids' => $group_string
-                            ]);
+                        DB::getInstance()->insert('forums_topic_labels', [
+                            'fids' => $forum_string,
+                            'name' => Output::getClean(Input::get('label_name')),
+                            'label' => Input::get('label_id'),
+                            'gids' => $group_string
+                        ]);
 
-                            Session::flash('forum_labels', $forum_language->get('forum', 'label_creation_success'));
-                            Redirect::to(URL::build('/panel/forums/labels'));
-                        } catch (Exception $e) {
-                            $errors = [$e->getMessage()];
-                        }
-
+                        Session::flash('forum_labels', $forum_language->get('forum', 'label_creation_success'));
+                        Redirect::to(URL::build('/panel/forums/labels'));
                     } else {
                         // Validation errors
                         $errors = $validation->errors();
@@ -263,20 +258,15 @@ if (!isset($_GET['action'])) {
 
                         $group_string = rtrim($group_string, ',');
 
-                        try {
-                            DB::getInstance()->update('forums_topic_labels', $label->id, [
-                                'fids' => $forum_string,
-                                'name' => Output::getClean(Input::get('label_name')),
-                                'label' => Input::get('label_id'),
-                                'gids' => $group_string
-                            ]);
+                        DB::getInstance()->update('forums_topic_labels', $label->id, [
+                            'fids' => $forum_string,
+                            'name' => Output::getClean(Input::get('label_name')),
+                            'label' => Input::get('label_id'),
+                            'gids' => $group_string
+                        ]);
 
-                            Session::flash('forum_labels', $forum_language->get('forum', 'label_edit_success'));
-                            Redirect::to(URL::build('/panel/forums/labels', 'action=edit&lid=' . Output::getClean($label->id)));
-                        } catch (Exception $e) {
-                            $errors = [$e->getMessage()];
-                        }
-
+                        Session::flash('forum_labels', $forum_language->get('forum', 'label_edit_success'));
+                        Redirect::to(URL::build('/panel/forums/labels', 'action=edit&lid=' . Output::getClean($label->id)));
                     } else {
                         // Validation errors
                         $errors = $validation->errors();
@@ -433,19 +423,13 @@ if (!isset($_GET['action'])) {
                     ])->message($forum_language->get('forum', 'label_type_creation_error'));
 
                     if ($validation->passed()) {
-                        try {
-                            DB::getInstance()->insert('forums_labels', [
-                                'name' => Output::getClean(Input::get('label_name')),
-                                'html' => Input::get('label_html')
-                            ]);
+                        DB::getInstance()->insert('forums_labels', [
+                            'name' => Output::getClean(Input::get('label_name')),
+                            'html' => Input::get('label_html')
+                        ]);
 
-                            Session::flash('forum_labels', $forum_language->get('forum', 'label_type_creation_success'));
-                            Redirect::to(URL::build('/panel/forums/labels/', 'action=types'));
-
-                        } catch (Exception $e) {
-                            $errors = [$e->getMessage()];
-                        }
-
+                        Session::flash('forum_labels', $forum_language->get('forum', 'label_type_creation_success'));
+                        Redirect::to(URL::build('/panel/forums/labels/', 'action=types'));
                     } else {
                         // Validation errors
                         $errors = $validation->errors();
@@ -514,18 +498,13 @@ if (!isset($_GET['action'])) {
                     ])->message($forum_language->get('forum', 'label_type_creation_error'));
 
                     if ($validation->passed()) {
-                        try {
-                            DB::getInstance()->update('forums_labels', $label->id, [
-                                'name' => Output::getClean(Input::get('label_name')),
-                                'html' => Input::get('label_html')
-                            ]);
+                        DB::getInstance()->update('forums_labels', $label->id, [
+                            'name' => Output::getClean(Input::get('label_name')),
+                            'html' => Input::get('label_html')
+                        ]);
 
-                            Session::flash('forum_labels', $forum_language->get('forum', 'label_type_edit_success'));
-                            Redirect::to(URL::build('/panel/forums/labels/', 'action=edit_type&lid=' . Output::getClean($label->id)));
-                        } catch (Exception $e) {
-                            $errors = [$e->getMessage()];
-                        }
-
+                        Session::flash('forum_labels', $forum_language->get('forum', 'label_type_edit_success'));
+                        Redirect::to(URL::build('/panel/forums/labels/', 'action=edit_type&lid=' . Output::getClean($label->id)));
                     } else {
                         // Validation errors
                         $errors = $validation->errors();


### PR DESCRIPTION
Most of these are super ancient and guarded very foundational pieces of our code - like simple DB calls. Removing them as I see no reason to wrap in try/catch for simple stuff like this - kept other ones where the result was more important.