### PR TITLE
add auto_reload config key to TwigTemplateEngine.php

### DIFF
--- a/core/classes/Templates/TwigTemplateEngine.php
+++ b/core/classes/Templates/TwigTemplateEngine.php
@@ -26,7 +26,7 @@ class TwigTemplateEngine extends TemplateEngine
         $loader = new FilesystemLoader($dir);
         $twig = new Environment($loader, [
             'cache' => ROOT_PATH . '/cache/twig',
-            'auto_reload' => true, 
+            'auto_reload' => true,
         ]);
 
         $policy = new SecurityPolicy();

--- a/core/classes/Templates/TwigTemplateEngine.php
+++ b/core/classes/Templates/TwigTemplateEngine.php
@@ -26,6 +26,7 @@ class TwigTemplateEngine extends TemplateEngine
         $loader = new FilesystemLoader($dir);
         $twig = new Environment($loader, [
             'cache' => ROOT_PATH . '/cache/twig',
+            'auto_reload' => true, 
         ]);
 
         $policy = new SecurityPolicy();


### PR DESCRIPTION
Howdy, this is a problem I've come across as I've tried making a template for Nameless using the new Twig engine, if you upload a template, it caches once and pretty much never refreshes the cache.

I believe the ideal behaviour would be for the cache to reload when the source file changes, the same as the Smarty engine, and this line of config should achieve that. To my knowledge, there isn't a big performance penalty or anything.

Reference to the config is available in the [Twig docs](https://twig.symfony.com/doc/3.x/api.html#environment-options)

Cheers :) 