### PR TITLE
Improve online staff/users widget caching

### DIFF
--- a/core/classes/Core/User.php
+++ b/core/classes/Core/User.php
@@ -650,7 +650,7 @@ class User
         if (isset(self::$_integration_cache[$this->data()->id])) {
             $integrations_query = self::$_integration_cache[$this->data()->id];
         } else {
-            $integrations_query = $this->_db->query('SELECT nl2_users_integrations.*, nl2_integrations.name as integration_name FROM nl2_users_integrations LEFT JOIN nl2_integrations ON integration_id=nl2_integrations.id WHERE user_id = ?', [$this->data()->id]);
+            $integrations_query = $this->_db->query('SELECT nl2_users_integrations.*, nl2_integrations.name as integration_name FROM nl2_users_integrations LEFT JOIN nl2_integrations ON integration_id = nl2_integrations.id WHERE user_id = ?', [$this->data()->id]);
             if ($integrations_query->count()) {
                 $integrations_query = $integrations_query->results();
             } else {

--- a/core/classes/Widgets/Widgets.php
+++ b/core/classes/Widgets/Widgets.php
@@ -48,6 +48,7 @@ class Widgets
             foreach ($widgets as $widget) {
                 $enabled[$widget->name] = true;
             }
+
             return $enabled;
         });
     }

--- a/core/classes/Widgets/Widgets.php
+++ b/core/classes/Widgets/Widgets.php
@@ -41,10 +41,15 @@ class Widgets
         $this->_language = $language;
         $this->_template = $template;
 
-        $enabled = $this->_cache->retrieve('enabled');
-        if ($enabled !== null && count($enabled)) {
-            $this->_enabled = $enabled;
-        }
+        $this->_enabled = $this->_cache->fetch('enabled', function () {
+            // Fetch enabled widgets from database
+            $widgets = $this->_db->query('SELECT * FROM nl2_widgets WHERE enabled = 1')->results();
+            $enabled = [];
+            foreach ($widgets as $widget) {
+                $enabled[$widget->name] = true;
+            }
+            return $enabled;
+        });
     }
 
     /**

--- a/core/includes/updates/230.php
+++ b/core/includes/updates/230.php
@@ -13,7 +13,6 @@ return new class() extends UpgradeScript {
         $default_panel_template = $this->_cache->retrieve('panel_default') ?: 'Default';
         Settings::set('default_template', $default_template);
         Settings::set('default_panel_template', $default_panel_template);
-        $this->_cache->eraseAll();
 
         // Convert template_settings to use settings table
         $this->_cache->setCache('template_settings');
@@ -21,7 +20,6 @@ return new class() extends UpgradeScript {
         $navbarColour = $this->_cache->retrieve('navbarColour') ?: 'white';
         Settings::set('dark_mode', $darkMode);
         Settings::set('default_revamp_navbar_color', $navbarColour);
-        $this->_cache->eraseAll();
 
         // Convert backgroundcache to use settings table
         $this->_cache->setCache('backgroundcache');
@@ -33,7 +31,6 @@ return new class() extends UpgradeScript {
         Settings::set('banner_image_path', $banner_image);
         Settings::set('og_image_path', $og_image);
         Settings::set('favicon_image_path', $favicon_image);
-        $this->_cache->eraseAll();
 
         // Convert avatar_settings_cache to use settings table
         $this->_cache->setCache('avatar_settings_cache');
@@ -50,7 +47,6 @@ return new class() extends UpgradeScript {
         Settings::set('default_avatar_image', $default_avatar_image);
         Settings::set('default_avatar_source', $default_avatar_source);
         Settings::set('default_avatar_perspective', $default_avatar_perspective);
-        $this->_cache->eraseAll();
 
         // Convert OnlineUsersWidget to use settings table
         $this->_cache->setCache('online_members');
@@ -58,13 +54,11 @@ return new class() extends UpgradeScript {
         $include_staff = $this->_cache->fetch('include_staff_in_users', 0);
         Settings::set('online_users_widget_use_nicknames', $use_nickname_show);
         Settings::set('online_users_widget_include_staff', $include_staff);
-        $this->_cache->eraseAll();
 
         // Convert social_media to use settings table
         $this->_cache->setCache('social_media');
         $discord_widget_theme = $this->_cache->retrieve('discord_widget_theme') ?: 'dark';
         Settings::set('discord_widget_theme', $discord_widget_theme, 'Discord Integration');
-        $this->_cache->eraseAll();
 
         $this->setVersion('2.3.0');
     }

--- a/dev/scripts/seeder/ForumPostSeeder.php
+++ b/dev/scripts/seeder/ForumPostSeeder.php
@@ -19,7 +19,7 @@ class ForumPostSeeder extends Seeder
                 'forum_id' => $topic->forum_id,
                 'topic_id' => $topic->id,
                 'post_creator' => $topic->topic_creator,
-                'post_content' => $faker->boolean(40) ? $faker->randomHtml() : $faker->sentences($faker->numberBetween(3, 30), true),
+                'post_content' => $faker->sentences($faker->numberBetween(3, 30), true),
                 'post_date' => $created->format('Y-m-d H:i:s'),
                 'created' => $created->format('U'),
             ]);
@@ -32,7 +32,7 @@ class ForumPostSeeder extends Seeder
                     'forum_id' => $topic->forum_id,
                     'topic_id' => $topic->id,
                     'post_creator' => $user->id,
-                    'post_content' => $faker->boolean(40) ? $faker->randomHtml() : $faker->sentences($faker->numberBetween(3, 30), true),
+                    'post_content' => $faker->sentences($faker->numberBetween(3, 30), true),
                     'post_date' => $created->format('Y-m-d H:i:s'),
                     'created' => $created->format('U'),
                 ]);

--- a/modules/Core/includes/admin_widgets/online_users.php
+++ b/modules/Core/includes/admin_widgets/online_users.php
@@ -10,7 +10,7 @@
  */
 
 // Check input
-$cache->setCache('online_members');
+$cache->setCache('online_members_widget');
 
 if (Input::exists()) {
     if (Token::check()) {
@@ -19,6 +19,10 @@ if (Input::exists()) {
 
         if ($cache->isCached('users')) {
             $cache->erase('users');
+        }
+
+        if ($cache->isCached('total')) {
+            $cache->erase('total');
         }
 
         $success = $language->get('admin', 'widget_updated');

--- a/modules/Core/widgets/OnlineStaffWidget.php
+++ b/modules/Core/widgets/OnlineStaffWidget.php
@@ -29,7 +29,28 @@ class OnlineStaffWidget extends WidgetBase {
         $this->_cache->setCache('online_staff_widget');
 
         $online_staff = $this->_cache->fetch('staff', function () {
-            $online = DB::getInstance()->query('SELECT U.id FROM nl2_users AS U JOIN nl2_users_groups AS UG ON (U.id = UG.user_id) JOIN nl2_groups AS G ON (UG.group_id = G.id) WHERE G.order = (SELECT min(iG.`order`) FROM nl2_users_groups AS iUG JOIN nl2_groups AS iG ON (iUG.group_id = iG.id) WHERE iUG.user_id = U.id GROUP BY iUG.user_id ORDER BY NULL) AND U.last_online > ' . strtotime('-5 minutes') . ' AND G.staff = 1 LIMIT 10')->results();
+            $online = DB::getInstance()->query(
+                <<<SQL
+                    SELECT
+                        u.id
+                    FROM nl2_users AS u
+                    JOIN nl2_users_groups AS ug ON u.id = ug.user_id
+                    JOIN nl2_groups AS g ON ug.group_id = g.id
+                    WHERE g.order = (
+                        SELECT MIN(iG.order)
+                        FROM nl2_users_groups AS iug
+                        JOIN nl2_groups AS ig ON iug.group_id = ig.id
+                        WHERE iug.user_id = u.id
+                        GROUP BY iug.user_id
+                        ORDER BY NULL
+                    )
+                    AND u.last_online > ?
+                    AND g.staff = 1
+                    ORDER BY g.order ASC
+                    LIMIT 10
+                SQL,
+                [strtotime('-5 minutes')]
+            )->results();
 
             foreach ($online as $staff) {
                 $staff_user = new User($staff->id);
@@ -51,7 +72,26 @@ class OnlineStaffWidget extends WidgetBase {
 
         // Count total online staff
         $total_online_staff = $this->_cache->fetch('total_staff', function () {
-            return DB::getInstance()->query('SELECT COUNT(U.id) AS count FROM nl2_users AS U JOIN nl2_users_groups AS UG ON (U.id = UG.user_id) JOIN nl2_groups AS G ON (UG.group_id = G.id) WHERE G.order = (SELECT min(iG.`order`) FROM nl2_users_groups AS iUG JOIN nl2_groups AS iG ON (iUG.group_id = iG.id) WHERE iUG.user_id = U.id GROUP BY iUG.user_id ORDER BY NULL) AND U.last_online > ? AND G.staff = 1', [strtotime('-5 minutes')])->first()->count;
+            return DB::getInstance()->query(
+                <<<SQL
+                    SELECT
+                        COUNT(u.id) AS count
+                    FROM nl2_users AS u
+                    JOIN nl2_users_groups AS ug ON u.id = ug.user_id
+                    JOIN nl2_groups AS g ON ug.group_id = g.id
+                    WHERE g.order = (
+                        SELECT MIN(iG.order)
+                        FROM nl2_users_groups AS iug
+                        JOIN nl2_groups AS ig ON iug.group_id = ig.id
+                        WHERE iug.user_id = u.id
+                        GROUP BY iug.user_id
+                        ORDER BY NULL
+                    )
+                    AND u.last_online > ?
+                    AND g.staff = 1
+                SQL,
+                [strtotime('-5 minutes')]
+            )->first()->count;
         }, 120);
 
         // Generate HTML code for widget

--- a/modules/Core/widgets/OnlineStaffWidget.php
+++ b/modules/Core/widgets/OnlineStaffWidget.php
@@ -26,21 +26,12 @@ class OnlineStaffWidget extends WidgetBase {
     }
 
     public function initialise(): void {
-        $this->_cache->setCache('online_members');
+        $this->_cache->setCache('online_staff_widget');
 
-        $online = $this->_cache->fetch('staff', function () {
-            return DB::getInstance()->query('SELECT U.id FROM nl2_users AS U JOIN nl2_users_groups AS UG ON (U.id = UG.user_id) JOIN nl2_groups AS G ON (UG.group_id = G.id) WHERE G.order = (SELECT min(iG.`order`) FROM nl2_users_groups AS iUG JOIN nl2_groups AS iG ON (iUG.group_id = iG.id) WHERE iUG.user_id = U.id GROUP BY iUG.user_id ORDER BY NULL) AND U.last_online > ' . strtotime('-5 minutes') . ' AND G.staff = 1')->results();
-        }, 120);
-
-        // Generate HTML code for widget
-        if (count($online)) {
-            $staff_members = [];
+        $online_staff = $this->_cache->fetch('staff', function () {
+            $online = DB::getInstance()->query('SELECT U.id FROM nl2_users AS U JOIN nl2_users_groups AS UG ON (U.id = UG.user_id) JOIN nl2_groups AS G ON (UG.group_id = G.id) WHERE G.order = (SELECT min(iG.`order`) FROM nl2_users_groups AS iUG JOIN nl2_groups AS iG ON (iUG.group_id = iG.id) WHERE iUG.user_id = U.id GROUP BY iUG.user_id ORDER BY NULL) AND U.last_online > ' . strtotime('-5 minutes') . ' AND G.staff = 1 LIMIT 10')->results();
 
             foreach ($online as $staff) {
-                if (count($staff_members) === 10) {
-                    break;
-                }
-
                 $staff_user = new User($staff->id);
                 if ($staff_user->exists()) {
                     $staff_members[] = [
@@ -51,15 +42,24 @@ class OnlineStaffWidget extends WidgetBase {
                         'avatar' => $staff_user->getAvatar(),
                         'id' => Output::getClean($staff_user->data()->id),
                         'group' => $staff_user->getMainGroup()->group_html,
-                        'group_order' => $staff_user->getMainGroup()->order
                     ];
                 }
             }
 
+            return $staff_members;
+        }, 120);
+
+        // Count total online staff
+        $total_online_staff = $this->_cache->fetch('total_staff', function () {
+            return DB::getInstance()->query('SELECT COUNT(U.id) AS count FROM nl2_users AS U JOIN nl2_users_groups AS UG ON (U.id = UG.user_id) JOIN nl2_groups AS G ON (UG.group_id = G.id) WHERE G.order = (SELECT min(iG.`order`) FROM nl2_users_groups AS iUG JOIN nl2_groups AS iG ON (iUG.group_id = iG.id) WHERE iUG.user_id = U.id GROUP BY iUG.user_id ORDER BY NULL) AND U.last_online > ? AND G.staff = 1', [strtotime('-5 minutes')])->first()->count;
+        }, 120);
+
+        // Generate HTML code for widget
+        if (count($online_staff)) {
             $this->_engine->addVariables([
                 'ONLINE_STAFF' => $this->_language->get('general', 'online_staff'),
-                'ONLINE_STAFF_LIST' => $staff_members,
-                'TOTAL_ONLINE_STAFF' => $this->_language->get('general', 'total_online_staff', ['count' => count($online)]),
+                'ONLINE_STAFF_LIST' => $online_staff,
+                'TOTAL_ONLINE_STAFF' => $this->_language->get('general', 'total_online_staff', ['count' => $total_online_staff]),
             ]);
 
         } else {

--- a/modules/Core/widgets/OnlineUsersWidget.php
+++ b/modules/Core/widgets/OnlineUsersWidget.php
@@ -26,27 +26,16 @@ class OnlineUsersWidget extends WidgetBase {
     }
 
     public function initialise(): void {
-        $this->_cache->setCache('online_members');
+        $this->_cache->setCache('online_members_widget');
 
-        $online = $this->_cache->fetch('users', function () {
+        $online_users = $this->_cache->fetch('users', function () {
             if (Settings::get('online_users_widget_include_staff', 0)) {
-                $online = DB::getInstance()->query('SELECT id FROM nl2_users WHERE last_online > ?', [strtotime('-5 minutes')])->results();
+                $online = DB::getInstance()->query('SELECT id FROM nl2_users WHERE last_online > ? LIMIT 10', [strtotime('-5 minutes')])->results();
             } else {
-                $online = DB::getInstance()->query('SELECT U.id FROM nl2_users AS U JOIN nl2_users_groups AS UG ON (U.id = UG.user_id) JOIN nl2_groups AS G ON (UG.group_id = G.id) WHERE G.order = (SELECT min(iG.`order`) FROM nl2_users_groups AS iUG JOIN nl2_groups AS iG ON (iUG.group_id = iG.id) WHERE iUG.user_id = U.id GROUP BY iUG.user_id ORDER BY NULL) AND U.last_online > ' . strtotime('-5 minutes') . ' AND G.staff = 0')->results();
+                $online = DB::getInstance()->query('SELECT U.id FROM nl2_users AS U JOIN nl2_users_groups AS UG ON (U.id = UG.user_id) JOIN nl2_groups AS G ON (UG.group_id = G.id) WHERE G.order = (SELECT min(iG.`order`) FROM nl2_users_groups AS iUG JOIN nl2_groups AS iG ON (iUG.group_id = iG.id) WHERE iUG.user_id = U.id GROUP BY iUG.user_id ORDER BY NULL) AND U.last_online > ' . strtotime('-5 minutes') . ' AND G.staff = 0 LIMIT 10')->results();
             }
 
-            return $online;
-        }, 120);
-
-        // Generate HTML code for widget
-        if (count($online)) {
-            $users = [];
-
             foreach ($online as $item) {
-                if (count($users) === 10) {
-                    break;
-                }
-
                 $online_user = new User($item->id);
                 if ($online_user->exists()) {
                     $users[] = [
@@ -62,13 +51,26 @@ class OnlineUsersWidget extends WidgetBase {
                 }
             }
 
+            return $users;
+        }, 120);
+
+        // Count total online users
+        $total_online_users = $this->_cache->fetch('total', function () {
+            if (Settings::get('online_users_widget_include_staff', 0)) {
+                return DB::getInstance()->query('SELECT COUNT(id) AS count FROM nl2_users WHERE last_online > ?', [strtotime('-5 minutes')])->first()->count;
+            } else {
+                return DB::getInstance()->query('SELECT COUNT(U.id) AS count FROM nl2_users AS U JOIN nl2_users_groups AS UG ON (U.id = UG.user_id) JOIN nl2_groups AS G ON (UG.group_id = G.id) WHERE G.order = (SELECT min(iG.`order`) FROM nl2_users_groups AS iUG JOIN nl2_groups AS iG ON (iUG.group_id = iG.id) WHERE iUG.user_id = U.id GROUP BY iUG.user_id ORDER BY NULL) AND U.last_online > ? AND G.staff = 0', [strtotime('-5 minutes')])->first()->count;
+            }
+        }, 120);
+
+        // Generate HTML code for widget
+        if (count($online_users)) {
             $this->_engine->addVariables([
                 'SHOW_NICKNAME_INSTEAD' => Settings::get('online_users_widget_use_nicknames', 0),
                 'ONLINE_USERS' => $this->_language->get('general', 'online_users'),
-                'ONLINE_USERS_LIST' => $users,
-                'TOTAL_ONLINE_USERS' => $this->_language->get('general', 'total_online_users', ['count' => count($online)])
+                'ONLINE_USERS_LIST' => $online_users,
+                'TOTAL_ONLINE_USERS' => $this->_language->get('general', 'total_online_users', ['count' => $total_online_users])
             ]);
-
         } else {
             $this->_engine->addVariables([
                 'ONLINE_USERS' => $this->_language->get('general', 'online_users'),

--- a/modules/Core/widgets/OnlineUsersWidget.php
+++ b/modules/Core/widgets/OnlineUsersWidget.php
@@ -30,9 +30,50 @@ class OnlineUsersWidget extends WidgetBase {
 
         $online_users = $this->_cache->fetch('users', function () {
             if (Settings::get('online_users_widget_include_staff', 0)) {
-                $online = DB::getInstance()->query('SELECT id FROM nl2_users WHERE last_online > ? LIMIT 10', [strtotime('-5 minutes')])->results();
+                $online = DB::getInstance()->query(
+                    <<<SQL
+                        SELECT
+                            u.id
+                        FROM nl2_users AS u
+                        JOIN nl2_users_groups AS ug ON u.id = ug.user_id
+                        JOIN nl2_groups AS g ON ug.group_id = g.id
+                        WHERE g.order = (
+                            SELECT MIN(ig.order)
+                            FROM nl2_users_groups AS iug
+                            JOIN nl2_groups AS ig ON iug.group_id = ig.id
+                            WHERE iug.user_id = u.id
+                            GROUP BY iug.user_id
+                            ORDER BY NULL
+                        )
+                        AND u.last_online > ?
+                        ORDER BY g.order ASC
+                        LIMIT 10
+                    SQL,
+                [strtotime('-5 minutes')]
+                )->results();
             } else {
-                $online = DB::getInstance()->query('SELECT U.id FROM nl2_users AS U JOIN nl2_users_groups AS UG ON (U.id = UG.user_id) JOIN nl2_groups AS G ON (UG.group_id = G.id) WHERE G.order = (SELECT min(iG.`order`) FROM nl2_users_groups AS iUG JOIN nl2_groups AS iG ON (iUG.group_id = iG.id) WHERE iUG.user_id = U.id GROUP BY iUG.user_id ORDER BY NULL) AND U.last_online > ' . strtotime('-5 minutes') . ' AND G.staff = 0 LIMIT 10')->results();
+                $online = DB::getInstance()->query(
+                    <<<SQL
+                        SELECT
+                            u.id
+                        FROM nl2_users AS u
+                        JOIN nl2_users_groups AS ug ON u.id = ug.user_id
+                        JOIN nl2_groups AS g ON ug.group_id = g.id
+                        WHERE g.order = (
+                            SELECT MIN(ig.order)
+                            FROM nl2_users_groups AS iug
+                            JOIN nl2_groups AS ig ON iug.group_id = ig.id
+                            WHERE iug.user_id = u.id
+                            GROUP BY iug.user_id
+                            ORDER BY NULL
+                        )
+                        AND u.last_online > ?
+                        AND g.staff = 0
+                        ORDER BY g.order ASC
+                        LIMIT 10
+                    SQL,
+                    [strtotime('-5 minutes')]
+                )->results();
             }
 
             foreach ($online as $item) {
@@ -59,7 +100,26 @@ class OnlineUsersWidget extends WidgetBase {
             if (Settings::get('online_users_widget_include_staff', 0)) {
                 return DB::getInstance()->query('SELECT COUNT(id) AS count FROM nl2_users WHERE last_online > ?', [strtotime('-5 minutes')])->first()->count;
             } else {
-                return DB::getInstance()->query('SELECT COUNT(U.id) AS count FROM nl2_users AS U JOIN nl2_users_groups AS UG ON (U.id = UG.user_id) JOIN nl2_groups AS G ON (UG.group_id = G.id) WHERE G.order = (SELECT min(iG.`order`) FROM nl2_users_groups AS iUG JOIN nl2_groups AS iG ON (iUG.group_id = iG.id) WHERE iUG.user_id = U.id GROUP BY iUG.user_id ORDER BY NULL) AND U.last_online > ? AND G.staff = 0', [strtotime('-5 minutes')])->first()->count;
+                return DB::getInstance()->query(
+                    <<<SQL
+                        SELECT
+                            COUNT(u.id) as count
+                        FROM nl2_users AS u
+                        JOIN nl2_users_groups AS ug ON u.id = ug.user_id
+                        JOIN nl2_groups AS g ON ug.group_id = g.id
+                        WHERE g.order = (
+                            SELECT MIN(ig.order)
+                            FROM nl2_users_groups AS iug
+                            JOIN nl2_groups AS ig ON iug.group_id = ig.id
+                            WHERE iug.user_id = u.id
+                            GROUP BY iug.user_id
+                            ORDER BY NULL
+                        )
+                        AND u.last_online > ?
+                        AND g.staff = 0
+                    SQL,
+                    [strtotime('-5 minutes')]
+                )->first()->count;
             }
         }, 120);
 


### PR DESCRIPTION
Rather than only fetch the online user IDs and then rebuild User instances on each page load, we will store the User instances in the cache

Also fixes an issue when, if cache is deleted, we can rebuild the enabled widgets. Previously users would have to toggle them off and then on again to trigger a cache rebuild.