### PR TITLE
Refactor dark mode toggle UI and placement

### DIFF
--- a/custom/templates/DefaultRevamp/css/custom.css
+++ b/custom/templates/DefaultRevamp/css/custom.css
@@ -1062,45 +1062,21 @@ select {
     display: inline-block;
 }
 
-.darkmode-toggle {
-    opacity: 0;
-    position: absolute;
+#toggle-dark-mode {
+    width: 33px;
+    height: 33px;
 }
 
-.darkmode-toggle:checked+.darkmode-toggle-label .darkmode-ball {
-    transform: translateX(24px);
-}
-
-.darkmode-toggle-label {
-    background-color: #111;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    border-radius: 50px;
-    position: relative;
-    padding: 5px;
-    height: 26px;
-    width: 50px;
-    cursor: pointer;
-}
-
-.darkmode-ball {
-    background-color: #fff;
-    border-radius: 50%;
-    position: absolute;
-    top: 2px;
-    left: 2px;
-    height: 22px;
-    width: 22px;
-    transition: transform 0.2s linear;
-}
-
-.fa-moon {
+#toggle-dark-mode[data-mode="dark"]::after {
+    content: "\f186";
     color: #f1c400;
+    font-family: "Font Awesome 5 Free";
 }
 
-.fa-sun {
+#toggle-dark-mode[data-mode="light"]::after {
+    content: "\f185";
     color: #f39c00;
+    font-family: "Font Awesome 5 Free";
 }
 
 /*

--- a/custom/templates/DefaultRevamp/footer.tpl
+++ b/custom/templates/DefaultRevamp/footer.tpl
@@ -17,22 +17,6 @@
                     {if $PAGE_LOAD_TIME}
                     <span class="item" id="page_load"></span>
                     {/if}
-                    <span class="item" id="darkmode">
-                        <input type="checkbox" class="darkmode-toggle" id="darkmode-toggle" onclick="toggleDarkLightMode()">
-                        <label for="darkmode-toggle" class="darkmode-toggle-label">
-                            <i class="fas fa-moon"></i>
-                            <i class="fas fa-sun"></i>
-                            <div class="darkmode-ball"></div>
-                        </label>
-
-                        <script type="text/javascript">
-                            if (document.body.classList.contains('dark')) {
-                                document.getElementById("darkmode-toggle").checked = true;
-                            } else {
-                                document.getElementById("darkmode-toggle").checked = false;
-                            }
-                        </script>
-                    </span>
                     {if isset($AUTO_LANGUAGE)}
                         <a class="item" href="javascript:" onclick="toggleAutoLanguage()" id="auto-language"></a>
                     {/if}
@@ -107,6 +91,12 @@
             });
 
         return false;
+    }
+
+    if (document.body.classList.contains('dark')) {
+        document.getElementById("toggle-dark-mode").setAttribute("data-mode", "dark");
+    } else {
+        document.getElementById("toggle-dark-mode").setAttribute("data-mode", "light");
     }
 
     {if isset($AUTO_LANGUAGE)}

--- a/custom/templates/DefaultRevamp/navbar.tpl
+++ b/custom/templates/DefaultRevamp/navbar.tpl
@@ -97,6 +97,7 @@
                     {/if}
                     {/if}
                     {/foreach}
+                    <a class="ui small default icon button" id="toggle-dark-mode" data-mode="dark" onclick="toggleDarkLightMode()"></a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Replaces the custom dark mode toggle switch in the footer with a Font Awesome icon button in the navbar. Updates CSS to use icon-based toggle and adjusts JavaScript to set the icon state based on the current mode.

Issue #3692 