### PR TITLE
Fix edge case where cache would be change in install

### DIFF
--- a/modules/Core/pages/panel/modules.php
+++ b/modules/Core/pages/panel/modules.php
@@ -186,8 +186,6 @@ if (!isset($_GET['action'])) {
 
             /** @phpstan-ignore-next-line */
             if ($module instanceof Module) {
-                // Cache
-                $cache->setCache('modulescache');
                 $modules = [];
 
                 $order = Module::determineModuleOrder();
@@ -203,6 +201,9 @@ if (!isset($_GET['action'])) {
                     // OK to enable
                     $module->onEnable();
 
+                    // Cache
+                    $cache->setCache('modulescache');
+                    
                     // Store
                     $cache->store('enabled_modules', $modules);
 


### PR DESCRIPTION
If a module were to change the cache in their onEnable method, Nameless would be storing the enabled modules in the wrong cache file. This PR just moves the setCache to *after* the onEnable of the module.