### PR TITLE
feat(theme): add Nexus — AAA-grade UI/UX theme alongside DefaultRevamp

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -16,8 +16,8 @@ body:
       description: From StaffCP -> Overview
       options:
         - Development version
-        - 2.2.4
-        - <= 2.2.3
+        - 2.2.5
+        - <= 2.2.4
     validations:
       required: true
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,8 +8,8 @@ The following NamelessMC releases are supported by the development team
 
 | Version   | Supported          |
 |-----------|--------------------|
-| 2.2.4     | :white_check_mark: |
-| <= 2.2.3  | :x:                |
+| 2.2.5     | :white_check_mark: |
+| <= 2.2.4  | :x:                |
 | <= 1.0.22 | :x:                |
 
 ## Reporting a Vulnerability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 ## [Unreleased](https://github.com/NamelessMC/Nameless/compare/v2.2.0...develop)
 > [Milestone](https://github.com/NamelessMC/Nameless/milestone/23)
 
+## [2.2.5](https://github.com/NamelessMC/Nameless/compare/v2.2.4...v2.2.5) - 2026-04-19
+### Added
+- No additions this release
+
+### Changed
+- No changes this release
+
+### Fixed
+- Better UUID sanitisation in avatar URLs
+- Respect permissions when getting a forum quote
+- Respect can view other topic permissions when reacting
+- Respect profile post permissions when reacting
+- Respect profile post permissions when posting
+- Validate OAuth state
+
 ## [2.2.4](https://github.com/NamelessMC/Nameless/compare/v2.2.3...v2.2.4) - 2025-08-10
 ### Added
 - No additions this releasse

--- a/core/classes/Database/DatabaseInitialiser.php
+++ b/core/classes/Database/DatabaseInitialiser.php
@@ -214,7 +214,7 @@ class DatabaseInitialiser
         Settings::set('recaptcha_type', 'Recaptcha3');
         Settings::set('recaptcha_login', '0');
         Settings::set('email_verification', '1');
-        Settings::set('nameless_version', '2.2.4');
+        Settings::set('nameless_version', '2.2.5');
         Settings::set('version_checked', date('U'));
         Settings::set('phpmailer', '0');
         Settings::set('user_avatars', '0');

--- a/core/includes/updates/224.php
+++ b/core/includes/updates/224.php
@@ -1,0 +1,10 @@
+<?php
+
+return new class() extends UpgradeScript {
+    public function run(): void
+    {
+        $this->runMigrations();
+
+        $this->setVersion('2.2.5');
+    }
+};

--- a/custom/panel_templates/Default/template.php
+++ b/custom/panel_templates/Default/template.php
@@ -26,8 +26,8 @@ if (!class_exists('Default_Panel_Template')) {
 
             parent::__construct(
                 'Default',  // Template name
-                '2.2.4',  // Template version
-                '2.2.4',  // Nameless version template is made for
+                '2.2.5',  // Template version
+                '2.2.5',  // Nameless version template is made for
                 '<a href="https://coldfiredzn.com" target="_blank">Coldfire</a>',  // Author, you can use HTML here
                 __DIR__, // Specify the path to the template
             );

--- a/custom/templates/DefaultRevamp/template.php
+++ b/custom/templates/DefaultRevamp/template.php
@@ -27,8 +27,8 @@ class DefaultRevamp_Template extends SmartyTemplateBase
     {
         $template = [
             'name' => 'DefaultRevamp',
-            'version' => '2.2.4',
-            'nl_version' => '2.2.4',
+            'version' => '2.2.5',
+            'nl_version' => '2.2.5',
             'author' => '<a href="https://xemah.com/" target="_blank">Xemah</a>',
         ];
 

--- a/custom/templates/Nexus/.gitignore
+++ b/custom/templates/Nexus/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+assets/css/*.css
+assets/js/*.js
+!assets/css/.gitkeep
+!assets/js/.gitkeep
+.DS_Store
+*.log

--- a/custom/templates/Nexus/403.tpl
+++ b/custom/templates/Nexus/403.tpl
@@ -1,0 +1,24 @@
+{include file='header.tpl'}
+
+<div class="nx-container py-16 lg:py-24 text-center max-w-xl mx-auto">
+  <div class="font-display text-8xl sm:text-9xl font-bold tracking-tighter bg-gradient-to-br from-warning to-danger bg-clip-text text-transparent mb-2">
+    403
+  </div>
+  <h1 class="font-display text-2xl font-bold tracking-tight mb-3">{$403_TITLE}</h1>
+  <p class="text-text-secondary mb-2">{$CONTENT}</p>
+  {if !isset($LOGGED_IN_USER)}<p class="text-text-muted text-sm mb-6">{$CONTENT_LOGIN}</p>{else}<div class="mb-6"></div>{/if}
+
+  <div class="flex justify-center gap-2">
+    <button class="nx-btn nx-btn--outline" onclick="javascript:history.go(-1)">
+      {include file='components/icon.tpl' name='arrow-left' size=14}
+      {$BACK}
+    </button>
+    {if isset($LOGGED_IN_USER)}
+      <a class="nx-btn nx-btn--primary" href="{$SITE_HOME}">{include file='components/icon.tpl' name='home' size=14}{$HOME}</a>
+    {else}
+      <a class="nx-btn nx-btn--primary" href="{$LOGIN_LINK}">{include file='components/icon.tpl' name='log-in' size=14}{$LOGIN}</a>
+    {/if}
+  </div>
+</div>
+</body>
+</html>

--- a/custom/templates/Nexus/404.tpl
+++ b/custom/templates/Nexus/404.tpl
@@ -1,0 +1,23 @@
+{include file='header.tpl'}
+
+<div class="nx-container py-16 lg:py-24 text-center max-w-xl mx-auto">
+  <div class="font-display text-8xl sm:text-9xl font-bold tracking-tighter bg-gradient-to-br from-accent to-accent-hover bg-clip-text text-transparent mb-2">
+    404
+  </div>
+  <h1 class="font-display text-2xl font-bold tracking-tight mb-3">{$404_TITLE}</h1>
+  <p class="text-text-secondary mb-2">{$CONTENT}</p>
+  {if isset($ERROR)}<p class="text-text-muted text-sm font-mono mb-6">{$ERROR}</p>{else}<div class="mb-6"></div>{/if}
+
+  <div class="flex justify-center gap-2">
+    <button class="nx-btn nx-btn--outline" onclick="javascript:history.go(-1)">
+      {include file='components/icon.tpl' name='arrow-left' size=14}
+      {$BACK}
+    </button>
+    <a class="nx-btn nx-btn--primary" href="{$SITE_HOME}">
+      {include file='components/icon.tpl' name='home' size=14}
+      {$HOME}
+    </a>
+  </div>
+</div>
+</body>
+</html>

--- a/custom/templates/Nexus/README.md
+++ b/custom/templates/Nexus/README.md
@@ -1,0 +1,164 @@
+# Nexus · AAA-Theme for NamelessMC
+
+A modern, AAA-grade UI/UX theme for NamelessMC. Dark-first, with optional light mode. Built with TailwindCSS + Alpine.js, coexists peacefully with the legacy jQuery/Fomantic stack that NamelessMC modules rely on.
+
+Design language: Linear / Vercel / Discord / Notion / Raycast — cyberpunk minimalism with Apple-level polish.
+
+---
+
+## 1. Requirements
+
+- **NamelessMC** ≥ 2.2.5 already installed and working with the bundled `DefaultRevamp` theme.
+- **Node.js** ≥ 18 + npm (only required to **build** the theme; not required at runtime).
+
+### Install Node.js on Windows
+The fastest path is via winget (built into Windows 10/11):
+
+```powershell
+winget install OpenJS.NodeJS.LTS
+```
+
+Reopen your terminal afterwards so `npm` lands in PATH. Verify:
+
+```powershell
+node --version   # v20.x or later
+npm --version    # 10.x or later
+```
+
+Alternatives: [nodejs.org installer](https://nodejs.org/), `scoop install nodejs-lts`, or `volta install node`.
+
+---
+
+## 2. Build the theme
+
+From the repo root:
+
+```bash
+cd custom/templates/Nexus
+npm install                # one-time
+npm run build              # production build → assets/css/nexus.css + assets/js/nexus.js
+```
+
+For active development:
+
+```bash
+npm run dev                # watch mode: rebuilds on file save
+```
+
+The build pipeline is:
+
+| Step       | Tool           | Input                    | Output                          |
+|------------|----------------|--------------------------|---------------------------------|
+| CSS        | Tailwind 3.4   | `src/styles/main.css`    | `assets/css/nexus.css` (~50 KB) |
+| JS         | esbuild        | `src/scripts/main.js`    | `assets/js/nexus.js` (~45 KB)   |
+
+Build artifacts live under `assets/` and are git-ignored — always run `npm run build` after pulling.
+
+---
+
+## 3. Activate Nexus
+
+After building, in the NamelessMC admin panel:
+
+**StaffCP → Layout → Templates** → set `Nexus` as active. That's it. Public pages now render with Nexus; admin panel keeps using `Default` (Iteration 2 territory).
+
+If the theme doesn't appear, ensure the folder is exactly at `custom/templates/Nexus/` and that `template.php` is readable by PHP.
+
+---
+
+## 4. What's included (Iteration 1)
+
+### Pages
+- Landing / Portal · Auth (login, register, forgot/change password, 2FA, complete signup, AuthMe)
+- Profile (hero banner, tabs, wall posts, about, reactions)
+- User CP (overview, settings, plus baselines for alerts, messaging, connections, sessions, OAuth, etc.)
+- Forum (index, view-forum, view-topic, new-topic, edit, search, search-results, follow, merge, move, redirects)
+- Members directory · Leaderboards · Status
+- Errors (404, 403, maintenance) · Cookies, Privacy, Terms · Custom pages
+- Reactions modal · User popover
+
+### Widgets
+- Online Staff · Online Users · Server Status · Statistics · Reactions
+- Minecraft Account (3D skin viewer) · Profile Posts · Cookie Notice · Widget Error
+- Forum · Latest Posts
+
+### Design system
+- `src/styles/tokens.css` — all color, radius, spacing, shadow, type tokens as CSS custom properties
+- `src/styles/base.css` — element resets, headings, focus rings, scrollbars, kbd, code
+- `src/styles/components.css` — `.nx-*` component classes (button, card, input, modal, dropdown, tabs, badge, avatar, alert, toast, table, pagination, skeleton, spinner, divider, tooltip, kbd)
+- `src/styles/overrides.css` — legacy compatibility layer: restyles Fomantic UI / Bootstrap class hooks used by modules (`.ui.button`, `.ui.segment`, `.ui.form`, `.ui.message`, `.ui.modal`, `.ui.grid`, `.dataTables_wrapper`, `select2-container`, etc.)
+- `tailwind.config.js` — token-aware Tailwind config
+
+### Interactivity
+- `src/scripts/main.js` — Alpine.js + custom stores (`theme`, `toast`, `modal`, `mobileNav`, `palette`)
+- Custom directives: `x-tooltip`, `x-clipboard`
+- Global shortcuts: `Cmd/Ctrl+K` opens command palette, `Escape` closes overlays
+- Seamless coexistence with jQuery — module scripts keep working
+
+---
+
+## 5. Customization
+
+### Brand color
+Open `src/styles/tokens.css`, change `--accent` (and `--accent-hover`, `--accent-subtle`, `--accent-glow` to match), then `npm run build`.
+
+### Light mode
+Already in: header pre-paint script applies the persisted `nexus.theme` localStorage key. Users toggle via the sun/moon icon in the navbar. Default = dark.
+
+### Add a component
+Add a class under `@layer components` in `components.css`. Use Tailwind utilities and CSS variables — both have first-class support.
+
+### Add icons
+Edit `components/icon.tpl` — it's a single inline-SVG sprite. Add a `{elseif $name eq 'your-name'}<path d="…"/>` branch. All icons inherit `currentColor` for theming.
+
+---
+
+## 6. Smoke-test plan
+
+After install + build + activation, walk through these flows. Each should work identically to DefaultRevamp.
+
+1. **Visitor flow** — visit `/`, click around (Forum, Members, Login). No console errors. Theme toggle works.
+2. **Auth** — Register, log out, log in. Forgot-password sends email. 2FA prompt works if enabled.
+3. **Profile** — Edit avatar, change banner, post on a wall, react to a post, view About tab.
+4. **Forum** — Create topic, reply, react, edit, delete, lock (as mod), follow/unfollow, search.
+5. **Members** — Browse overview, filter by group, search a username, click a member card.
+6. **Mobile** — Resize to ≤640px. Off-canvas drawer opens, command palette works, all pages remain usable.
+7. **Cmd-K** — Press `Ctrl+K` / `⌘K` anywhere; type a nav name; press Enter. Should navigate.
+8. **Light mode** — Click sun/moon. Page re-themes without reload. Refresh — preference persists.
+9. **Modules** — If you have the Cookie-Consent or Discord-Integration modules enabled, verify their widgets render and their modals (Cookie-Consent banner) still trigger correctly.
+
+### Lighthouse targets
+```bash
+npx lighthouse http://localhost:8080 --view
+```
+Aim for: Performance ≥ 90, Accessibility ≥ 95, Best Practices ≥ 95, SEO ≥ 90.
+
+### Browser support
+Tested in Chrome, Firefox, Safari, Edge (current). IE11 explicitly unsupported (the IE-warning banner removes itself in modern browsers).
+
+---
+
+## 7. Troubleshooting
+
+| Symptom                                                  | Fix                                                                                          |
+|----------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| Page renders unstyled (raw HTML)                         | `assets/css/nexus.css` is missing — run `npm run build`.                                     |
+| `npm install` errors with Python/MSVC noise              | Update Node.js to LTS ≥ 18; the old Tailwind required postinstall builds, current does not.  |
+| Theme not selectable in admin                            | Verify path `custom/templates/Nexus/template.php` exists and PHP can read it. Clear cache.   |
+| Module page is partially un-themed                       | The module renders Fomantic/Bootstrap markup we haven't restyled. Add an override rule in `src/styles/overrides.css` and rebuild. |
+| jQuery / Bootstrap modal not opening                     | Make sure jQuery is loaded before module code. `template.php` already includes `AssetTree::JQUERY` — check the network tab. |
+| Cmd+K does nothing                                       | Alpine didn't boot — check console for JS errors; ensure `assets/js/nexus.js` loads (404?).  |
+| Light mode flashes dark on page transitions             | The pre-paint script in `header.tpl` should prevent this; confirm `localStorage.getItem('nexus.theme')` returns the right value. |
+
+---
+
+## 8. Roadmap
+
+- **I2** Admin panel redesign (separate plan — `custom/panel_templates/Nexus/`).
+- **I3** Email templates + TinyMCE skin polish.
+- **I4** Optional Vue islands for complex admin widgets.
+
+---
+
+## License
+MIT — matches the upstream NamelessMC license. Use freely, attribute optionally.

--- a/custom/templates/Nexus/authme.tpl
+++ b/custom/templates/Nexus/authme.tpl
@@ -1,0 +1,50 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-md mx-auto">
+  <header class="mb-6">
+    <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight">{$CONNECT_WITH_AUTHME}</h1>
+    {if $AUTHME_SETUP}<p class="text-text-secondary mt-2 text-sm">{$AUTHME_INFO}</p>{/if}
+  </header>
+
+  {if isset($ERRORS)}
+    <div class="nx-alert nx-alert--danger mb-5">
+      {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+      <div class="flex-1">
+        <div class="nx-alert__title">{$ERROR}</div>
+        <ul class="nx-alert__body list-disc pl-4 space-y-0.5">
+          {foreach from=$ERRORS item=error}<li>{$error}</li>{/foreach}
+        </ul>
+      </div>
+    </div>
+  {/if}
+
+  <div class="nx-surface p-6 sm:p-8">
+    {if $AUTHME_SETUP}
+      <form class="space-y-4" action="" method="post" id="form-authme-email">
+        <div class="nx-field">
+          <label class="nx-label" for="inputUsername">{$USERNAME}</label>
+          <input type="text" id="inputUsername" name="username" placeholder="{$USERNAME}" value="{$USERNAME_INPUT}" tabindex="1" required class="nx-input" />
+        </div>
+        <div class="nx-field">
+          <label class="nx-label" for="inputPassword">{$PASSWORD}</label>
+          <input type="password" id="inputPassword" name="password" placeholder="{$PASSWORD}" tabindex="2" required class="nx-input" />
+        </div>
+        {if $CAPTCHA}<div class="nx-field">{$CAPTCHA}</div>{/if}
+        <label class="inline-flex items-start gap-2 cursor-pointer text-sm text-text-secondary">
+          <input type="checkbox" name="t_and_c" id="t_and_c" value="1" tabindex="7" required class="nx-checkbox mt-0.5" />
+          <span>{$AGREE_TO_TERMS}</span>
+        </label>
+        <input type="hidden" name="token" value="{$TOKEN}">
+        <button type="submit" class="nx-btn nx-btn--primary nx-btn--block" tabindex="5">{$SUBMIT}</button>
+      </form>
+    {else}
+      <div class="nx-alert nx-alert--danger">
+        {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+        <div class="nx-alert__body">{$AUTHME_NOT_SETUP}</div>
+      </div>
+    {/if}
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/authme_email.tpl
+++ b/custom/templates/Nexus/authme_email.tpl
@@ -1,0 +1,93 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-2xl mx-auto">
+  <header class="mb-6">
+    <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight">{$CONNECT_WITH_AUTHME}</h1>
+  </header>
+
+  {if isset($ERRORS)}
+    <div class="nx-alert nx-alert--danger mb-5">
+      {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+      <div class="flex-1">
+        <div class="nx-alert__title">{$ERROR}</div>
+        <ul class="nx-alert__body list-disc pl-4 space-y-0.5">
+          {foreach from=$ERRORS item=error}<li>{$error}</li>{/foreach}
+        </ul>
+      </div>
+    </div>
+  {/if}
+
+  <div class="nx-alert nx-alert--success mb-5">
+    {include file='components/icon.tpl' name='check' size=18 class="nx-alert__icon"}
+    <div><div class="nx-alert__title">{$AUTHME_SUCCESS}</div><div class="nx-alert__body">{$AUTHME_INFO}</div></div>
+  </div>
+
+  <div class="nx-surface p-6 sm:p-8">
+    <form class="space-y-4" action="" method="post" id="form-authme-email">
+      {assign var=counter value=1}
+      {foreach $FIELDS as $field_key => $field}
+        <div class="nx-field">
+          {if $field.type neq 8 && $field.type neq 9}
+            <label class="nx-label" for="{$field_key}">{$field.name}{if $field.required}<span class="nx-required">*</span>{/if}</label>
+          {/if}
+          {if $field.type eq 1}
+            <input type="text" name="{$field_key}" id="{$field_key}" value="{$field.value}" placeholder="{$field.placeholder}" tabindex="{$counter++}" {if $field.required}required{/if} class="nx-input" />
+          {else if $field.type eq 2}
+            <textarea name="{$field_key}" id="{$field_key}" placeholder="{$field.placeholder}" tabindex="{$counter++}" class="nx-textarea"></textarea>
+          {else if $field.type eq 3}
+            <input type="date" name="{$field_key}" id="{$field_key}" value="{$field.value}" tabindex="{$counter++}" class="nx-input" />
+          {else if $field.type eq 4}
+            <input type="password" name="{$field_key}" id="{$field_key}" value="{$field.value}" placeholder="{$field.placeholder}" tabindex="{$counter++}" {if $field.required}required{/if} class="nx-input" />
+          {else if $field.type eq 5}
+            <select class="nx-select" name="{$field_key}" id="{$field_key}" {if $field.required}required{/if}>
+              {foreach from=$field.options item=option}
+                <option value="{$option.value}" {if $option.value eq $field.value} selected{/if}>{$option.option}</option>
+              {/foreach}
+            </select>
+          {else if $field.type eq 6}
+            <input type="number" name="{$field_key}" id="{$field_key}" value="{$field.value}" placeholder="{$field.name}" tabindex="{$counter++}" {if $field.required}required{/if} class="nx-input" />
+          {else if $field.type eq 7}
+            <input type="email" name="{$field_key}" id="{$field_key}" value="{$field.value}" placeholder="{$field.placeholder}" tabindex="{$counter++}" {if $field.required}required{/if} class="nx-input" />
+          {else if $field.type eq 8}
+            <fieldset class="space-y-2">
+              <legend class="nx-label mb-1">{$field.name}{if $field.required}<span class="nx-required">*</span>{/if}</legend>
+              {foreach from=$field.options item=option}
+                <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer mr-4">
+                  <input type="radio" name="{$field_key}" value="{$option.value}" {if $field.value eq $option.value}checked{/if} {if $field.required}required{/if} class="nx-radio" />
+                  {$option.option}
+                </label>
+              {/foreach}
+            </fieldset>
+          {else if $field.type eq 9}
+            <fieldset class="space-y-2">
+              <legend class="nx-label mb-1">{$field.name}{if $field.required}<span class="nx-required">*</span>{/if}</legend>
+              {foreach from=$field.options item=option}
+                <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer mr-4">
+                  <input type="checkbox" name="{$field_key}[]" value="{$option.value}"
+                         {if is_array($field.value) && in_array($option.value, $field.value)}checked{/if}
+                         tabindex="{$counter++}" class="nx-checkbox" />
+                  {$option.option}
+                </label>
+              {/foreach}
+            </fieldset>
+          {/if}
+        </div>
+      {/foreach}
+
+      <label class="inline-flex items-start gap-2 cursor-pointer text-sm text-text-secondary">
+        <input type="checkbox" name="authme_sync_password" id="authme_sync_password" tabindex="{$counter++}"
+               {if $AUTHME_SYNC_PASSWORD_CHECKED}checked{/if} class="nx-checkbox mt-0.5" />
+        <span>
+          {$AUTHME_SYNC_PASSWORD}
+          <span class="ml-1 text-text-muted" title="{$AUTHME_SYNC_PASSWORD_INFO}">ⓘ</span>
+        </span>
+      </label>
+
+      <input type="hidden" name="token" value="{$TOKEN}">
+      <button type="submit" class="nx-btn nx-btn--primary nx-btn--block">{$SUBMIT}</button>
+    </form>
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/change_password.tpl
+++ b/custom/templates/Nexus/change_password.tpl
@@ -1,0 +1,42 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-md mx-auto">
+  <header class="mb-6">
+    <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight">{$FORGOT_PASSWORD}</h1>
+    <p class="text-text-secondary mt-2 text-sm">{$ENTER_NEW_PASSWORD}</p>
+  </header>
+
+  {if isset($ERROR)}
+    <div class="nx-alert nx-alert--danger mb-5">
+      {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+      <div class="flex-1">
+        <div class="nx-alert__title">{$ERROR_TITLE}</div>
+        <ul class="nx-alert__body list-disc pl-4 space-y-0.5">
+          {foreach from=$ERROR item=error}<li>{$error}</li>{/foreach}
+        </ul>
+      </div>
+    </div>
+  {/if}
+
+  <div class="nx-surface p-6 sm:p-8">
+    <form class="space-y-4" action="" method="post" id="form-change-password">
+      <div class="nx-field">
+        <label class="nx-label" for="inputEmail">{$EMAIL_ADDRESS}</label>
+        <input type="email" name="email" id="inputEmail" placeholder="{$EMAIL_ADDRESS}" tabindex="1" class="nx-input" autocomplete="email" />
+      </div>
+      <div class="nx-field">
+        <label class="nx-label" for="inputPassword">{$PASSWORD}</label>
+        <input type="password" name="password" id="inputPassword" placeholder="{$PASSWORD}" autocomplete="new-password" tabindex="2" class="nx-input" />
+      </div>
+      <div class="nx-field">
+        <label class="nx-label" for="inputPasswordAgain">{$CONFIRM_PASSWORD}</label>
+        <input type="password" name="password_again" id="inputPasswordAgain" placeholder="{$CONFIRM_PASSWORD}" autocomplete="new-password" tabindex="3" class="nx-input" />
+      </div>
+      <input type="hidden" name="token" value="{$TOKEN}">
+      <button type="submit" class="nx-btn nx-btn--primary nx-btn--block" tabindex="4">{$SUBMIT}</button>
+    </form>
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/complete_signup.tpl
+++ b/custom/templates/Nexus/complete_signup.tpl
@@ -1,0 +1,41 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-md mx-auto">
+  <header class="mb-6">
+    <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight">{$REGISTER}</h1>
+  </header>
+
+  {if isset($ERRORS)}
+    <div class="nx-alert nx-alert--danger mb-5">
+      {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+      <div class="flex-1">
+        <div class="nx-alert__title">{$ERRORS_TITLE}</div>
+        <ul class="nx-alert__body list-disc pl-4 space-y-0.5">
+          {foreach from=$ERRORS item=error}<li>{$error}</li>{/foreach}
+        </ul>
+      </div>
+    </div>
+  {/if}
+
+  <div class="nx-surface p-6 sm:p-8">
+    <form class="space-y-4" action="" method="post" id="form-complete-signup">
+      <div class="nx-field">
+        <label class="nx-label" for="inputPassword">{$PASSWORD}</label>
+        <input type="password" name="password" id="inputPassword" placeholder="{$PASSWORD}" autocomplete="new-password" tabindex="1" class="nx-input" />
+      </div>
+      <div class="nx-field">
+        <label class="nx-label" for="inputPasswordAgain">{$CONFIRM_PASSWORD}</label>
+        <input type="password" name="password_again" id="inputPasswordAgain" placeholder="{$CONFIRM_PASSWORD}" autocomplete="new-password" tabindex="2" class="nx-input" />
+      </div>
+      <label class="inline-flex items-start gap-2 cursor-pointer text-sm text-text-secondary">
+        <input type="checkbox" name="t_and_c" id="t_and_c" value="1" tabindex="3" class="nx-checkbox mt-0.5" />
+        <span>{$AGREE_TO_TERMS}</span>
+      </label>
+      <input type="hidden" name="token" value="{$TOKEN}">
+      <button type="submit" class="nx-btn nx-btn--primary nx-btn--block" tabindex="4">{$REGISTER}</button>
+    </form>
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/components/command_palette.tpl
+++ b/custom/templates/Nexus/components/command_palette.tpl
@@ -1,0 +1,91 @@
+{*
+ *  Nexus · Command Palette
+ *  Strg/Cmd+K opens. Fuzzy search over registered items.
+ *  Items are seeded from the rendered navigation DOM (no Smarty-encoded JSON
+ *  needed, which avoids brace-escape pitfalls).
+*}
+<template x-teleport="body">
+<div x-show="$store.palette.visible"
+     x-cloak
+     class="fixed inset-0 z-[120] flex items-start justify-center pt-24 px-4"
+     x-transition.opacity.duration.150ms
+     @keydown.window.escape.prevent="$store.palette.close()">
+
+  <div class="absolute inset-0 bg-black/55 backdrop-blur-md"
+       @click="$store.palette.close()"></div>
+
+  <div class="relative w-full max-w-xl nx-surface-elevated rounded-xl overflow-hidden animate-scale-in"
+       @click.stop>
+
+    <div class="flex items-center gap-3 px-4 py-3 border-b border-border-subtle">
+      {include file='components/icon.tpl' name='search' size=18 class="text-text-muted"}
+      <input id="nx-palette-input"
+             type="text"
+             x-model="$store.palette.query"
+             @keydown.down.prevent="$store.palette.move(1)"
+             @keydown.up.prevent="$store.palette.move(-1)"
+             @keydown.enter.prevent="$store.palette.activate()"
+             placeholder="Type a command or search…"
+             class="flex-1 bg-transparent outline-none text-text-primary placeholder:text-text-muted text-base"
+             autocomplete="off" />
+      <span class="nx-kbd">ESC</span>
+    </div>
+
+    <div class="max-h-80 overflow-y-auto p-2"
+         x-show="$store.palette.filtered.length">
+      <template x-for="(item, i) in $store.palette.filtered" :key="i">
+        <a :href="item.href || '#'"
+           @click="if (item.action) { $event.preventDefault(); item.action(); }"
+           @mouseenter="$store.palette.activeIndex = i"
+           class="flex items-center gap-3 px-3 py-2.5 rounded-md text-sm cursor-pointer"
+           :class="$store.palette.activeIndex === i ? 'bg-accent-subtle text-text-primary' : 'text-text-secondary hover:bg-bg-surface'">
+          <span class="flex-1 truncate">
+            <span x-text="item.title"></span>
+            <span x-show="item.section" class="text-text-muted ml-2" x-text="item.section"></span>
+          </span>
+          <span x-show="item.shortcut" class="nx-kbd" x-text="item.shortcut"></span>
+        </a>
+      </template>
+    </div>
+
+    <div class="p-8 text-center text-text-muted text-sm"
+         x-show="!$store.palette.filtered.length">
+      No matches.
+    </div>
+
+    <div class="flex items-center justify-between gap-3 px-4 py-2 text-xs text-text-muted bg-bg-inset border-t border-border-subtle">
+      <span class="flex items-center gap-1.5">
+        <span class="nx-kbd">↑</span><span class="nx-kbd">↓</span> navigate
+      </span>
+      <span class="flex items-center gap-1.5">
+        <span class="nx-kbd">↵</span> select
+      </span>
+    </div>
+  </div>
+</div>
+</template>
+
+{* Seed palette by walking the rendered nav DOM — no Smarty-encoded JSON. *}
+{literal}
+<script>
+  (function () {
+    function bootPalette() {
+      if (!window.Alpine || !window.Alpine.store('palette')) return;
+      var seen = new Set();
+      var items = [];
+      function push(el, section) {
+        var href = el.getAttribute('href');
+        var title = (el.textContent || '').trim().replace(/\s+/g, ' ');
+        if (!href || !title || href === '#' || seen.has(href + '|' + title)) return;
+        seen.add(href + '|' + title);
+        items.push({ title: title, href: href, section: section });
+      }
+      document.querySelectorAll('header nav a[href]').forEach(function (a) { push(a, 'Navigation'); });
+      document.querySelectorAll('header .nx-dropdown__panel a[href]').forEach(function (a) { push(a, 'Menu'); });
+      window.Alpine.store('palette').register(items);
+    }
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', bootPalette);
+    else bootPalette();
+  })();
+</script>
+{/literal}

--- a/custom/templates/Nexus/components/icon.tpl
+++ b/custom/templates/Nexus/components/icon.tpl
@@ -1,0 +1,69 @@
+{*
+ *  Nexus · Inline SVG Icon
+ *  Usage: {include file='components/icon.tpl' name='search' size=18}
+ *  All paths are 24×24 stroke icons (Phosphor / Lucide style).
+ *  Set `class` to add Tailwind classes. Default stroke uses currentColor.
+*}
+{if !isset($size)}{assign var=size value=18}{/if}
+{if !isset($class)}{assign var=class value=""}{/if}
+{if !isset($strokeWidth)}{assign var=strokeWidth value=1.6}{/if}
+
+<svg xmlns="http://www.w3.org/2000/svg" width="{$size}" height="{$size}" viewBox="0 0 24 24" fill="none"
+     stroke="currentColor" stroke-width="{$strokeWidth}" stroke-linecap="round" stroke-linejoin="round"
+     class="nx-icon {$class}" aria-hidden="true" focusable="false">
+  {if $name eq 'search'}      <circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/>
+  {elseif $name eq 'menu'}    <path d="M4 6h16M4 12h16M4 18h16"/>
+  {elseif $name eq 'close'}   <path d="M6 6l12 12M18 6 6 18"/>
+  {elseif $name eq 'chevron-down'}  <path d="m6 9 6 6 6-6"/>
+  {elseif $name eq 'chevron-right'} <path d="m9 6 6 6-6 6"/>
+  {elseif $name eq 'chevron-left'}  <path d="m15 6-6 6 6 6"/>
+  {elseif $name eq 'arrow-right'}   <path d="M5 12h14M13 5l7 7-7 7"/>
+  {elseif $name eq 'arrow-left'}    <path d="M19 12H5M11 5l-7 7 7 7"/>
+  {elseif $name eq 'sun'}    <circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M5 5l1.5 1.5M17.5 17.5 19 19M2 12h2M20 12h2M5 19l1.5-1.5M17.5 6.5 19 5"/>
+  {elseif $name eq 'moon'}   <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z"/>
+  {elseif $name eq 'user'}   <circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 4-7 8-7s8 3 8 7"/>
+  {elseif $name eq 'users'}  <path d="M16 18v-1c0-2.2-1.8-4-4-4H8c-2.2 0-4 1.8-4 4v1"/><circle cx="10" cy="7" r="3"/><path d="M22 18v-1c0-1.9-1.3-3.5-3-3.9"/><path d="M17 5.1A3 3 0 0 1 17 11"/>
+  {elseif $name eq 'home'}   <path d="m3 11 9-7 9 7v9a1 1 0 0 1-1 1h-5v-7H10v7H5a1 1 0 0 1-1-1z"/>
+  {elseif $name eq 'forum'}  <path d="M21 14a2 2 0 0 1-2 2H7l-4 4V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+  {elseif $name eq 'bell'}   <path d="M6 8a6 6 0 0 1 12 0c0 7 3 8 3 8H3s3-1 3-8"/><path d="M10 21a2 2 0 0 0 4 0"/>
+  {elseif $name eq 'mail'}   <rect x="3" y="5" width="18" height="14" rx="2"/><path d="m3 7 9 6 9-6"/>
+  {elseif $name eq 'shield'} <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10"/>
+  {elseif $name eq 'settings'}<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 0 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 0 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 0 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 0 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 0 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h.1a1.7 1.7 0 0 0 1-1.5V3a2 2 0 0 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 0 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v.1a1.7 1.7 0 0 0 1.5 1H21a2 2 0 0 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/>
+  {elseif $name eq 'log-out'}<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="m16 17 5-5-5-5"/><path d="M21 12H9"/>
+  {elseif $name eq 'log-in'} <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><path d="m10 17 5-5-5-5"/><path d="M15 12H3"/>
+  {elseif $name eq 'plus'}   <path d="M12 5v14M5 12h14"/>
+  {elseif $name eq 'check'}  <path d="m5 12 5 5L20 7"/>
+  {elseif $name eq 'edit'}   <path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"/>
+  {elseif $name eq 'trash'}  <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M19 6 18 20a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+  {elseif $name eq 'pin'}    <path d="M12 17v5"/><path d="M9 11V5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v6l3 3v2H6v-2z"/>
+  {elseif $name eq 'lock'}   <rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/>
+  {elseif $name eq 'star'}   <path d="m12 3 2.7 6.1 6.6.6-5 4.5 1.5 6.5L12 17.3 6.2 20.7l1.5-6.5-5-4.5 6.6-.6z"/>
+  {elseif $name eq 'heart'}  <path d="M20.8 4.6a5.5 5.5 0 0 0-7.8 0L12 5.7l-1-1.1a5.5 5.5 0 1 0-7.8 7.8l1 1L12 21l7.8-7.6 1-1a5.5 5.5 0 0 0 0-7.8Z"/>
+  {elseif $name eq 'reply'}  <path d="M9 17 4 12l5-5"/><path d="M4 12h11a5 5 0 0 1 5 5v2"/>
+  {elseif $name eq 'globe'}  <circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 0 1 0 18M12 3a14 14 0 0 0 0 18"/>
+  {elseif $name eq 'discord'}<path d="M18.9 5.5A16 16 0 0 0 14.7 4l-.2.4a14 14 0 0 1 4 1.4 14 14 0 0 0-9 0 14 14 0 0 1 4-1.4L13.3 4a16 16 0 0 0-4.2 1.5C5.6 10 4.7 14.3 5.1 18.6a16 16 0 0 0 4.8 2.4l.4-.5a11 11 0 0 1-2-1c.2-.1.4-.3.6-.4a11 11 0 0 0 10.2 0c.2.1.4.3.6.4a11 11 0 0 1-2 1l.4.5a16 16 0 0 0 4.8-2.4c.5-5-.9-9.3-3.9-13.1ZM10.3 16c-.9 0-1.7-.8-1.7-1.9s.7-1.9 1.6-1.9c1 0 1.7.9 1.7 2s-.7 1.8-1.6 1.8Zm5.4 0c-.9 0-1.6-.8-1.6-1.9s.7-1.9 1.6-1.9 1.7.9 1.7 2-.7 1.8-1.7 1.8Z"/>
+  {elseif $name eq 'minecraft'}<rect x="4" y="4" width="16" height="16" rx="2"/><path d="M4 12h16M12 4v16"/>
+  {elseif $name eq 'github'} <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.9c0-1 .1-1.4-.5-2 3-.3 5.5-1.5 5.5-6a4.6 4.6 0 0 0-1.3-3.2 4.3 4.3 0 0 0-.1-3.2s-1.1-.3-3.5 1.3a12.3 12.3 0 0 0-6.2 0C7 2.3 5.9 2.6 5.9 2.6a4.3 4.3 0 0 0-.1 3.2A4.6 4.6 0 0 0 4.5 9c0 4.5 2.5 5.7 5.5 6-.6.6-.6 1.2-.5 2V21"/>
+  {elseif $name eq 'twitter'}<path d="M22 5.8c-.7.4-1.5.6-2.4.8a4.1 4.1 0 0 0 1.8-2.3 8.3 8.3 0 0 1-2.6 1A4.1 4.1 0 0 0 12 9.1c0 .3 0 .6.1.9A11.7 11.7 0 0 1 3.4 5a4.1 4.1 0 0 0 1.3 5.5 4 4 0 0 1-1.9-.5v.1a4.1 4.1 0 0 0 3.3 4 4.1 4.1 0 0 1-1.8.1 4.1 4.1 0 0 0 3.8 2.8A8.3 8.3 0 0 1 2 18.7a11.7 11.7 0 0 0 6.3 1.8c7.5 0 11.7-6.3 11.7-11.7v-.5A8.4 8.4 0 0 0 22 5.8Z"/>
+  {elseif $name eq 'youtube'}<path d="M22.5 7.2a3 3 0 0 0-2-2.2C18.6 4.5 12 4.5 12 4.5s-6.6 0-8.5.5a3 3 0 0 0-2 2.2A31.2 31.2 0 0 0 1 12a31.2 31.2 0 0 0 .5 4.8 3 3 0 0 0 2 2.2c1.9.5 8.5.5 8.5.5s6.6 0 8.5-.5a3 3 0 0 0 2-2.2A31.2 31.2 0 0 0 23 12a31.2 31.2 0 0 0-.5-4.8z"/><path d="M10 15V9l5 3z"/>
+  {elseif $name eq 'eye'}    <path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12Z"/><circle cx="12" cy="12" r="3"/>
+  {elseif $name eq 'eye-off'}<path d="M9.9 5a10.4 10.4 0 0 1 2.1-.2c6 0 10 7.2 10 7.2a18.4 18.4 0 0 1-2.2 3.2M6.7 6.7C3.3 9 2 12 2 12s4 7.2 10 7.2a10.4 10.4 0 0 0 4-.8M14.1 14.1a3 3 0 1 1-4.2-4.2M1 1l22 22"/>
+  {elseif $name eq 'filter'} <path d="M22 3H2l8 9.5V19l4 2v-8.5z"/>
+  {elseif $name eq 'sort'}   <path d="M7 4v16M3 8l4-4 4 4M17 20V4M21 16l-4 4-4-4"/>
+  {elseif $name eq 'grid'}   <rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/>
+  {elseif $name eq 'list'}   <path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/>
+  {elseif $name eq 'calendar'}<rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/>
+  {elseif $name eq 'clock'}  <circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/>
+  {elseif $name eq 'tag'}    <path d="M20.6 13.4 13.4 20.6a2 2 0 0 1-2.8 0L3 13V3h10l7.6 7.6a2 2 0 0 1 0 2.8Z"/><circle cx="7.5" cy="7.5" r="1"/>
+  {elseif $name eq 'external'}<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6M10 14 21 3"/>
+  {elseif $name eq 'arrow-up'}<path d="M12 19V5M5 12l7-7 7 7"/>
+  {elseif $name eq 'arrow-down'}<path d="M12 5v14M5 12l7 7 7-7"/>
+  {elseif $name eq 'info'}   <circle cx="12" cy="12" r="9"/><path d="M12 8v.01M11 12h1v4h1"/>
+  {elseif $name eq 'alert'}  <path d="M10.3 3.9 2.1 18a2 2 0 0 0 1.7 3h16.4a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z"/><path d="M12 9v4M12 17h.01"/>
+  {elseif $name eq 'sparkle'}<path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M5.6 18.4l2.1-2.1M16.3 7.7l2.1-2.1"/>
+  {elseif $name eq 'palette'}<circle cx="13.5" cy="6.5" r=".5"/><circle cx="17.5" cy="10.5" r=".5"/><circle cx="8.5" cy="7.5" r=".5"/><circle cx="6.5" cy="12.5" r=".5"/><path d="M12 2A10 10 0 1 0 22 12c0-1.1-.9-2-2-2h-2a2 2 0 0 1-2-2 2 2 0 0 0-2-2z"/>
+  {elseif $name eq 'server'} <rect x="2" y="3" width="20" height="6" rx="1"/><rect x="2" y="15" width="20" height="6" rx="1"/><path d="M6 6h.01M6 18h.01"/>
+  {elseif $name eq 'trophy'} <path d="M6 9H4a2 2 0 0 1-2-2V5a1 1 0 0 1 1-1h3M18 9h2a2 2 0 0 0 2-2V5a1 1 0 0 0-1-1h-3M4 22h16M10 14.7V19a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-4.3M18 2H6v9a6 6 0 1 0 12 0V2Z"/>
+  {else}<circle cx="12" cy="12" r="9"/>
+  {/if}
+</svg>

--- a/custom/templates/Nexus/components/toasts.tpl
+++ b/custom/templates/Nexus/components/toasts.tpl
@@ -1,0 +1,24 @@
+{*
+ *  Nexus · Toast container
+ *  Rendered once in footer.tpl. Items are pushed via Alpine.store('toast').
+*}
+<div class="nx-toast-container" x-data>
+  <template x-for="t in $store.toast.items" :key="t.id">
+    <div class="nx-toast animate-slide-up"
+         :class="{
+           'border-l-4 border-l-success': t.variant === 'success',
+           'border-l-4 border-l-danger':  t.variant === 'danger',
+           'border-l-4 border-l-warning': t.variant === 'warning',
+           'border-l-4 border-l-info':    t.variant === 'info',
+         }">
+      <div class="flex-1 min-w-0">
+        <div class="font-medium text-text-primary text-sm" x-show="t.title" x-text="t.title"></div>
+        <div class="text-text-secondary text-sm" x-show="t.body" x-text="t.body"></div>
+      </div>
+      <button class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm"
+              @click="$store.toast.dismiss(t.id)" aria-label="Dismiss">
+        {include file='components/icon.tpl' name='close' size=14}
+      </button>
+    </div>
+  </template>
+</div>

--- a/custom/templates/Nexus/cookies.tpl
+++ b/custom/templates/Nexus/cookies.tpl
@@ -1,0 +1,16 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-3xl mx-auto">
+  <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6">{$COOKIE_NOTICE_HEADER}</h1>
+
+  <div class="nx-surface p-6 sm:p-8">
+    <div class="prose prose-invert max-w-none forum_post">
+      {$COOKIE_NOTICE}
+    </div>
+    <hr class="my-6 border-border-subtle">
+    <button class="nx-btn nx-btn--primary" onclick="configureCookies()">{$UPDATE_SETTINGS}</button>
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/custom.tpl
+++ b/custom/templates/Nexus/custom.tpl
@@ -1,0 +1,24 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6">{$TITLE}</h1>
+
+<div class="grid gap-6
+            {if count($WIDGETS_LEFT) && count($WIDGETS_RIGHT)}lg:grid-cols-[18rem_minmax(0,1fr)_18rem]
+            {elseif count($WIDGETS_LEFT) || count($WIDGETS_RIGHT)}lg:grid-cols-[18rem_minmax(0,1fr)]
+            {else}grid-cols-1{/if}">
+
+  {if count($WIDGETS_LEFT)}
+    <aside class="space-y-4 order-2 lg:order-1">{foreach from=$WIDGETS_LEFT item=widget}{$widget}{/foreach}</aside>
+  {/if}
+
+  <main class="order-1 lg:order-2 min-w-0">
+    <div class="nx-surface p-6 sm:p-8 forum_post">{$CONTENT}</div>
+  </main>
+
+  {if count($WIDGETS_RIGHT)}
+    <aside class="space-y-4 order-3">{foreach from=$WIDGETS_RIGHT item=widget}{$widget}{/foreach}</aside>
+  {/if}
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/custom_basic.tpl
+++ b/custom/templates/Nexus/custom_basic.tpl
@@ -1,0 +1,5 @@
+{include file='header.tpl'}
+{$CONTENT}
+{foreach from=$TEMPLATE_JS item=script}{$script}{/foreach}
+</body>
+</html>

--- a/custom/templates/Nexus/docs/CHANGES.md
+++ b/custom/templates/Nexus/docs/CHANGES.md
@@ -1,0 +1,85 @@
+# Nexus · Change Summary (Iteration 1)
+
+This document summarises every file added or touched. The base NamelessMC code, all modules, the `core/` tree, and the `DefaultRevamp` theme are **untouched**.
+
+## Created files (all under `custom/templates/Nexus/`)
+
+### Theme bootstrap & build
+- `template.php` — registers `Nexus_Template extends SmartyTemplateBase`, includes jQuery, jQuery-Cookie, Font-Awesome from `AssetTree`, loads our compiled CSS+JS, exposes all the JS variables `DefaultRevamp` consumers expect.
+- `package.json` — devDeps: tailwindcss, @tailwindcss/forms, @tailwindcss/typography, postcss, autoprefixer, alpinejs, esbuild, npm-run-all.
+- `tailwind.config.js` — token-aware (reads CSS variables), JIT, custom `nx-*` colors/shadows/radius, custom animations (`fade-in`, `scale-in`, `slide-up`, `shimmer`, `pulse-glow`), `3xl` breakpoint.
+- `postcss.config.js`
+- `.gitignore` — excludes `node_modules/`, `assets/css/*.css`, `assets/js/*.js`.
+
+### Design system (source)
+- `src/styles/tokens.css` — all colors, radius, spacing, shadow, type, motion as CSS custom properties. Dark + light variants.
+- `src/styles/base.css` — element resets, headings, focus ring, scrollbars, code, kbd, hr.
+- `src/styles/components.css` — `.nx-container`, `.nx-surface`, `.nx-card`, `.nx-btn` (+ variants), `.nx-input` / `.nx-textarea` / `.nx-select`, `.nx-checkbox` / `.nx-radio`, `.nx-badge`, `.nx-avatar`, `.nx-alert`, `.nx-modal-*`, `.nx-dropdown`, `.nx-tabs`, `.nx-skeleton`, `.nx-tooltip`, `.nx-pagination`, `.nx-table`, `.nx-toast*`, `.nx-kbd`, `.nx-spinner`, `.nx-divider`.
+- `src/styles/overrides.css` — legacy Fomantic compatibility: `.ui.segment`, `.ui.message`, `.ui.button`, `.ui.form`, `.ui.header`, `.ui.divider`, `.ui.label`, `.ui.card`, `.ui.grid` (CSS-grid bridge), `.ui.container`, `.ui.list`, `.ui.modal`, `.forum_post`, `.ui.inverted.vertical.footer.segment`, `table.dataTable*`, `.select2-container`.
+- `src/styles/main.css` — entry that imports tokens, runs `@tailwind base/components/utilities`, then imports base, components, overrides.
+
+### Client JS
+- `src/scripts/main.js` — Alpine bootstrap, theme/toast/modal/mobileNav/palette stores, fuzzy-search palette, `x-tooltip` + `x-clipboard` directives, Cmd-K + Escape shortcuts, loading-time injector, IE-warning auto-hide, nav-key active marker.
+
+### Smarty partials
+- `components/icon.tpl` — inline SVG sprite, ~50 named icons (search, menu, close, user, forum, bell, mail, shield, settings, sun, moon, plus, edit, trash, pin, lock, star, heart, reply, globe, discord, minecraft, github, twitter, youtube, eye, filter, sort, grid, list, calendar, clock, tag, external, arrow-*, info, alert, sparkle, palette, server, trophy, etc.).
+- `components/command_palette.tpl` — Strg-K/Cmd-K palette, seeded from `$NAV_LINKS`, fuzzy filter, kbd hints.
+- `components/toasts.tpl` — Alpine-store-driven toast container.
+
+### Layout
+- `header.tpl` — `<head>`, meta, OG/Twitter cards, pre-paint theme script, font preconnect, asset includes, skip-link.
+- `navbar.tpl` — sticky glassmorphic top bar, primary nav (desktop), off-canvas drawer (mobile), Cmd-K trigger, theme toggle, user/account dropdowns, optional MC-server hero, IE/update/announcement/maintenance/widget-top region.
+- `footer.tpl` — site footer (3 cols), social links, auto-language toggle, legacy global-warning modal, toast + palette includes, `$TEMPLATE_JS` injection, dark/light Ajax bridge.
+
+### Public pages
+- `index.tpl` — News-card feed or custom-home, widgets-left/right.
+- `portal.tpl` — placeholder mirroring DefaultRevamp.
+- `profile.tpl` — banner, avatar, groups, tabs (feed/about/custom), wall posts with reactions, replies, edit/delete modals, banner-change modal, block modal.
+- `leaderboards.tpl` — Podium-style ranking with sidebar tab nav.
+- `login.tpl` — split layout, OAuth providers, captcha hook, register CTA.
+- `register.tpl` — dynamic field renderer (text/textarea/date/password/select/number/email/radio/checkbox), OAuth flow support, captcha, t&c, email-verify hook.
+- `forgot_password.tpl`, `change_password.tpl`, `complete_signup.tpl`, `tfa.tpl`, `authme.tpl`, `authme_email.tpl`, `registration_disabled.tpl`, `user_not_exist.tpl` — all with consistent auth styling.
+- `404.tpl`, `403.tpl`, `maintenance.tpl` — gradient text errors, action buttons.
+- `cookies.tpl`, `terms.tpl`, `privacy.tpl` — surface card + prose styling.
+- `custom.tpl` — wrapper for arbitrary custom content with widgets-left/right.
+- `custom_basic.tpl` — bare-bones wrapper.
+- `status.tpl` — server cards grid with copyable IP badges.
+- `reactions_modal.tpl` — emoji-tabbed reaction details modal body.
+- `user_popover.tpl` — hover card with avatar/groups/stats.
+
+### User CP subpages
+- `user/navigation.tpl` — Nexus-styled vertical nav.
+- `user/index.tpl` — overview with detail list + optional chart canvas.
+- `user/settings.tpl` — full settings form (profile, email, password, 2FA, avatar) split into surface cards.
+- `user/{alert,alerts,connections,messaging,new_message,notification_settings,oauth,placeholders,sessions,tfa,view_message}.tpl` — initial baseline copied from `DefaultRevamp`; the override layer in `overrides.css` already styles them consistently. Targeted polish lives in I2.
+
+### Forum
+- `forum/forum_index.tpl` — category cards, per-subforum row with last-post avatar, search input.
+- `forum/view_forum.tpl` — sticky discussion section, topic list, subforums list, new-topic CTA.
+- `forum/_topic_row.tpl` — reusable topic-row partial.
+- `forum/view_topic.tpl` — Reddit-style post stream with author sidebar, reactions, mod actions dropdown, share dropdown, quick-reply box, legacy report/delete/spam modals.
+- `forum/new_topic.tpl`, `forum/forum_edit_post.tpl` — TinyMCE-host textarea + label chips.
+- `forum/search.tpl`, `forum/search_results.tpl` — single-card search; result list with read-full CTA.
+- `forum/following_topics.tpl` — user-cp following list with unfollow controls.
+- `forum/merge.tpl`, `forum/move.tpl` — single-form moderator actions.
+- `forum/view_forum_no_discussions.tpl` — empty-state with CTA.
+- `forum/view_forum_confirm_redirect.tpl` — redirect confirmation card.
+- `forum/profile_tab.tpl` — recent forum posts for the profile.
+
+### Members
+- `members/members.tpl` — list nav, fuzzy search, group filter, new-members avatar grid, dynamic list renderer (renderList JS rewired to Nexus DOM).
+
+### Widgets
+- `widgets/online_staff.tpl` · `widgets/online_users.tpl` · `widgets/server_status.tpl` · `widgets/statistics.tpl` · `widgets/minecraft_account.tpl` · `widgets/profile_posts.tpl` · `widgets/reactions.tpl` · `widgets/cookie_notice.tpl` · `widgets/widget_error.tpl`
+- `widgets/forum/latest_posts.tpl`
+
+### Docs
+- `README.md` — install, build, activate, customize, smoke-test, troubleshooting.
+- `docs/CHANGES.md` — this file.
+
+## Files NOT touched
+- `core/**` (NamelessMC core)
+- `modules/**` (all modules)
+- `custom/templates/DefaultRevamp/**` (untouched, still usable)
+- `custom/panel_templates/**` (admin panel — Iteration 2)
+- DB schema, controllers, language files

--- a/custom/templates/Nexus/footer.tpl
+++ b/custom/templates/Nexus/footer.tpl
@@ -1,0 +1,145 @@
+{*
+ *  Nexus · Document footer
+ *  Closes <main>, renders footer-widgets and the site footer, then injects $TEMPLATE_JS.
+ *  Preserves $WIDGETS_FOOTER, $FOOTER_NAVIGATION, $SOCIAL_MEDIA_ICONS, $TERMS_*, $PRIVACY_*,
+ *  $DARK_LIGHT_MODE_ACTION/$DARK_LIGHT_MODE_TOKEN, $AUTO_LANGUAGE_*, $GLOBAL_WARNING_* contracts.
+*}
+  {if count($WIDGETS_FOOTER)}
+    <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-6">
+      {foreach from=$WIDGETS_FOOTER item=widget}{$widget}{/foreach}
+    </div>
+  {/if}
+</main>
+
+<footer class="mt-12 border-t border-border-subtle bg-bg-inset">
+  <div class="nx-container py-10 grid gap-8 md:grid-cols-3">
+    <div>
+      <div class="flex items-center gap-2 font-display font-semibold text-text-primary text-base mb-3">
+        <span class="inline-flex items-center justify-center w-7 h-7 rounded-md bg-gradient-to-br from-accent to-accent-hover text-white">
+          {include file='components/icon.tpl' name='sparkle' size=14}
+        </span>
+        {$smarty.const.SITE_NAME}
+      </div>
+      <p class="text-text-muted text-sm leading-relaxed">
+        &copy; {$smarty.const.SITE_NAME} {'Y'|date}<br>
+        Powered by <a href="https://namelessmc.com" class="text-text-secondary hover:text-text-primary">NamelessMC</a>
+      </p>
+      {if $PAGE_LOAD_TIME}
+        <p class="text-text-muted text-xs mt-3" id="page_load"></p>
+      {/if}
+    </div>
+
+    <div>
+      <h4 class="text-xs uppercase tracking-wider font-semibold text-text-muted mb-3">{$FOOTER_LINKS_TITLE}</h4>
+      <ul class="space-y-1.5 text-sm">
+        {foreach from=$FOOTER_NAVIGATION key=name item=item}
+          {if isset($item.items)}
+            <li x-data="{ open: false }">
+              <button class="flex items-center gap-1.5 text-text-secondary hover:text-text-primary transition"
+                      @click="open = !open" :aria-expanded="open">
+                <span class="opacity-80">{$item.icon}</span>{$item.title}
+                {include file='components/icon.tpl' name='chevron-down' size=12}
+              </button>
+              <ul x-show="open" x-cloak x-transition class="pl-3 mt-1 space-y-1.5 border-l border-border-subtle">
+                {foreach from=$item.items item=dropdown}
+                  <li><a href="{$dropdown.link}" target="{$dropdown.target}"
+                         class="text-text-muted hover:text-text-primary transition">
+                    <span class="opacity-80">{$dropdown.icon}</span> {$dropdown.title}
+                  </a></li>
+                {/foreach}
+              </ul>
+            </li>
+          {else}
+            <li><a href="{$item.link}" target="{$item.target}"
+                   class="text-text-secondary hover:text-text-primary transition flex items-center gap-1.5">
+              <span class="opacity-80">{$item.icon}</span>{$item.title}
+            </a></li>
+          {/if}
+        {/foreach}
+        <li><a href="{$TERMS_LINK}" class="text-text-secondary hover:text-text-primary transition">{$TERMS_TEXT}</a></li>
+        <li><a href="{$PRIVACY_LINK}" class="text-text-secondary hover:text-text-primary transition">{$PRIVACY_TEXT}</a></li>
+      </ul>
+    </div>
+
+    <div>
+      {if $SOCIAL_MEDIA_ICONS|count > 0}
+        <h4 class="text-xs uppercase tracking-wider font-semibold text-text-muted mb-3">{$FOOTER_SOCIAL_TITLE}</h4>
+        <ul class="flex flex-wrap gap-2">
+          {foreach from=$SOCIAL_MEDIA_ICONS item=icon}
+            <li>
+              <a href="{$icon.link}" target="_blank" rel="noopener"
+                 class="nx-btn nx-btn--outline nx-btn--sm">
+                {$icon.text}
+              </a>
+            </li>
+          {/foreach}
+        </ul>
+      {/if}
+
+      <div class="mt-6 flex items-center gap-2 text-xs text-text-muted">
+        {if isset($AUTO_LANGUAGE)}
+          <a class="hover:text-text-primary cursor-pointer" onclick="toggleAutoLanguage()" id="auto-language"></a>
+        {/if}
+      </div>
+    </div>
+  </div>
+</footer>
+
+{* === Legacy global warning modal === *}
+{if isset($GLOBAL_WARNING_TITLE)}
+<div class="ui medium modal" id="modal-acknowledge">
+  <div class="header">{$GLOBAL_WARNING_TITLE}</div>
+  <div class="content">{$GLOBAL_WARNING_REASON}</div>
+  <div class="actions">
+    <a class="ui positive button" href="{$GLOBAL_WARNING_ACKNOWLEDGE_LINK}">{$GLOBAL_WARNING_ACKNOWLEDGE}</a>
+  </div>
+</div>
+{/if}
+
+{* === Toast container === *}
+{include file='components/toasts.tpl'}
+
+{* === Command palette === *}
+{include file='components/command_palette.tpl'}
+
+{* === Module/template JS === *}
+{foreach from=$TEMPLATE_JS item=script}{$script}{/foreach}
+
+{if isset($GLOBAL_WARNING_TITLE)}
+<script>$('#modal-acknowledge').modal({ closable: false }).modal('show');</script>
+{/if}
+
+<script>
+  // Dark/light toggle bridges into the legacy server-side preference if available.
+  // The header-inline script already applied the preferred theme pre-paint.
+  {if isset($DARK_LIGHT_MODE_ACTION) && isset($DARK_LIGHT_MODE_TOKEN)}
+    function toggleDarkLightMode() {
+      $.post("{$DARK_LIGHT_MODE_ACTION}", { token: "{$DARK_LIGHT_MODE_TOKEN}" })
+        .done(function () { window.location.reload(); });
+      return false;
+    }
+  {/if}
+
+  {if isset($AUTO_LANGUAGE)}
+    const autoLanguage = document.getElementById('auto-language');
+    const autoLanguageValue = $.cookie('auto_language') ?? 'true';
+    autoLanguage.innerText = '{$AUTO_LANGUAGE_TEXT} (' + (autoLanguageValue === 'true' ? '{$ENABLED}' : '{$DISABLED}') + ')';
+    {if isset($AUTO_LANGUAGE_VALUE)}
+      if (autoLanguageValue) autoLanguage.title = '{$AUTO_LANGUAGE_VALUE}';
+    {/if}
+    function toggleAutoLanguage() {
+      $.cookie('auto_language', autoLanguageValue === 'true' ? 'false' : 'true', { path: '/' });
+      window.location.reload();
+    }
+  {/if}
+</script>
+
+{if isset($NEW_UPDATE) && ($NEW_UPDATE_URGENT != true)}
+  <script src="{$TEMPLATE.path}/js/core/update.js"></script>
+{/if}
+
+{if !isset($EXCLUDE_END_BODY)}
+  {if isset($DEBUGBAR_HTML)}{$DEBUGBAR_HTML}{/if}
+</body>
+</html>
+{/if}

--- a/custom/templates/Nexus/forgot_password.tpl
+++ b/custom/templates/Nexus/forgot_password.tpl
@@ -1,0 +1,34 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-md mx-auto">
+  <header class="mb-6">
+    <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight">{$FORGOT_PASSWORD}</h1>
+    <p class="text-text-secondary mt-2 text-sm">{$FORGOT_PASSWORD_INSTRUCTIONS}</p>
+  </header>
+
+  {if isset($ERROR)}
+    <div class="nx-alert nx-alert--danger mb-5">
+      {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+      <div><div class="nx-alert__title">{$ERROR_TITLE}</div><div class="nx-alert__body">{$ERROR}</div></div>
+    </div>
+  {else if isset($SUCCESS)}
+    <div class="nx-alert nx-alert--success mb-5">
+      {include file='components/icon.tpl' name='check' size=18 class="nx-alert__icon"}
+      <div><div class="nx-alert__title">{$SUCCESS_TITLE}</div><div class="nx-alert__body">{$SUCCESS}</div></div>
+    </div>
+  {/if}
+
+  <div class="nx-surface p-6 sm:p-8">
+    <form class="space-y-4" action="" method="post" id="form-forgot-password">
+      <div class="nx-field">
+        <label class="nx-label" for="inputEmail">{$EMAIL_ADDRESS}</label>
+        <input type="email" id="inputEmail" name="email" placeholder="{$EMAIL_ADDRESS}" tabindex="1" class="nx-input" autocomplete="email" />
+      </div>
+      <input type="hidden" name="token" value="{$TOKEN}">
+      <button type="submit" class="nx-btn nx-btn--primary nx-btn--block" tabindex="2">{$SUBMIT}</button>
+    </form>
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/forum/_topic_row.tpl
+++ b/custom/templates/Nexus/forum/_topic_row.tpl
@@ -1,0 +1,29 @@
+{*  Nexus · Topic-row partial shared by view_forum, sticky lists, etc. *}
+<li class="flex items-center gap-4 px-5 py-4 hover:bg-bg-elevated transition">
+  <span class="hidden sm:inline-flex w-9 h-9 rounded-lg bg-bg-elevated text-text-muted items-center justify-center flex-shrink-0">
+    {include file='components/icon.tpl' name='forum' size=14}
+  </span>
+  <div class="flex-1 min-w-0">
+    <div class="flex flex-wrap items-center gap-2 mb-1">
+      {if isset($discussion.labels) && count($discussion.labels)}
+        {foreach from=$discussion.labels item=label}{$label}{/foreach}
+      {/if}
+      <a href="{$discussion.link}" class="font-semibold text-text-primary hover:text-accent transition truncate">{$discussion.topic_title}</a>
+    </div>
+    <div class="text-xs text-text-muted">
+      <a href="{$discussion.author_link}" data-poload="{$USER_INFO_URL}{$discussion.topic_created_user_id}" style="{$discussion.topic_created_style}" class="hover:text-text-primary">{$discussion.topic_created_username}</a>
+      · <span title="{$discussion.topic_created}">{$discussion.topic_created_rough}</span>
+    </div>
+  </div>
+  <div class="hidden md:flex flex-col items-end text-xs text-text-muted min-w-[6rem]">
+    <span>{$VIEWS|capitalize}: <span class="text-text-primary font-medium">{$discussion.views}</span></span>
+    <span>{$POSTS|capitalize}: <span class="text-text-primary font-medium">{$discussion.posts}</span></span>
+  </div>
+  <div class="hidden md:flex items-center gap-3 min-w-[12rem] flex-shrink-0">
+    <span class="nx-avatar nx-avatar--sm"><img src="{$discussion.last_reply_avatar}" loading="lazy" alt="" /></span>
+    <div class="min-w-0 flex-1">
+      <a href="{$discussion.last_reply_link}" data-poload="{$USER_INFO_URL}{$discussion.last_reply_user_id}" style="{$discussion.last_reply_style}" class="block text-sm text-text-primary hover:text-accent truncate">{$discussion.last_reply_username}</a>
+      <div class="text-xs text-text-muted" title="{$discussion.last_reply}">{$discussion.last_reply_rough}</div>
+    </div>
+  </div>
+</li>

--- a/custom/templates/Nexus/forum/following_topics.tpl
+++ b/custom/templates/Nexus/forum/following_topics.tpl
@@ -1,0 +1,82 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6">{$USER_CP}</h1>
+
+<div class="grid lg:grid-cols-[18rem_minmax(0,1fr)] gap-6" id="alerts">
+  <aside>{include file='user/navigation.tpl'}</aside>
+
+  <main class="min-w-0">
+    <section class="nx-surface overflow-hidden">
+      <header class="nx-card__header flex items-center justify-between">
+        <h2 class="nx-card__title">{$FOLLOWING_TOPICS}</h2>
+        {if count($TOPICS_LIST)}
+          <a class="nx-btn nx-btn--outline nx-btn--sm" href="#" data-toggle="modal" data-target="#modal-delete">
+            {include file='components/icon.tpl' name='trash' size=14}{$UNFOLLOW_ALL}
+          </a>
+        {/if}
+      </header>
+
+      {if isset($SUCCESS_MESSAGE)}
+        <div class="px-5 pt-4">
+          <div class="nx-alert nx-alert--success">
+            {include file='components/icon.tpl' name='check' size=18 class="nx-alert__icon"}
+            <div><div class="nx-alert__title">{$SUCCESS}</div><div class="nx-alert__body">{$SUCCESS_MESSAGE}</div></div>
+          </div>
+        </div>
+      {/if}
+
+      {nocache}
+      {if count($TOPICS_LIST)}
+        <ul class="divide-y divide-border-subtle">
+          {foreach from=$TOPICS_LIST item=topic}
+            <li class="flex items-center gap-3 px-5 py-4 hover:bg-bg-elevated transition cursor-pointer"
+                onclick="window.location.href = '{$topic.last_post_link}'">
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2">
+                  {if $topic.unread}{include file='components/icon.tpl' name='bell' size=14 class="text-accent"}{/if}
+                  <span class="font-medium text-text-primary {if $topic.unread}font-bold{/if} truncate">{$topic.topic_title}</span>
+                </div>
+              </div>
+              <div class="hidden sm:flex items-center gap-2 min-w-0">
+                <span class="nx-avatar nx-avatar--sm"><img src="{$topic.reply_author_avatar}" loading="lazy" alt="" /></span>
+                <div class="min-w-0">
+                  <a href="{$topic.reply_author_link}" data-poload="{$USER_INFO_URL}{$topic.reply_author_id}" style="{$topic.reply_author_style}" onclick="event.stopPropagation()" class="text-sm text-text-primary hover:text-accent truncate block">{$topic.reply_author_nickname}</a>
+                  <div class="text-xs text-text-muted" title="{$topic.reply_date_full}">{$topic.reply_date}</div>
+                </div>
+              </div>
+              <form action="{$topic.unfollow_link}" method="post" onclick="event.stopPropagation()" class="flex-shrink-0">
+                <input type="hidden" value="{$TOKEN}" name="token" />
+                <button class="nx-btn nx-btn--danger nx-btn--sm">{$UNFOLLOW_TOPIC}</button>
+              </form>
+            </li>
+          {/foreach}
+        </ul>
+        <div class="p-4 border-t border-border-subtle">{$PAGINATION}</div>
+      {else}
+        <div class="p-6">
+          <div class="nx-alert nx-alert--info">
+            {include file='components/icon.tpl' name='info' size=18 class="nx-alert__icon"}
+            <div class="nx-alert__body">{$NO_TOPICS}</div>
+          </div>
+        </div>
+      {/if}
+      {/nocache}
+    </section>
+  </main>
+</div>
+
+<div class="ui small modal" id="modal-delete">
+  <div class="header">{$UNFOLLOW_ALL}</div>
+  <div class="content">{$CONFIRM_UNFOLLOW}</div>
+  <div class="actions">
+    <a class="ui negative button">{$NO}</a>
+    <form action="" method="post" class="inline">
+      <input type="hidden" name="token" value="{$TOKEN}">
+      <input type="hidden" name="action" value="purge">
+      <button type="submit" class="ui positive button">{$YES}</button>
+    </form>
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/forum/forum_edit_post.tpl
+++ b/custom/templates/Nexus/forum/forum_edit_post.tpl
@@ -1,0 +1,49 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6">{$EDITING_POST}</h1>
+
+{if isset($ERRORS)}
+  <div class="nx-alert nx-alert--danger mb-4">
+    {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+    <div class="flex-1">
+      <div class="nx-alert__title">{$ERROR_TITLE}</div>
+      <ul class="nx-alert__body list-disc pl-4">{foreach from=$ERRORS item=error}<li>{$error}</li>{/foreach}</ul>
+    </div>
+  </div>
+{/if}
+
+<div class="nx-surface p-6 sm:p-8" id="post-edit">
+  <form class="space-y-4" action="" method="post" id="form-post-edit">
+    {if isset($EDITING_TOPIC)}
+      <div class="nx-field">
+        <label class="nx-label" for="title">{$TOPIC_TITLE}</label>
+        <input type="text" id="title" name="title" value="{$TOPIC_TITLE_VALUE}" class="nx-input" />
+      </div>
+      {if count($LABELS)}
+        <div class="nx-field">
+          <span class="nx-label">Labels</span>
+          <div class="flex flex-wrap gap-2 labels">
+            {foreach from=$LABELS item=label}
+              <label class="cursor-pointer">
+                <input type="checkbox" name="topic_label[]" id="{$label.id}" value="{$label.id}" {if $label.active}checked{/if} hidden class="peer">
+                <span class="nx-badge peer-checked:bg-accent peer-checked:text-accent-fg peer-checked:border-accent transition">{$label.html}</span>
+              </label>
+            {/foreach}
+          </div>
+        </div>
+      {/if}
+    {/if}
+    <div class="nx-field">
+      <label class="nx-label" for="editor">{$CONTENT_LABEL}</label>
+      <textarea name="content" id="editor" class="nx-textarea min-h-[300px]"></textarea>
+    </div>
+    <input type="hidden" name="token" value="{$TOKEN}">
+    <div class="flex flex-wrap gap-2">
+      <button type="submit" class="nx-btn nx-btn--primary">{$SUBMIT}</button>
+      <a class="nx-btn nx-btn--outline" href="{$CANCEL_LINK}" onclick="return confirm('{$CONFIRM_CANCEL}')">{$CANCEL}</a>
+    </div>
+  </form>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/forum/forum_index.tpl
+++ b/custom/templates/Nexus/forum/forum_index.tpl
@@ -1,0 +1,114 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<nav class="text-sm text-text-muted mb-4" aria-label="Breadcrumb">
+  <a class="text-text-secondary hover:text-text-primary transition" href="{$BREADCRUMB_URL}">{$BREADCRUMB_TEXT}</a>
+</nav>
+
+<div class="flex flex-col sm:flex-row items-start sm:items-end gap-4 mb-6">
+  <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight flex-1">{$TITLE}</h1>
+  <form method="post" action="{$SEARCH_URL}" name="searchForm" class="w-full sm:w-80">
+    <input type="hidden" name="token" value="{$TOKEN}">
+    <div class="nx-input-group">
+      <span class="nx-input-group__icon">{include file='components/icon.tpl' name='search' size=14}</span>
+      <input type="text" name="forum_search" placeholder="{$SEARCH}" minlength="3" maxlength="128" class="nx-input" />
+    </div>
+  </form>
+</div>
+
+<div class="grid gap-6
+            {if count($WIDGETS_LEFT) && count($WIDGETS_RIGHT)}lg:grid-cols-[16rem_minmax(0,1fr)_16rem]
+            {elseif count($WIDGETS_LEFT) || count($WIDGETS_RIGHT)}lg:grid-cols-[16rem_minmax(0,1fr)]
+            {else}grid-cols-1{/if}">
+
+  {if count($WIDGETS_LEFT)}
+    <aside class="space-y-4 order-2 lg:order-1">{foreach from=$WIDGETS_LEFT item=widget}{$widget}{/foreach}</aside>
+  {/if}
+
+  <main class="order-1 lg:order-2 min-w-0">
+    {if isset($SPAM_INFO)}
+      <div class="nx-alert nx-alert--warning mb-4">
+        {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+        <div><div class="nx-alert__title">{$FORUM_SPAM_WARNING_TITLE}</div><div class="nx-alert__body">{$SPAM_INFO}</div></div>
+      </div>
+    {/if}
+
+    <div class="space-y-6">
+    {foreach from=$FORUMS key=category item=forum}
+      {if !empty($forum.subforums)}
+        <section class="nx-surface overflow-hidden">
+          <header class="nx-card__header flex items-center justify-between gap-3">
+            <h2 class="font-display font-semibold text-text-primary">
+              <a href="{$forum.link}" class="hover:text-accent transition">{$forum.title}</a>
+            </h2>
+          </header>
+          <ul class="divide-y divide-border-subtle">
+            {foreach from=$forum.subforums item=subforum}
+              {if $subforum->redirect_forum neq 1}
+                <li class="flex items-center gap-4 px-5 py-4 hover:bg-bg-elevated transition">
+                  <span class="hidden sm:inline-flex w-10 h-10 rounded-lg bg-accent-subtle text-accent items-center justify-center flex-shrink-0">
+                    {if empty($subforum->icon)}{include file='components/icon.tpl' name='forum' size=18}{else}{$subforum->icon}{/if}
+                  </span>
+                  <div class="flex-1 min-w-0">
+                    <a href="{$subforum->link}" class="block font-semibold text-text-primary hover:text-accent transition truncate">{$subforum->forum_title}</a>
+                    <div class="text-xs text-text-muted mt-0.5 truncate">
+                      {if !empty($subforum->forum_description)}{$subforum->forum_description}{/if}
+                    </div>
+                    <div class="flex flex-wrap gap-x-3 gap-y-1 text-xs text-text-muted mt-1">
+                      <span>{$TOPICS|capitalize}: <span class="text-text-primary font-medium">{$subforum->topics}</span></span>
+                      <span>{$POSTS|capitalize}: <span class="text-text-primary font-medium">{$subforum->posts}</span></span>
+                      {if isset($subforum->subforums)}
+                        <span class="text-text-muted">·
+                          {foreach from=$subforum->subforums item=ss name=ss}
+                            <a href="{$ss->link}" class="text-text-secondary hover:text-text-primary">{$ss->title}</a>{if !$smarty.foreach.ss.last}, {/if}
+                          {/foreach}
+                        </span>
+                      {/if}
+                    </div>
+                  </div>
+                  <div class="hidden md:flex items-center gap-3 min-w-[14rem] flex-shrink-0">
+                    {if isset($subforum->last_post)}
+                      <span class="nx-avatar nx-avatar--sm"><img src="{$subforum->last_post->avatar}" alt="{$subforum->last_post->username}" loading="lazy" /></span>
+                      <div class="min-w-0 flex-1">
+                        <a href="{$subforum->last_post->link}" class="block text-sm text-text-primary hover:text-accent truncate">{$subforum->last_post->title}</a>
+                        <div class="text-xs text-text-muted">
+                          <a href="{$subforum->last_post->profile}" style="{$subforum->last_post->user_style}" data-poload="{$USER_INFO_URL}{$subforum->last_post->post_creator}" class="hover:text-text-primary">{$subforum->last_post->username}</a>
+                          · <span title="{$subforum->last_post->post_date}">{$subforum->last_post->date_friendly}</span>
+                        </div>
+                      </div>
+                    {else}
+                      <span class="text-xs text-text-muted">{$NO_TOPICS}</span>
+                    {/if}
+                  </div>
+                </li>
+              {else}
+                <li class="flex items-center gap-4 px-5 py-4 hover:bg-bg-elevated transition">
+                  <span class="text-accent flex-shrink-0">
+                    {if empty($subforum->icon)}{include file='components/icon.tpl' name='external' size=18}{else}{$subforum->icon}{/if}
+                  </span>
+                  <a class="font-semibold text-text-primary hover:text-accent transition"
+                     {if isset($subforum->redirect_confirm)}href="#" data-toggle="modal" data-target="#modal-redirect-{$subforum->id}"
+                     {else}href="{$subforum->redirect_url}"{/if}>{$subforum->forum_title}</a>
+                </li>
+                <div class="ui mini modal" id="modal-redirect-{$subforum->id}">
+                  <div class="content">{$subforum->redirect_confirm}</div>
+                  <div class="actions">
+                    <a class="ui negative button">{$NO}</a>
+                    <a class="ui positive button" href="{$subforum->redirect_url}" target="_blank" rel="noopener nofollow">{$YES}</a>
+                  </div>
+                </div>
+              {/if}
+            {/foreach}
+          </ul>
+        </section>
+      {/if}
+    {/foreach}
+    </div>
+  </main>
+
+  {if count($WIDGETS_RIGHT)}
+    <aside class="space-y-4 order-3">{foreach from=$WIDGETS_RIGHT item=widget}{$widget}{/foreach}</aside>
+  {/if}
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/forum/merge.tpl
+++ b/custom/templates/Nexus/forum/merge.tpl
@@ -1,0 +1,23 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-xl mx-auto">
+  <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6">{$MERGE_TOPICS}</h1>
+  <div class="nx-surface p-6 sm:p-8" id="merge-topic">
+    <form class="space-y-4" action="" method="post" id="form-merge-topic">
+      <div class="nx-field">
+        <label class="nx-label" for="InputTopic">{$MERGE_INSTRUCTIONS}</label>
+        <select name="merge" id="InputTopic" class="nx-select">
+          {foreach from=$TOPICS item=topic}<option value="{$topic->id}">{$topic->topic_title|escape}</option>{/foreach}
+        </select>
+      </div>
+      <input type="hidden" name="token" value="{$TOKEN}">
+      <div class="flex flex-wrap gap-2">
+        <button type="submit" class="nx-btn nx-btn--primary">{$SUBMIT}</button>
+        <a class="nx-btn nx-btn--outline" href="{$CANCEL_LINK}" onclick="return confirm('{$CONFIRM_CANCEL}')">{$CANCEL}</a>
+      </div>
+    </form>
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/forum/move.tpl
+++ b/custom/templates/Nexus/forum/move.tpl
@@ -1,0 +1,30 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-xl mx-auto">
+  <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6">{$MOVE_TOPIC}</h1>
+  <div class="nx-surface p-6 sm:p-8" id="move-topic">
+    <form class="space-y-4" action="" method="post" id="form-move-topic">
+      <div class="nx-field">
+        <label class="nx-label" for="InputForum">{$MOVE_TO}</label>
+        <select name="forum" id="InputForum" class="nx-select">
+          <option value="">{$MOVE_TO}</option>
+          {foreach from=$FORUMS item=forum}
+            {if $forum->category}
+              <optgroup label="{$forum->forum_title}"></optgroup>
+            {else}
+              <option value="{$forum->id}">{$forum->forum_title}</option>
+            {/if}
+          {/foreach}
+        </select>
+      </div>
+      <input type="hidden" name="token" value="{$TOKEN}">
+      <div class="flex flex-wrap gap-2">
+        <button type="submit" class="nx-btn nx-btn--primary">{$SUBMIT}</button>
+        <a class="nx-btn nx-btn--outline" href="{$CANCEL_LINK}" onclick="return confirm('{$CONFIRM_CANCEL}')">{$CANCEL}</a>
+      </div>
+    </form>
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/forum/new_topic.tpl
+++ b/custom/templates/Nexus/forum/new_topic.tpl
@@ -1,0 +1,60 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6">{$CREATING_TOPIC_IN}</h1>
+
+{if isset($ERROR)}
+  <div class="nx-alert nx-alert--danger mb-4">
+    {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+    <div class="flex-1">
+      <div class="nx-alert__title">Error</div>
+      <ul class="nx-alert__body list-disc pl-4">{foreach from=$ERROR item=error}<li>{$error}</li>{/foreach}</ul>
+    </div>
+  </div>
+{/if}
+
+<div class="nx-surface p-6 sm:p-8" id="new-topic">
+  <form class="space-y-4" action="" method="post" id="form-new-topic">
+    <div class="nx-field">
+      <label class="nx-label" for="title">{$TOPIC_TITLE}</label>
+      <input type="text" id="title" name="title" placeholder="{$TOPIC_TITLE}" maxlength="64" value="{$TOPIC_VALUE}" class="nx-input" />
+    </div>
+
+    {if count($LABELS)}
+      <div class="nx-field">
+        <span class="nx-label">Labels</span>
+        <div class="flex flex-wrap gap-2 labels">
+          {foreach from=$LABELS item=label}
+            <label class="cursor-pointer">
+              <input type="checkbox" name="topic_label[]" id="{$label.id}" value="{$label.id}" {if $label.checked}checked{/if} hidden class="peer">
+              <span class="nx-badge peer-checked:bg-accent peer-checked:text-accent-fg peer-checked:border-accent transition">{$label.html}</span>
+            </label>
+          {/foreach}
+        </div>
+      </div>
+    {/if}
+
+    <div class="nx-field">
+      <label class="nx-label" for="reply">{$CONTENT_LABEL}</label>
+      <textarea name="content" id="reply" class="nx-textarea min-h-[300px]"></textarea>
+    </div>
+
+    {$TOKEN}
+
+    <div class="flex flex-wrap gap-2">
+      <button type="submit" class="nx-btn nx-btn--primary">{$SUBMIT}</button>
+      <a class="nx-btn nx-btn--outline" href="#" data-toggle="modal" data-target="#modal-cancel">{$CANCEL}</a>
+    </div>
+  </form>
+</div>
+
+<div class="ui small modal" id="modal-cancel">
+  <div class="header">{$CANCEL}</div>
+  <div class="content">{$CONFIRM_CANCEL}</div>
+  <div class="actions">
+    <button type="button" class="ui positive button">{$NO}</button>
+    <a class="ui negative button" href="{$FORUM_LINK}">{$YES}</a>
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/forum/profile_tab.tpl
+++ b/custom/templates/Nexus/forum/profile_tab.tpl
@@ -1,0 +1,23 @@
+{*  Nexus · Forum activity tab inside a user profile *}
+<h3 class="font-display text-lg font-semibold mb-4">{$PF_LATEST_POSTS_TITLE}</h3>
+
+{if isset($NO_POSTS)}
+  <div class="nx-alert nx-alert--info">
+    {include file='components/icon.tpl' name='info' size=18 class="nx-alert__icon"}
+    <div class="nx-alert__body">{$NO_POSTS}</div>
+  </div>
+{else}
+  <div class="space-y-5">
+    {foreach from=$PF_LATEST_POSTS item=post}
+      <article class="pb-4 border-b border-border-subtle last:border-0">
+        <div class="flex items-start justify-between gap-3 mb-2">
+          <h4 class="font-semibold text-text-primary">
+            <a href="{$post.link}" class="hover:text-accent transition">{$post.title}</a>
+          </h4>
+          <span class="text-xs text-text-muted whitespace-nowrap" title="{$post.date_full}">{$post.date_friendly}</span>
+        </div>
+        <div class="forum_post text-text-secondary text-sm line-clamp-3">{$post.content}</div>
+      </article>
+    {/foreach}
+  </div>
+{/if}

--- a/custom/templates/Nexus/forum/search.tpl
+++ b/custom/templates/Nexus/forum/search.tpl
@@ -1,0 +1,27 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-2xl mx-auto">
+  <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6 flex items-center gap-3">
+    <span class="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-accent-subtle text-accent">{include file='components/icon.tpl' name='search' size=18}</span>
+    {$FORUM_SEARCH}
+  </h1>
+
+  {if isset($ERROR)}
+    <div class="nx-alert nx-alert--danger mb-4">{include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}<div><div class="nx-alert__title">{$ERROR_TITLE}</div><div class="nx-alert__body">{$ERROR}</div></div></div>
+  {/if}
+
+  <div class="nx-surface p-6 sm:p-8">
+    <form action="" method="post" id="form-forum-search">
+      <label class="nx-label" for="forum-search-input">{$SEARCH}</label>
+      <div class="nx-input-group">
+        <span class="nx-input-group__icon">{include file='components/icon.tpl' name='search' size=14}</span>
+        <input type="text" id="forum-search-input" name="forum_search" placeholder="{$SEARCH}" class="nx-input" autofocus />
+      </div>
+      <input type="hidden" name="token" value="{$TOKEN}">
+      <button type="submit" class="nx-btn nx-btn--primary nx-btn--block mt-4">{$SEARCH}</button>
+    </form>
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/forum/search_results.tpl
+++ b/custom/templates/Nexus/forum/search_results.tpl
@@ -1,0 +1,43 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="flex flex-wrap items-center justify-between gap-3 mb-6">
+  <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight">{$SEARCH_RESULTS}</h1>
+  <a href="{$NEW_SEARCH_URL}" class="nx-btn nx-btn--primary">
+    {include file='components/icon.tpl' name='search' size=14}
+    {$NEW_SEARCH}
+  </a>
+</div>
+
+{if isset($PAGINATION)}<div class="mb-4">{$PAGINATION}</div>{/if}
+
+{if empty($RESULTS)}
+  <div class="nx-alert nx-alert--danger">
+    {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+    <div class="nx-alert__body">{$NO_RESULTS}</div>
+  </div>
+{else}
+  <div class="space-y-3">
+  {foreach from=$RESULTS item=result}
+    <article class="nx-surface overflow-hidden" id="forum-search-result">
+      <div class="p-5">
+        <h2 class="font-display text-lg font-semibold mb-1">
+          <a href="{$result.post_url}" class="hover:text-accent transition">{$result.topic_title}</a>
+        </h2>
+        <div class="text-xs text-text-muted mb-3">
+          <a href="{$result.post_author_profile}" style="{$result.post_author_style}" data-poload="{$USER_INFO_URL}{$result.post_author_id}" class="hover:text-text-primary">{$result.post_author}</a>
+          · <span title="{$result.post_date_full}">{$result.post_date_friendly}</span>
+        </div>
+        <div class="forum_post text-text-secondary line-clamp-4">{$result.content}</div>
+      </div>
+      <div class="bg-bg-inset border-t border-border-subtle px-5 py-3 flex justify-end">
+        <a class="nx-btn nx-btn--primary nx-btn--sm" href="{$result.post_url}">{$READ_FULL_POST}</a>
+      </div>
+    </article>
+  {/foreach}
+  </div>
+{/if}
+
+{if isset($PAGINATION)}<div class="mt-4">{$PAGINATION}</div>{/if}
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/forum/view_forum.tpl
+++ b/custom/templates/Nexus/forum/view_forum.tpl
@@ -1,0 +1,118 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<nav class="text-sm text-text-muted mb-4 flex flex-wrap items-center gap-1" aria-label="Breadcrumb">
+  {assign i 1}
+  {foreach from=$BREADCRUMBS item=breadcrumb}
+    {if $i != 1}<span class="text-text-muted">/</span>{/if}
+    <a class="hover:text-text-primary transition {if isset($breadcrumb.active)}text-text-primary{else}text-text-secondary{/if}" href="{$breadcrumb.link}">{$breadcrumb.forum_title}</a>
+    {assign i $i+1}
+  {/foreach}
+</nav>
+
+<div class="flex flex-col sm:flex-row items-start sm:items-end gap-4 mb-6">
+  <div class="flex-1">
+    <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight">{$FORUM_TITLE}</h1>
+  </div>
+  <div class="flex gap-2 w-full sm:w-auto">
+    <form method="post" action="{$SEARCH_URL}" name="searchForm" class="flex-1 sm:w-72">
+      <input type="hidden" name="token" value="{$TOKEN}">
+      <div class="nx-input-group">
+        <span class="nx-input-group__icon">{include file='components/icon.tpl' name='search' size=14}</span>
+        <input type="text" name="forum_search" placeholder="{$SEARCH}" class="nx-input" />
+      </div>
+    </form>
+    {if $NEW_TOPIC_BUTTON}
+      <a class="nx-btn nx-btn--primary" href="{$NEW_TOPIC_BUTTON}">
+        {include file='components/icon.tpl' name='plus' size=14}
+        <span class="hidden sm:inline">{$NEW_TOPIC}</span>
+      </a>
+    {/if}
+  </div>
+</div>
+
+{if isset($PAGINATION)}<div class="flex justify-end mb-4">{$PAGINATION}</div>{/if}
+
+<div class="grid gap-6
+            {if count($WIDGETS_LEFT) && count($WIDGETS_RIGHT)}lg:grid-cols-[16rem_minmax(0,1fr)_16rem]
+            {elseif count($WIDGETS_LEFT) || count($WIDGETS_RIGHT)}lg:grid-cols-[16rem_minmax(0,1fr)]
+            {else}grid-cols-1{/if}">
+
+  {if count($WIDGETS_LEFT)}
+    <aside class="space-y-4 order-2 lg:order-1">{foreach from=$WIDGETS_LEFT item=widget}{$widget}{/foreach}</aside>
+  {/if}
+
+  <main class="order-1 lg:order-2 min-w-0 space-y-6">
+
+    {if count($SUBFORUMS)}
+      <section class="nx-surface overflow-hidden" id="subforums-table">
+        <header class="nx-card__header"><h2 class="nx-card__title">{$SUBFORUM_LANGUAGE}</h2></header>
+        <ul class="divide-y divide-border-subtle">
+          {foreach from=$SUBFORUMS item=subforum}
+            <li class="flex items-center gap-4 px-5 py-4 hover:bg-bg-elevated transition">
+              <span class="hidden sm:inline-flex w-9 h-9 rounded-lg bg-accent-subtle text-accent items-center justify-center flex-shrink-0">
+                {if empty($subforum.icon)}{include file='components/icon.tpl' name='forum' size=16}{else}{$subforum.icon}{/if}
+              </span>
+              <div class="flex-1 min-w-0">
+                <a href="{$subforum.link}" class="block font-semibold text-text-primary hover:text-accent transition truncate">{$subforum.title}</a>
+                {if !$subforum.redirect}<div class="text-xs text-text-muted">{$TOPICS|capitalize}: <span class="text-text-primary font-medium">{$subforum.topics}</span></div>{/if}
+              </div>
+              {if !$subforum.redirect && !empty($subforum.latest_post)}
+                <div class="hidden md:flex items-center gap-3 min-w-[14rem] flex-shrink-0">
+                  <span class="nx-avatar nx-avatar--sm"><img src="{$subforum.latest_post.last_user_avatar}" loading="lazy" alt="" /></span>
+                  <div class="min-w-0 flex-1">
+                    <a href="{$subforum.latest_post.link}" class="block text-sm text-text-primary hover:text-accent truncate">{$subforum.latest_post.title}</a>
+                    <div class="text-xs text-text-muted">
+                      <a href="{$subforum.latest_post.last_user_link}" style="{$subforum.latest_post.last_user_style}" data-poload="{$USER_INFO_URL}{$subforum.latest_post.last_user_id}">{$subforum.latest_post.last_user}</a>
+                      · <span title="{$subforum.latest_post.time}">{$subforum.latest_post.timeago}</span>
+                    </div>
+                  </div>
+                </div>
+              {/if}
+            </li>
+          {/foreach}
+        </ul>
+      </section>
+    {/if}
+
+    {if count($STICKY_DISCUSSIONS)}
+      <section class="nx-surface overflow-hidden" id="sticky-threads">
+        <header class="nx-card__header flex items-center gap-2">
+          {include file='components/icon.tpl' name='pin' size=14 class="text-accent"}
+          <h2 class="nx-card__title">{$STICKY_TOPICS}</h2>
+        </header>
+        <ul class="divide-y divide-border-subtle">
+          {foreach from=$STICKY_DISCUSSIONS item=discussion}
+            {include file='forum/_topic_row.tpl' discussion=$discussion}
+          {/foreach}
+        </ul>
+      </section>
+    {/if}
+
+    {if count($LATEST_DISCUSSIONS)}
+      <section class="nx-surface overflow-hidden" id="normal-threads">
+        <header class="nx-card__header"><h2 class="nx-card__title">{$TOPICS|capitalize}</h2></header>
+        <ul class="divide-y divide-border-subtle">
+          {foreach from=$LATEST_DISCUSSIONS item=discussion}
+            {include file='forum/_topic_row.tpl' discussion=$discussion}
+          {/foreach}
+        </ul>
+      </section>
+    {/if}
+
+    {if isset($NO_TOPICS_FULL) && !count($LATEST_DISCUSSIONS) && !count($STICKY_DISCUSSIONS)}
+      <div class="nx-alert nx-alert--info">
+        {include file='components/icon.tpl' name='info' size=18 class="nx-alert__icon"}
+        <div class="nx-alert__body">{$NO_TOPICS_FULL}</div>
+      </div>
+    {/if}
+
+    {if isset($PAGINATION)}<div class="flex justify-center">{$PAGINATION}</div>{/if}
+  </main>
+
+  {if count($WIDGETS_RIGHT)}
+    <aside class="space-y-4 order-3">{foreach from=$WIDGETS_RIGHT item=widget}{$widget}{/foreach}</aside>
+  {/if}
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/forum/view_forum_confirm_redirect.tpl
+++ b/custom/templates/Nexus/forum/view_forum_confirm_redirect.tpl
@@ -1,0 +1,20 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-xl mx-auto text-center">
+  <div class="nx-surface p-8" id="forum-redirect">
+    <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-warning/15 text-warning mb-4">
+      {include file='components/icon.tpl' name='external' size=24}
+    </div>
+    <h2 class="font-display text-xl font-semibold mb-6">{$CONFIRM_REDIRECT}</h2>
+    <div class="flex justify-center gap-2">
+      <a class="nx-btn nx-btn--outline" href="{$FORUM_INDEX}">{$NO}</a>
+      <a class="nx-btn nx-btn--primary" href="{$REDIRECT_URL}" target="_blank" rel="noopener nofollow">
+        {$YES}
+        {include file='components/icon.tpl' name='external' size=14}
+      </a>
+    </div>
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/forum/view_forum_no_discussions.tpl
+++ b/custom/templates/Nexus/forum/view_forum_no_discussions.tpl
@@ -1,0 +1,67 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<nav class="text-sm text-text-muted mb-4 flex flex-wrap items-center gap-1" aria-label="Breadcrumb">
+  {assign i 1}
+  {foreach from=$BREADCRUMBS item=breadcrumb}
+    {if $i != 1}<span class="text-text-muted">/</span>{/if}
+    <a class="hover:text-text-primary transition {if isset($breadcrumb.active)}text-text-primary{else}text-text-secondary{/if}" href="{$breadcrumb.link}">{$breadcrumb.forum_title}</a>
+    {assign i $i+1}
+  {/foreach}
+</nav>
+
+<div class="flex flex-col sm:flex-row items-start sm:items-end gap-4 mb-6">
+  <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight flex-1">{$FORUM_TITLE}</h1>
+  <div class="flex gap-2">
+    <form method="post" action="{$SEARCH_URL}" name="searchForm" class="w-72">
+      <input type="hidden" name="token" value="{$TOKEN}">
+      <div class="nx-input-group">
+        <span class="nx-input-group__icon">{include file='components/icon.tpl' name='search' size=14}</span>
+        <input type="text" name="forum_search" placeholder="{$SEARCH}" class="nx-input" />
+      </div>
+    </form>
+    {if $NEW_TOPIC_BUTTON}
+      <a class="nx-btn nx-btn--primary" href="{$NEW_TOPIC_BUTTON}">{include file='components/icon.tpl' name='plus' size=14}{$NEW_TOPIC}</a>
+    {/if}
+  </div>
+</div>
+
+<div class="grid gap-6
+            {if count($WIDGETS_LEFT) && count($WIDGETS_RIGHT)}lg:grid-cols-[16rem_minmax(0,1fr)_16rem]
+            {elseif count($WIDGETS_LEFT) || count($WIDGETS_RIGHT)}lg:grid-cols-[16rem_minmax(0,1fr)]
+            {else}grid-cols-1{/if}">
+
+  {if count($WIDGETS_LEFT)}<aside class="space-y-4 order-2 lg:order-1">{foreach from=$WIDGETS_LEFT item=widget}{$widget}{/foreach}</aside>{/if}
+
+  <main class="order-1 lg:order-2 min-w-0 space-y-6">
+    {if count($SUBFORUMS)}
+      <section class="nx-surface overflow-hidden">
+        <header class="nx-card__header"><h2 class="nx-card__title">{$SUBFORUM_LANGUAGE}</h2></header>
+        <ul class="divide-y divide-border-subtle">
+          {foreach from=$SUBFORUMS item=subforum}
+            <li class="flex items-center gap-4 px-5 py-4 hover:bg-bg-elevated transition">
+              <span class="hidden sm:inline-flex w-9 h-9 rounded-lg bg-accent-subtle text-accent items-center justify-center flex-shrink-0">
+                {if empty($subforum.icon)}{include file='components/icon.tpl' name='forum' size=16}{else}{$subforum.icon}{/if}
+              </span>
+              <div class="flex-1 min-w-0">
+                <a href="{$subforum.link}" class="block font-semibold text-text-primary hover:text-accent transition truncate">{$subforum.title}</a>
+                {if !$subforum.redirect}<div class="text-xs text-text-muted">{$TOPICS|capitalize}: <span class="text-text-primary font-medium">{$subforum.topics}</span></div>{/if}
+              </div>
+            </li>
+          {/foreach}
+        </ul>
+      </section>
+    {/if}
+
+    <div class="nx-surface p-8 text-center">
+      <div class="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-bg-elevated text-text-muted mb-3">
+        {include file='components/icon.tpl' name='forum' size=24}
+      </div>
+      <p class="text-text-secondary">{$NO_TOPICS_FULL}</p>
+    </div>
+  </main>
+
+  {if count($WIDGETS_RIGHT)}<aside class="space-y-4 order-3">{foreach from=$WIDGETS_RIGHT item=widget}{$widget}{/foreach}</aside>{/if}
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/forum/view_topic.tpl
+++ b/custom/templates/Nexus/forum/view_topic.tpl
@@ -1,0 +1,283 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<nav class="text-sm text-text-muted mb-4 flex flex-wrap items-center gap-1" aria-label="Breadcrumb">
+  {assign i 1}
+  {foreach from=$BREADCRUMBS item=breadcrumb}
+    {if $i ne 1}<span class="text-text-muted">/</span>{/if}
+    <a class="hover:text-text-primary transition {if isset($breadcrumb.active)}text-text-primary{else}text-text-secondary{/if}" href="{$breadcrumb.link}">{$breadcrumb.forum_title}</a>
+    {assign i $i+1}
+  {/foreach}
+</nav>
+
+<header class="mb-6">
+  <div class="flex flex-wrap items-start gap-2 mb-1">
+    {if count($TOPIC_LABELS)}{foreach from=$TOPIC_LABELS item=label}{$label}{/foreach}{/if}
+    <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight">{$TOPIC_TITLE}</h1>
+  </div>
+  <p class="text-text-secondary text-sm">{$STARTED_BY}</p>
+</header>
+
+{if isset($SESSION_SUCCESS_POST)}
+  <div class="nx-alert nx-alert--success mb-4">{include file='components/icon.tpl' name='check' size=18 class="nx-alert__icon"}<div><div class="nx-alert__title">{$SUCCESS}</div><div class="nx-alert__body">{$SESSION_SUCCESS_POST}</div></div></div>
+{/if}
+{if isset($SESSION_FAILURE_POST)}
+  <div class="nx-alert nx-alert--danger mb-4">{include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}<div><div class="nx-alert__title">{$ERROR}</div><div class="nx-alert__body">{$SESSION_FAILURE_POST}</div></div></div>
+{/if}
+{if isset($ERRORS)}
+  <div class="nx-alert nx-alert--danger mb-4">{include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}<div class="flex-1"><div class="nx-alert__title">{$ERROR_TITLE}</div><ul class="nx-alert__body list-disc pl-4">{foreach from=$ERRORS item=error}<li>{$error}</li>{/foreach}</ul></div></div>
+{/if}
+
+<div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+  <div>{$PAGINATION}</div>
+  <div class="flex flex-wrap gap-2">
+    {if isset($UNFOLLOW)}
+      <form action="{$UNFOLLOW_URL}" method="post" class="inline">
+        <input type="hidden" value="{$TOKEN}" name="token" />
+        <button class="nx-btn nx-btn--outline nx-btn--sm">{include file='components/icon.tpl' name='bell' size=14}{$UNFOLLOW}</button>
+      </form>
+    {elseif isset($FOLLOW)}
+      <form action="{$FOLLOW_URL}" method="post" class="inline">
+        <input type="hidden" value="{$TOKEN}" name="token" />
+        <button class="nx-btn nx-btn--outline nx-btn--sm">{include file='components/icon.tpl' name='bell' size=14}{$FOLLOW}</button>
+      </form>
+    {/if}
+    {if isset($CAN_MODERATE)}
+      <form action="{$LOCK_URL}" method="post" id="lockTopic" class="hidden"><input type="hidden" value="{$TOKEN}" name="token" /></form>
+      <form action="{$STICK_URL}" method="post" id="stickTopic" class="hidden"><input type="hidden" value="{$TOKEN}" name="token" /></form>
+      <div class="nx-dropdown" x-data="{ open: false }">
+        <button class="nx-btn nx-btn--outline nx-btn--sm" @click="open = !open" @click.away="open = false">
+          {include file='components/icon.tpl' name='shield' size=14}{$MOD_ACTIONS}
+          {include file='components/icon.tpl' name='chevron-down' size=12}
+        </button>
+        <div class="nx-dropdown__panel right-0" x-show="open" x-cloak x-transition>
+          <div class="nx-dropdown__header">{$MOD_ACTIONS}</div>
+          <a class="nx-dropdown__item" onclick="document.getElementById('lockTopic').submit()">{include file='components/icon.tpl' name='lock' size=14}{$LOCK}</a>
+          <a class="nx-dropdown__item" href="{$MERGE_URL}">{$MERGE}</a>
+          <a class="nx-dropdown__item nx-dropdown__item--danger" data-toggle="modal" data-target="#modal-delete">{include file='components/icon.tpl' name='trash' size=14}{$DELETE}</a>
+          <a class="nx-dropdown__item" href="{$MOVE_URL}">{$MOVE}</a>
+          <a class="nx-dropdown__item" onclick="document.getElementById('stickTopic').submit()">{include file='components/icon.tpl' name='pin' size=14}{$STICK}</a>
+        </div>
+      </div>
+    {/if}
+    <div class="nx-dropdown" x-data="{ open: false }">
+      <button class="nx-btn nx-btn--outline nx-btn--sm" @click="open = !open" @click.away="open = false">
+        {include file='components/icon.tpl' name='external' size=14}{$SHARE}
+        {include file='components/icon.tpl' name='chevron-down' size=12}
+      </button>
+      <div class="nx-dropdown__panel right-0" x-show="open" x-cloak x-transition>
+        <div class="nx-dropdown__header">{$SHARE}</div>
+        <a class="nx-dropdown__item" href="{$SHARE_TWITTER_URL}">{$SHARE_TWITTER}</a>
+        <a class="nx-dropdown__item" href="{$SHARE_FACEBOOK_URL}">{$SHARE_FACEBOOK}</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+{if isset($TOPIC_LOCKED_NOTICE)}<div class="nx-alert nx-alert--warning mb-4">{include file='components/icon.tpl' name='lock' size=18 class="nx-alert__icon"}<div class="nx-alert__body">{$TOPIC_LOCKED_NOTICE}</div></div>
+{elseif isset($TOPIC_LOCKED)}<div class="nx-alert nx-alert--warning mb-4">{include file='components/icon.tpl' name='lock' size=18 class="nx-alert__icon"}<div class="nx-alert__body">{$TOPIC_LOCKED}</div></div>{/if}
+
+<div class="space-y-4">
+  {foreach from=$REPLIES item=reply}
+    <article class="nx-surface overflow-hidden" id="topic-post" post-id="{$reply.id}">
+      <div class="grid lg:grid-cols-[14rem_minmax(0,1fr)]">
+        <aside class="bg-bg-inset p-4 sm:p-5 border-b lg:border-b-0 lg:border-r border-border-subtle" id="post-sidebar">
+          <div class="text-center">
+            <a href="{$reply.profile}" class="inline-block">
+              <span class="nx-avatar nx-avatar--lg mx-auto"><img src="{$reply.avatar}" alt="{$reply.username}" loading="lazy" /></span>
+            </a>
+            <a href="{$reply.profile}" style="{$reply.user_style}" class="block mt-2 font-medium text-text-primary hover:text-accent transition truncate">{$reply.username}</a>
+            {if isset($reply.user_title)}<div class="text-xs text-text-muted mt-0.5">{$reply.user_title}</div>{/if}
+          </div>
+          <div class="flex flex-wrap gap-1 justify-center mt-3 groups">
+            {foreach from=$reply.user_groups item=group}{$group}{/foreach}
+          </div>
+          <dl class="mt-4 pt-4 border-t border-border-subtle space-y-1.5 text-xs">
+            <div class="flex justify-between gap-2"><dt class="text-text-muted">{$reply.user_registered|regex_replace:'/[:].*/':''}</dt><dd class="text-text-primary">{$reply.user_registered_full}</dd></div>
+            <div class="flex justify-between gap-2"><dt class="text-text-muted">{$reply.last_seen|regex_replace:'/[:].*/':''}</dt><dd class="text-text-primary">{$reply.last_seen_full}</dd></div>
+            <div class="flex justify-between gap-2"><dt class="text-text-muted">{$reply.user_topics_count|regex_replace:'/[0-9]+/':''|capitalize}</dt><dd class="text-text-primary">{$reply.user_topics_count|regex_replace:'/[^0-9]+/':''}</dd></div>
+            <div class="flex justify-between gap-2"><dt class="text-text-muted">{$reply.user_posts_count|regex_replace:'/[0-9]+/':''|capitalize}</dt><dd class="text-text-primary">{$reply.user_posts_count|regex_replace:'/[^0-9]+/':''}</dd></div>
+          </dl>
+          {if count($reply.fields)}
+            <dl class="mt-4 pt-4 border-t border-border-subtle space-y-1.5 text-xs">
+              {foreach from=$reply.fields item=field}
+                {if !empty($field->value)}
+                  <div class="flex justify-between gap-2"><dt class="text-text-muted">{$field->name}</dt><dd class="text-text-primary">{$field->value}</dd></div>
+                {/if}
+              {/foreach}
+            </dl>
+          {/if}
+        </aside>
+
+        <div class="p-5 sm:p-6 min-w-0" id="post-content">
+          <div class="forum_post">{$reply.content}</div>
+          {if !empty($reply.signature)}
+            <hr class="my-4 border-border-subtle" />
+            <div class="text-sm text-text-muted overflow-auto max-h-[500px]">{$reply.signature}</div>
+          {/if}
+          {if $REACTIONS_ENABLED && ((isset($LOGGED_IN_USER) && $reply.user_id !== $USER_ID) || count($reply.post_reactions))}
+            <div class="flex items-center justify-between flex-wrap gap-2 mt-4 pt-4 border-t border-border-subtle" id="reactions">
+              <div class="flex flex-wrap gap-1.5">
+                {foreach from=$reply.post_reactions name=reactions item=reaction}
+                  <button class="nx-badge nx-badge--accent cursor-pointer" onclick="openReactionModal({$reply.id}, {$reaction.id})" title="{$reaction.name}">
+                    {$reaction.html} {$reaction.count}
+                  </button>
+                {/foreach}
+              </div>
+              {if (isset($LOGGED_IN_USER) && $reply.user_id !== $USER_ID)}
+                <div class="flex flex-wrap gap-1">
+                  {foreach from=$REACTIONS item=reaction}
+                    <button title="{$reaction->name}"
+                            class="px-2 py-1 rounded-md hover:bg-bg-elevated transition {if array_key_exists($reply.id, $REACTIONS_BY_USER) && in_array($reaction->id, $REACTIONS_BY_USER[$reply.id])}bg-accent-subtle reaction-button-selected{else}reaction-button{/if}"
+                            onclick="submitReaction({$reply.id}, {$reaction->id});">{$reaction->html}</button>
+                  {/foreach}
+                </div>
+              {/if}
+            </div>
+          {/if}
+        </div>
+      </div>
+
+      <footer class="bg-bg-inset border-t border-border-subtle px-5 py-2.5 flex items-center justify-between flex-wrap gap-2 text-xs text-text-muted" id="post-meta">
+        <span>
+          <a href="{$reply.profile}" data-poload="{$USER_INFO_URL}{$reply.user_id}" style="{$reply.user_style}" class="text-text-secondary hover:text-text-primary">{$reply.username}</a>
+          · <span title="{$reply.post_date}">{$reply.post_date_rough}</span>
+          {if $reply.edited !== null} · <span title="{$reply.edited_full}">{$reply.edited}</span>{/if}
+        </span>
+        <div class="flex gap-1">
+          {if isset($reply.buttons.spam)}
+            <button class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm" data-toggle="modal" data-target="#modal-spam-{$reply.id}" title="{$reply.buttons.spam.TEXT}">{include file='components/icon.tpl' name='alert' size=14}</button>
+          {/if}
+          {if isset($reply.buttons.edit)}
+            <a class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm" href="{$reply.buttons.edit.URL}" title="{$reply.buttons.edit.TEXT}">{include file='components/icon.tpl' name='edit' size=14}</a>
+          {/if}
+          {if isset($reply.buttons.delete)}
+            <button class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm" data-toggle="modal" data-target="#modal-delete-{$reply.id}" title="{$reply.buttons.delete.TEXT}">{include file='components/icon.tpl' name='trash' size=14}</button>
+          {/if}
+          {if isset($reply.buttons.report)}
+            <button class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm" data-toggle="modal" data-target="#modal-report-{$reply.id}" title="{$reply.buttons.report.TEXT}">{include file='components/icon.tpl' name='alert' size=14}</button>
+          {/if}
+          {if isset($reply.buttons.quote)}
+            <button class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm" onclick="quote({$reply.id})" title="{$reply.buttons.quote.TEXT}">{include file='components/icon.tpl' name='reply' size=14}</button>
+          {/if}
+        </div>
+      </footer>
+    </article>
+  {/foreach}
+</div>
+
+{if isset($TOPIC_LOCKED_NOTICE)}<div class="nx-alert nx-alert--warning my-4">{include file='components/icon.tpl' name='lock' size=18 class="nx-alert__icon"}<div class="nx-alert__body">{$TOPIC_LOCKED_NOTICE}</div></div>{/if}
+
+<div class="my-4">{$PAGINATION}</div>
+
+{if isset($CAN_REPLY)}
+  <section class="nx-surface overflow-hidden" id="topic-reply">
+    <div class="grid lg:grid-cols-[14rem_minmax(0,1fr)]">
+      <aside class="bg-bg-inset p-4 sm:p-5 text-center border-b lg:border-b-0 lg:border-r border-border-subtle" id="reply-sidebar">
+        <span class="nx-avatar nx-avatar--lg mx-auto"><img src="{$LOGGED_IN_USER.avatar}" alt="" /></span>
+        <a href="{$LOGGED_IN_USER.profile}" style="{$LOGGED_IN_USER.username_style}" class="block mt-2 font-medium text-text-primary hover:text-accent transition truncate">{$LOGGED_IN_USER.username}</a>
+      </aside>
+      <div class="p-5 sm:p-6" id="reply-content">
+        <form class="space-y-4" action="" method="post">
+          <textarea name="content" id="quickreply" class="nx-textarea" placeholder="Reply…"></textarea>
+          <input type="hidden" name="token" value="{$TOKEN}">
+          <button type="submit" class="nx-btn nx-btn--primary">{$SUBMIT}</button>
+        </form>
+      </div>
+    </div>
+  </section>
+{/if}
+
+{if $REACTIONS_ENABLED}
+  <div class="ui small modal" id="modal-reactions">
+    <i class="close icon"></i>
+    <div class="header">{$REACTIONS_TEXT}</div>
+    <div class="scrolling content"></div>
+  </div>
+{/if}
+
+{foreach from=$REPLIES item=reply}
+  {if isset($reply.buttons.report)}
+    <div class="ui small modal" id="modal-report-{$reply.id}">
+      <div class="header">{$reply.buttons.report.TEXT}</div>
+      <div class="content">
+        <form action="{$reply.buttons.report.URL}" method="post" id="form-report-{$reply.id}">
+          <label class="nx-label" for="InputReason-{$reply.id}">{$reply.buttons.report.REPORT_TEXT}</label>
+          <textarea id="InputReason-{$reply.id}" name="reason" class="nx-textarea"></textarea>
+          <input type="hidden" name="post" value="{$reply.id}">
+          <input type="hidden" name="topic" value="{$TOPIC_ID}">
+          <input type="hidden" name="token" value="{$TOKEN}">
+        </form>
+      </div>
+      <div class="actions">
+        <a class="ui negative button">{$CANCEL}</a>
+        <a class="ui positive button" onclick="$('#form-report-{$reply.id}').submit();">{$reply.buttons.report.TEXT}</a>
+      </div>
+    </div>
+  {/if}
+  {if isset($CAN_MODERATE)}
+    <div class="ui small modal" id="modal-spam-{$reply.id}">
+      <div class="header">{$MARK_AS_SPAM}</div>
+      <div class="content">
+        {$CONFIRM_SPAM_POST}
+        <form action="{$reply.buttons.spam.URL}" method="post" id="form-spam-{$reply.id}">
+          <input type="hidden" name="post" value="{$reply.id}">
+          <input type="hidden" name="token" value="{$TOKEN}">
+        </form>
+      </div>
+      <div class="actions">
+        <a class="ui negative button">{$CANCEL}</a>
+        <a class="ui positive button" onclick="$('#form-spam-{$reply.id}').submit();">{$MARK_AS_SPAM}</a>
+      </div>
+    </div>
+    <div class="ui small modal" id="modal-delete-{$reply.id}">
+      <div class="header">{$CONFIRM_DELETE_SHORT}</div>
+      <div class="content">
+        {$CONFIRM_DELETE_POST}
+        <form action="{$reply.buttons.delete.URL}" method="post" id="form-delete-{$reply.id}">
+          <input type="hidden" name="tid" value="{$TOPIC_ID}">
+          <input type="hidden" name="number" value="{$reply.buttons.delete.NUMBER}">
+          <input type="hidden" name="pid" value="{$reply.id}">
+          <input type="hidden" name="token" value="{$TOKEN}">
+        </form>
+      </div>
+      <div class="actions">
+        <a class="ui negative button">{$CANCEL}</a>
+        <a class="ui positive button" onclick="$('#form-delete-{$reply.id}').submit();">{$reply.buttons.delete.TEXT}</a>
+      </div>
+    </div>
+  {/if}
+{/foreach}
+
+{if isset($CAN_MODERATE)}
+  <div class="ui small modal" id="modal-delete">
+    <div class="header">{$CONFIRM_DELETE_SHORT}</div>
+    <div class="content">{$CONFIRM_DELETE}</div>
+    <div class="actions">
+      <a class="ui negative button">{$CANCEL}</a>
+      <form action="{$DELETE_URL}" method="post" id="deleteTopic" class="hidden">
+        <input type="hidden" value="{$TOKEN}" name="token" />
+      </form>
+      <a class="ui positive button" onclick="document.getElementById('deleteTopic').submit()">{$DELETE}</a>
+    </div>
+  </div>
+{/if}
+
+{if $REACTIONS_ENABLED}
+<script>
+  const submitReaction = (post_id, reaction_id) => {
+    $.post("{$REACTIONS_URL}", { token: "{$TOKEN}", reaction_id, reactable_id: post_id, context: 'forum_post' })
+      .done((r) => { if (r.startsWith('Reaction ')) { window.location.replace(window.location.href.replace(/#.*$/, '') + '#post-' + post_id); window.location.reload(); } else console.error(r); })
+      .fail(console.error);
+  };
+  const openReactionModal = (post_id, reaction_id) => {
+    const modal = $('#modal-reactions'); modal.modal('show');
+    modal.find('.content').html('<div class="text-center py-4"><span class="nx-spinner inline-block"></span></div>');
+    $.get("{$REACTIONS_URL}", { reactable_id: post_id, context: 'forum_post', tab: reaction_id })
+      .done((r) => modal.find('.content').html(r))
+      .fail(console.error);
+  };
+</script>
+{/if}
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/header.tpl
+++ b/custom/templates/Nexus/header.tpl
@@ -1,0 +1,73 @@
+{*
+ *  Nexus · Document head
+ *  Preserves the DefaultRevamp $TEMPLATE_CSS / $TEMPLATE_JS / $TITLE contract.
+*}
+{if "HTML_CLASS"|defined}{assign var="HTMLCLASS" value=" {$smarty.const.HTML_CLASS}"}{else}{assign var="HTMLCLASS" value=""}{/if}
+{if "HTML_LANG"|defined}{assign var="HTMLLANG" value=" lang='{$smarty.const.HTML_LANG}'"}{else}{assign var="HTMLLANG" value=" lang='en'"}{/if}
+{if "HTML_RTL"|defined && $smarty.const.HTML_RTL eq true}{assign var="HTMLRTL" value=" dir='rtl'"}{else}{assign var="HTMLRTL" value=" dir='ltr'"}{/if}
+{if "LANG_CHARSET"|defined}{assign var="METACHARSET" value="{$smarty.const.LANG_CHARSET}"}{else}{assign var="METACHARSET" value="utf-8"}{/if}
+{if isset($PAGE_DESCRIPTION) && $PAGE_DESCRIPTION|count_characters > 0}{assign var="PAGEDESCRIPTION" value="{$PAGE_DESCRIPTION}"}{else}{assign var="PAGEDESCRIPTION" value=""}{/if}
+{if isset($PAGE_KEYWORDS) && $PAGE_KEYWORDS|count_characters > 0}{assign var="PAGEKEYWORDS" value="{$PAGE_KEYWORDS}"}{else}{assign var="PAGEKEYWORDS" value=""}{/if}
+
+<!DOCTYPE html>
+<html{$HTMLCLASS}{$HTMLLANG}{$HTMLRTL} data-theme="{if $NEXUS_DARK_MODE}dark{else}light{/if}">
+<head>
+    <meta charset="{$METACHARSET}">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="theme-color" content="#07080B" media="(prefers-color-scheme: dark)">
+    <meta name="theme-color" content="#FAFAFB" media="(prefers-color-scheme: light)">
+
+    <title>{$TITLE} &bull; {$smarty.const.SITE_NAME}</title>
+
+    {if isset($FAVICON)}<link rel="shortcut icon" href="{$FAVICON}" type="image/x-icon" />{/if}
+
+    <meta name="author" content="{$smarty.const.SITE_NAME}">
+    <meta name="description" content="{$PAGEDESCRIPTION}" />
+    <meta name="keywords" content="{$PAGEKEYWORDS}" />
+
+    <meta property="og:title" content="{$TITLE} &bull; {$smarty.const.SITE_NAME}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="{$OG_URL}" />
+    <meta property="og:image" content="{$OG_IMAGE}" />
+    <meta property="og:description" content="{$PAGEDESCRIPTION}" />
+
+    <meta name="twitter:title" content="{$TITLE} &bull; {$smarty.const.SITE_NAME}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content="{$OG_IMAGE}" />
+    {if isset($PAGE_DESCRIPTION) && $PAGE_DESCRIPTION|count_characters > 0}
+        <meta name="twitter:description" content="{$PAGEDESCRIPTION}" />
+    {/if}
+
+    {* FOUC-prevention: apply persisted theme before paint *}
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem('nexus.theme');
+          if (t === 'dark' || t === 'light') {
+            document.documentElement.setAttribute('data-theme', t);
+          }
+        } catch (e) {}
+      })();
+    </script>
+
+    {* Preconnect to font sources *}
+    <link rel="preconnect" href="https://rsms.me" crossorigin>
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" media="print" onload="this.media='all'">
+
+    {foreach from=$TEMPLATE_CSS item=css}{$css}{/foreach}
+
+    {if isset($ANALYTICS_ID)}
+        {literal}<script async src="https://www.googletagmanager.com/gtag/js?id={/literal}{$ANALYTICS_ID}{literal}"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '{/literal}{$ANALYTICS_ID}{literal}');
+        </script>{/literal}
+    {/if}
+
+    {if isset($DEBUGBAR_JS)}{$DEBUGBAR_JS}{/if}
+</head>
+<body class="font-sans antialiased" id="page-{if is_numeric($smarty.const.PAGE)}{$TITLE}{else}{$smarty.const.PAGE}{/if}">
+
+<a href="#nx-main" class="skip-link">Skip to main content</a>

--- a/custom/templates/Nexus/index.tpl
+++ b/custom/templates/Nexus/index.tpl
@@ -1,0 +1,84 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+{if isset($HOME_SESSION_FLASH)}
+  <div class="nx-alert nx-alert--success mb-5 animate-fade-in">
+    {include file='components/icon.tpl' name='check' size=18 class="nx-alert__icon"}
+    <div><div class="nx-alert__title">{$SUCCESS_TITLE}</div><div class="nx-alert__body">{$HOME_SESSION_FLASH}</div></div>
+  </div>
+{/if}
+
+{if isset($HOME_SESSION_ERROR_FLASH)}
+  <div class="nx-alert nx-alert--danger mb-5 animate-fade-in">
+    {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+    <div><div class="nx-alert__title">{$ERROR_TITLE}</div><div class="nx-alert__body">{$HOME_SESSION_ERROR_FLASH}</div></div>
+  </div>
+{/if}
+
+<div class="grid gap-6 lg:gap-8
+            {if count($WIDGETS_LEFT) && count($WIDGETS_RIGHT)}lg:grid-cols-[18rem_minmax(0,1fr)_18rem]
+            {elseif count($WIDGETS_LEFT) || count($WIDGETS_RIGHT)}lg:grid-cols-[18rem_minmax(0,1fr)]
+            {else}grid-cols-1{/if}">
+
+  {if count($WIDGETS_LEFT)}
+    <aside class="space-y-4 order-2 lg:order-1">
+      {foreach from=$WIDGETS_LEFT item=widget}{$widget}{/foreach}
+    </aside>
+  {/if}
+
+  <section class="order-1 lg:order-2 min-w-0">
+    {if $HOME_TYPE === 'news'}
+      <div class="space-y-4">
+        {foreach from=$NEWS item=item}
+          <article class="nx-card nx-card--interactive animate-fade-in">
+            <div class="nx-card__body">
+              <div class="flex items-start gap-3 mb-3">
+                <a href="{$item.author_url}" class="nx-avatar nx-avatar--sm">
+                  <img src="{$item.author_avatar}" alt="{$item.author_name}" loading="lazy" />
+                </a>
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center flex-wrap gap-2 text-xs text-text-muted">
+                    <a href="{$item.author_url}" style="{$item.author_style}" class="text-text-secondary hover:text-text-primary font-medium">{$item.author_name}</a>
+                    <span>·</span>
+                    <time class="text-text-muted" title="{$item.date}">{$item.time_ago}</time>
+                    {if isset($item.label)}<span class="ml-1">{$item.label}</span>{/if}
+                  </div>
+                  <h2 class="nx-card__title mt-1">
+                    <a href="{$item.url}" class="hover:text-accent transition">{$item.title}</a>
+                  </h2>
+                </div>
+              </div>
+              <div class="forum_post text-text-secondary line-clamp-5">
+                {$item.content}
+              </div>
+            </div>
+            <div class="nx-card__footer">
+              <span class="nx-card__meta">{$item.date}</span>
+              <a class="nx-btn nx-btn--primary nx-btn--sm" href="{$item.url}">
+                {$READ_FULL_POST}
+                {include file='components/icon.tpl' name='arrow-right' size=12}
+              </a>
+            </div>
+          </article>
+        {foreachelse}
+          <div class="nx-alert nx-alert--info">
+            {include file='components/icon.tpl' name='info' size=18 class="nx-alert__icon"}
+            <div class="nx-alert__body">{$NO_NEWS}</div>
+          </div>
+        {/foreach}
+      </div>
+    {elseif $HOME_TYPE === 'custom'}
+      <div class="nx-surface p-6 sm:p-8 forum_post">
+        {$CUSTOM_HOME_CONTENT}
+      </div>
+    {/if}
+  </section>
+
+  {if count($WIDGETS_RIGHT)}
+    <aside class="space-y-4 order-3">
+      {foreach from=$WIDGETS_RIGHT item=widget}{$widget}{/foreach}
+    </aside>
+  {/if}
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/leaderboards.tpl
+++ b/custom/templates/Nexus/leaderboards.tpl
@@ -1,0 +1,54 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6 flex items-center gap-3">
+  <span class="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-accent-subtle text-accent">
+    {include file='components/icon.tpl' name='trophy' size=18}
+  </span>
+  {$LEADERBOARDS}
+</h1>
+
+<div class="grid lg:grid-cols-[18rem_minmax(0,1fr)] gap-6">
+  <nav class="nx-surface p-2 space-y-0.5 h-fit lg:sticky lg:top-20">
+    {foreach from=$LEADERBOARD_PLACEHOLDERS item=placeholder}
+      <a class="leaderboard_tab flex items-center gap-2 px-3 py-2 rounded-md text-sm text-text-secondary hover:text-text-primary hover:bg-bg-elevated transition cursor-pointer"
+         name="{$placeholder->safe_name}"
+         server_id="{$placeholder->server_id}"
+         id="tab-{$placeholder->safe_name}-server-{$placeholder->server_id}"
+         onclick="showTable('{$placeholder->safe_name}', '{$placeholder->server_id}');">
+        {include file='components/icon.tpl' name='star' size=14}
+        {$placeholder->leaderboard_title}
+      </a>
+    {/foreach}
+  </nav>
+
+  <div class="min-w-0">
+    {foreach from=$LEADERBOARD_PLACEHOLDERS item=placeholder}
+      <div class="leaderboard_table nx-surface p-6" style="display:none" id="table-{$placeholder->safe_name}-server-{$placeholder->server_id}">
+        <h3 class="font-display text-lg font-semibold mb-4">{$placeholder->leaderboard_title}</h3>
+        <ol class="space-y-1">
+          {assign var=rank value=1}
+          {foreach from=$LEADERBOARD_PLACEHOLDERS_DATA item=data}
+            {if $data->name eq $placeholder->name and $data->server_id eq $placeholder->server_id}
+              <li>
+                <a href="{$data->profile}"
+                   class="flex items-center gap-3 px-3 py-2.5 rounded-md hover:bg-bg-elevated transition">
+                  <span class="font-mono text-text-muted w-8 text-sm">#{$rank}</span>
+                  <span class="nx-avatar nx-avatar--sm"><img src="{$data->avatar}" alt="{$data->username}" loading="lazy" /></span>
+                  <span class="flex-1 min-w-0">
+                    <span class="block text-text-primary font-medium truncate" style="{$data->style}">{$data->username}</span>
+                    <span class="block text-xs text-text-muted truncate" title="{$data->last_updated_full}">{$data->last_updated_string}</span>
+                  </span>
+                  <span class="font-display text-lg font-semibold text-text-primary tabular-nums">{$data->value}</span>
+                </a>
+              </li>
+              {assign var=rank value=$rank+1}
+            {/if}
+          {/foreach}
+        </ol>
+      </div>
+    {/foreach}
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/login.tpl
+++ b/custom/templates/Nexus/login.tpl
@@ -1,0 +1,105 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="grid lg:grid-cols-2 gap-10 items-center min-h-[60vh]">
+  {* === Visual side === *}
+  <aside class="hidden lg:block relative">
+    <div class="nx-surface-elevated overflow-hidden p-10 h-full min-h-[420px] relative">
+      <div class="absolute inset-0 bg-gradient-mesh opacity-80"></div>
+      <div class="relative z-10 h-full flex flex-col justify-between">
+        <div class="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br from-accent to-accent-hover shadow-glow text-white">
+          {include file='components/icon.tpl' name='sparkle' size=22}
+        </div>
+        <div>
+          <h1 class="font-display text-3xl font-bold tracking-tight text-text-primary mb-3">
+            {$SIGN_IN}
+          </h1>
+          <p class="text-text-secondary max-w-md leading-relaxed">
+            {$smarty.const.SITE_NAME} &mdash; pick up where you left off.
+          </p>
+        </div>
+      </div>
+    </div>
+  </aside>
+
+  {* === Form side === *}
+  <section class="max-w-md mx-auto w-full">
+    <div class="lg:hidden mb-6">
+      <h1 class="font-display text-2xl font-bold tracking-tight">{$SIGN_IN}</h1>
+    </div>
+
+    {if count($ERROR)}
+      <div class="nx-alert nx-alert--danger mb-5">
+        {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+        <div class="flex-1">
+          <div class="nx-alert__title">{$ERROR_TITLE}</div>
+          <ul class="nx-alert__body list-disc pl-4 space-y-0.5">
+            {foreach from=$ERROR item=error}<li>{$error}</li>{/foreach}
+          </ul>
+        </div>
+      </div>
+    {/if}
+
+    <form class="space-y-4" action="" method="post" id="form-login">
+      {if isset($EMAIL)}
+        <div class="nx-field">
+          <label class="nx-label" for="email">{$EMAIL}</label>
+          <input type="email" name="email" id="email" value="{$USERNAME_INPUT}" placeholder="{$EMAIL}"
+                 tabindex="1" class="nx-input" autocomplete="email" />
+        </div>
+      {else}
+        <div class="nx-field">
+          <label class="nx-label" for="username">{$USERNAME}</label>
+          <input type="text" name="username" id="username" value="{$USERNAME_INPUT}" placeholder="{$USERNAME}"
+                 tabindex="1" class="nx-input" autocomplete="username" />
+        </div>
+      {/if}
+
+      <div class="nx-field">
+        <label class="nx-label" for="password">{$PASSWORD}</label>
+        <input type="password" name="password" id="password" placeholder="{$PASSWORD}"
+               tabindex="2" class="nx-input" autocomplete="current-password" />
+      </div>
+
+      <div class="flex items-center justify-between">
+        <label class="inline-flex items-center gap-2 cursor-pointer text-sm text-text-secondary">
+          <input type="checkbox" name="remember" id="remember" value="1" tabindex="3" class="nx-checkbox" />
+          {$REMEMBER_ME}
+        </label>
+        <a href="{$FORGOT_PASSWORD_URL}" class="text-sm text-accent hover:text-accent-hover transition">{$FORGOT_PASSWORD}</a>
+      </div>
+
+      {if $CAPTCHA}
+        <div class="nx-field">{$CAPTCHA}</div>
+      {/if}
+
+      <input type="hidden" name="token" value="{$FORM_TOKEN}">
+
+      <button type="submit" class="nx-btn nx-btn--primary nx-btn--lg nx-btn--block" tabindex="5">
+        {$SIGN_IN}
+        {include file='components/icon.tpl' name='arrow-right' size=14}
+      </button>
+    </form>
+
+    {if $OAUTH_AVAILABLE}
+      <div class="nx-divider">{$OR}</div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {foreach $OAUTH_PROVIDERS as $name => $meta}
+          <a href="{$meta.url}" class="nx-btn nx-btn--outline gap-2" {if $meta.button_css}style="{$meta.button_css}"{/if}>
+            {if $meta.logo_url}
+              <img src="{$meta.logo_url}" {if $meta.logo_css}style="{$meta.logo_css}"{/if} alt="{$name|ucfirst}" class="w-4 h-4" />
+            {elseif $meta.icon}
+              <i class="{$meta.icon}"></i>
+            {/if}
+            <span {if $meta.text_css}style="{$meta.text_css}"{/if}>{$meta.log_in_with}</span>
+          </a>
+        {/foreach}
+      </div>
+    {/if}
+
+    <div class="nx-divider">{$NOT_REGISTERED_YET}</div>
+    <a href="{$REGISTER_URL}" class="nx-btn nx-btn--outline nx-btn--block">{$REGISTER}</a>
+  </section>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/maintenance.tpl
+++ b/custom/templates/Nexus/maintenance.tpl
@@ -1,0 +1,21 @@
+{include file='header.tpl'}
+
+<div class="nx-container py-16 lg:py-24 text-center max-w-xl mx-auto">
+  <div class="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-warning/15 text-warning mb-6">
+    {include file='components/icon.tpl' name='settings' size=28 class="animate-spin" strokeWidth=1.5}
+  </div>
+  <h1 class="font-display text-3xl font-bold tracking-tight mb-3">{$MAINTENANCE_TITLE}</h1>
+  <p class="text-text-secondary mb-6">{$MAINTENANCE_MESSAGE}</p>
+
+  <div class="flex justify-center gap-2">
+    <button class="nx-btn nx-btn--primary" onclick="window.location.reload()">{$RETRY}</button>
+  </div>
+
+  {if isset($LOGIN)}
+    <div class="mt-6 pt-6 border-t border-border-subtle">
+      <a class="text-sm text-text-secondary hover:text-text-primary transition" href="{$LOGIN_LINK}">{$LOGIN}</a>
+    </div>
+  {/if}
+</div>
+</body>
+</html>

--- a/custom/templates/Nexus/members/members.tpl
+++ b/custom/templates/Nexus/members/members.tpl
@@ -1,0 +1,179 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6 flex items-center gap-3">
+  <span class="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-accent-subtle text-accent">{include file='components/icon.tpl' name='users' size=18}</span>
+  {$MEMBERS}
+</h1>
+
+{if isset($ERROR)}
+  <div class="nx-alert nx-alert--danger mb-4">
+    {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+    <div><div class="nx-alert__title">{$ERROR_TITLE}</div><div class="nx-alert__body">{$ERROR}</div></div>
+  </div>
+{/if}
+
+<div class="grid lg:grid-cols-[18rem_minmax(0,1fr)] gap-6">
+  <aside class="space-y-4">
+    {* List navigation *}
+    <nav class="nx-surface p-2 space-y-0.5">
+      <a class="flex items-center gap-2 px-3 py-2 rounded-md text-sm transition
+                {if $VIEWING_LIST eq "overview"}bg-accent-subtle text-text-primary{else}text-text-secondary hover:text-text-primary hover:bg-bg-elevated{/if}"
+         href="{$MEMBER_LIST_URL}">
+        {include file='components/icon.tpl' name='grid' size=14}{$OVERVIEW}
+      </a>
+      {foreach from=$SIDEBAR_MEMBER_LISTS item=list}
+        <a class="flex items-center gap-2 px-3 py-2 rounded-md text-sm transition
+                  {if $VIEWING_LIST eq $list->getName()}bg-accent-subtle text-text-primary{else}text-text-secondary hover:text-text-primary hover:bg-bg-elevated{/if}"
+           href="{$list->url()}">
+          <i class="{if $list->getIcon()}{$list->getIcon()}{else}icon{/if}"></i> {$list->getFriendlyName()}
+        </a>
+      {/foreach}
+    </nav>
+
+    {* Find member *}
+    <div class="nx-surface p-4">
+      <h3 class="font-medium text-text-primary mb-3 text-sm">{$FIND_MEMBER}</h3>
+      <div class="ui search">
+        <div class="nx-input-group">
+          <span class="nx-input-group__icon">{include file='components/icon.tpl' name='search' size=14}</span>
+          <input class="prompt nx-input" type="text" minlength="2" required placeholder="{$NAME}" autocomplete="off">
+        </div>
+        <div class="results"></div>
+      </div>
+    </div>
+
+    {if $GROUPS|count}
+      <div class="nx-surface p-4">
+        <h3 class="font-medium text-text-primary mb-3 text-sm">{$VIEW_GROUP}</h3>
+        <select class="nx-select" onchange="viewGroup(this)">
+          <option value="">{$GROUP}</option>
+          {foreach from=$GROUPS item=group}
+            <option value="{$group.id}" {if $VIEWING_GROUP.id == $group.id}selected{/if}>{$group.name}</option>
+          {/foreach}
+        </select>
+      </div>
+    {/if}
+
+    <div class="nx-surface p-4">
+      <h3 class="font-medium text-text-primary mb-3 text-sm">{$NEW_MEMBERS}</h3>
+      <div class="grid grid-cols-4 gap-2" id="new-members-grid">
+        {foreach from=$NEW_MEMBERS_VALUE item=member}
+          <a href="{$member->getProfileUrl()}" data-poload="{$USER_INFO_URL}{$member->data()->id}"
+             class="nx-avatar block">
+            <img src="{$member->getAvatar()}" alt="{$member->getDisplayname()}" loading="lazy" />
+          </a>
+        {/foreach}
+      </div>
+    </div>
+  </aside>
+
+  <main class="min-w-0">
+    {if $VIEWING_LIST == "group" || $MEMBER_LISTS_VIEWING|count}
+      <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {if $VIEWING_LIST == "group"}
+          <div class="nx-surface p-5 col-span-full">
+            <h3 class="font-display text-lg font-semibold mb-3">{$VIEWING_GROUP.name}</h3>
+            <ul id="member_list_group_{$VIEWING_GROUP.id}" class="space-y-1"></ul>
+            <div class="mt-3">{$PAGINATION}</div>
+          </div>
+        {else}
+          {foreach from=$MEMBER_LISTS_VIEWING item=list}
+            <div class="nx-surface p-5">
+              <h3 class="font-display text-lg font-semibold mb-3">{$list->getFriendlyName()}</h3>
+              <ul id="member_list_{$list->getName()}" class="space-y-1"></ul>
+              {if $VIEWING_LIST == "overview"}
+                <a class="nx-btn nx-btn--outline nx-btn--block mt-3" href="{$list->url()}">{$VIEW_ALL}</a>
+              {else}
+                <div class="mt-3">{$PAGINATION}</div>
+              {/if}
+            </div>
+          {/foreach}
+        {/if}
+      </div>
+    {else}
+      <div class="nx-alert nx-alert--warning">
+        {include file='components/icon.tpl' name='info' size=18 class="nx-alert__icon"}
+        <div class="nx-alert__body">{$NO_OVERVIEW_LISTS_ENABLED}</div>
+      </div>
+    {/if}
+  </main>
+</div>
+
+<script>
+  const viewGroup = (e) => { window.location.href = '{$VIEW_GROUP_URL}' + e.value; };
+
+  const renderList = (name) => {
+    const list = document.getElementById('member_list_' + name);
+    list.innerHTML = '<div class="flex justify-center py-4"><span class="nx-spinner inline-block"></span></div>';
+
+    fetch(
+      '{$QUERIES_URL}'
+        .replace({literal}'{{list}}'{/literal}, name)
+        .replace({literal}'{{page}}'{/literal}, new URLSearchParams(window.location.search).get('p') ?? 1)
+    ).then(async response => {
+      const data = await response.json();
+      if (data.length === 0) {
+        list.parentElement.innerHTML = '<div class="nx-alert nx-alert--warning"><div class="nx-alert__body">{$NO_MEMBERS_FOUND}</div></div>';
+        return;
+      }
+      list.innerHTML = '';
+      for (const member of data) {
+        const li = document.createElement('li');
+        li.className = 'flex items-center gap-3 px-2 py-2 rounded-md hover:bg-bg-elevated cursor-pointer transition';
+        li.onclick = () => window.location.href = member.profile_url;
+
+        const avatar = document.createElement('img');
+        avatar.src = member.avatar_url;
+        avatar.className = 'w-8 h-8 rounded-full object-cover flex-shrink-0';
+        li.appendChild(avatar);
+
+        const nameWrap = document.createElement('div');
+        nameWrap.className = 'flex-1 min-w-0';
+        const nameDiv = document.createElement('span');
+        nameDiv.className = 'block text-sm text-text-primary truncate';
+        nameDiv.style = member.group_style?.replace('&#039;', "'")?.replace('&quot;', '"');
+        {if $VIEWING_LIST != "overview"}
+          nameDiv.innerHTML = member.username + '&nbsp;' + member.group_html.join('');
+          const meta = document.createElement('div');
+          meta.className = 'text-xs text-text-muted';
+          const memberMeta = member.metadata;
+          meta.innerHTML = Object.keys(memberMeta).map(key => key + ': ' + memberMeta[key]).join(' &middot; ');
+          nameWrap.appendChild(nameDiv);
+          nameWrap.appendChild(meta);
+        {else}
+          nameDiv.innerText = member.username;
+          nameWrap.appendChild(nameDiv);
+        {/if}
+        li.appendChild(nameWrap);
+
+        if (member.count !== null) {
+          const count = document.createElement('span');
+          count.className = 'font-display text-base font-semibold text-text-primary tabular-nums';
+          count.innerText = member.count;
+          li.appendChild(count);
+        }
+        list.appendChild(li);
+      }
+    });
+  };
+
+  window.onload = () => {
+    {if $VIEWING_LIST == "group"}
+      renderList('group_{$VIEWING_GROUP.id}');
+    {else}
+      {foreach from=$MEMBER_LISTS_VIEWING item=list}renderList('{$list->getName()}');{/foreach}
+    {/if}
+
+    $('.ui.search').search({
+      minCharacters: 2,
+      maxResults: 5,
+      selectFirstResult: true,
+      fields: { title: 'username', description: 'nickname', image: 'avatar_url', url: 'profile_url' },
+      apiSettings: { url: '{$SEARCH_URL}&search={literal}{query}{/literal}&limit=5' },
+      error: { noResultsHeader: "{$NO_RESULTS_HEADER}", noResults: "{$NO_RESULTS_TEXT}" }
+    });
+  };
+</script>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/navbar.tpl
+++ b/custom/templates/Nexus/navbar.tpl
@@ -1,0 +1,290 @@
+{*
+ *  Nexus · Top navigation + announcement region + main content opener
+ *  Preserves the $NAV_LINKS / $USER_SECTION / $WIDGETS_TOP / $ANNOUNCEMENTS contract.
+*}
+
+{* === Off-Canvas Mobile Drawer === *}
+<div x-data
+     x-show="$store.mobileNav.open"
+     x-cloak
+     class="fixed inset-0 z-[110] lg:hidden"
+     @keydown.window.escape="$store.mobileNav.close()">
+
+  <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"
+       x-transition.opacity
+       @click="$store.mobileNav.close()"></div>
+
+  <aside class="absolute left-0 top-0 h-full w-[82%] max-w-sm nx-surface-elevated rounded-none border-r border-border-default
+                flex flex-col gap-1 p-4 overflow-y-auto"
+         x-transition:enter="transition ease-out duration-200"
+         x-transition:enter-start="-translate-x-full"
+         x-transition:enter-end="translate-x-0"
+         x-transition:leave="transition ease-in duration-150"
+         x-transition:leave-start="translate-x-0"
+         x-transition:leave-end="-translate-x-full">
+
+    <div class="flex items-center justify-between mb-4">
+      <a href="/" class="font-display text-lg font-semibold tracking-tight">{$smarty.const.SITE_NAME}</a>
+      <button class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm" @click="$store.mobileNav.close()" aria-label="Close menu">
+        {include file='components/icon.tpl' name='close' size=18}
+      </button>
+    </div>
+
+    <nav class="flex flex-col gap-0.5" aria-label="Mobile primary">
+      {foreach from=$NAV_LINKS key=name item=item}
+        {if isset($item.items)}
+          <div class="px-3 pt-3 pb-1 text-[11px] uppercase tracking-wider text-text-muted font-semibold">{$item.title}</div>
+          {foreach from=$item.items item=dropdown}
+            {if !isset($dropdown.separator)}
+              <a href="{$dropdown.link}" target="{$dropdown.target}"
+                 class="flex items-center gap-2.5 px-3 py-2.5 rounded-md text-sm text-text-secondary hover:text-text-primary hover:bg-bg-surface transition">
+                <span class="opacity-80">{$dropdown.icon}</span>{$dropdown.title}
+              </a>
+            {/if}
+          {/foreach}
+        {else}
+          <a href="{$item.link}" target="{$item.target}" data-nav-key="{$name}"
+             class="flex items-center gap-2.5 px-3 py-2.5 rounded-md text-sm hover:bg-bg-surface transition
+                    {if isset($item.active)}bg-bg-surface text-text-primary{else}text-text-secondary hover:text-text-primary{/if}">
+            <span class="opacity-80">{$item.icon}</span>{$item.title}
+          </a>
+        {/if}
+      {/foreach}
+    </nav>
+
+    <div class="mt-auto pt-4 border-t border-border-subtle flex flex-wrap gap-2">
+      {foreach from=$USER_SECTION key=name item=item}
+        {if !isset($item.items)}
+          <a href="{$item.link}" target="{$item.target}"
+             class="nx-btn {if $name eq 'register' || $name eq 'panel'}nx-btn--primary{else}nx-btn--outline{/if} nx-btn--sm">
+            <span class="opacity-80">{$item.icon}</span>{$item.title}
+          </a>
+        {/if}
+      {/foreach}
+    </div>
+  </aside>
+</div>
+
+{* === Top Bar === *}
+<header class="sticky top-0 z-50 backdrop-blur-xl bg-bg-overlay border-b border-border-subtle" x-data>
+  <div class="nx-container flex items-center gap-3 h-16">
+
+    {* Mobile burger *}
+    <button class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm lg:hidden"
+            @click="$store.mobileNav.toggle()" aria-label="Open menu">
+      {include file='components/icon.tpl' name='menu' size=18}
+    </button>
+
+    {* Brand *}
+    <a href="/" class="flex items-center gap-2 font-display font-semibold text-text-primary text-[15px] tracking-tight">
+      <span class="inline-flex items-center justify-center w-7 h-7 rounded-md bg-gradient-to-br from-accent to-accent-hover shadow-glow text-white">
+        {include file='components/icon.tpl' name='sparkle' size=14}
+      </span>
+      <span class="hidden sm:inline">{$smarty.const.SITE_NAME}</span>
+    </a>
+
+    {* Primary nav (desktop) *}
+    <nav class="hidden lg:flex items-center gap-1 ml-4" aria-label="Primary">
+      {foreach from=$NAV_LINKS key=name item=item}
+        {if isset($item.items)}
+          <div x-data="{ open: false }" class="relative">
+            <button class="nx-btn nx-btn--ghost nx-btn--sm" @click="open = !open" @click.away="open = false"
+                    :aria-expanded="open" aria-haspopup="menu">
+              <span class="opacity-80">{$item.icon}</span>{$item.title}
+              {include file='components/icon.tpl' name='chevron-down' size=14}
+            </button>
+            <div x-show="open" x-cloak x-transition
+                 class="nx-dropdown__panel left-0">
+              <div class="nx-dropdown__header">{$item.title}</div>
+              {foreach from=$item.items item=dropdown}
+                {if isset($dropdown.separator)}
+                  <div class="nx-dropdown__divider"></div>
+                {else}
+                  <a class="nx-dropdown__item" href="{$dropdown.link}" target="{$dropdown.target}">
+                    <span class="opacity-80">{$dropdown.icon}</span>{$dropdown.title}
+                  </a>
+                {/if}
+              {/foreach}
+            </div>
+          </div>
+        {else}
+          <a href="{$item.link}" target="{$item.target}" data-nav-key="{$name}"
+             class="nx-btn nx-btn--ghost nx-btn--sm{if isset($item.active)} bg-bg-elevated text-text-primary{/if}">
+            <span class="opacity-80">{$item.icon}</span>{$item.title}
+          </a>
+        {/if}
+      {/foreach}
+    </nav>
+
+    <div class="flex-1"></div>
+
+    {* Cmd+K trigger *}
+    <button class="nx-btn nx-btn--outline nx-btn--sm hidden md:inline-flex gap-2"
+            @click="$store.palette.open()" aria-label="Open command palette">
+      {include file='components/icon.tpl' name='search' size=14}
+      <span class="text-text-muted">Search…</span>
+      <span class="nx-kbd ml-2">⌘K</span>
+    </button>
+    <button class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm md:hidden"
+            @click="$store.palette.open()" aria-label="Search">
+      {include file='components/icon.tpl' name='search' size=18}
+    </button>
+
+    {* Theme toggle *}
+    <button class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm"
+            @click="$store.theme.toggle()"
+            :aria-label="$store.theme.current === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'">
+      <span x-show="$store.theme.current === 'dark'">{include file='components/icon.tpl' name='moon' size=18}</span>
+      <span x-show="$store.theme.current === 'light'" x-cloak>{include file='components/icon.tpl' name='sun' size=18}</span>
+    </button>
+
+    {* Right user section *}
+    <div class="hidden md:flex items-center gap-2">
+      {foreach from=$USER_SECTION key=name item=item}
+        {if isset($item.items)}
+          <div x-data="{ open: false }" class="relative">
+            <button class="nx-btn {if $name eq 'account'}nx-btn--ghost{else}nx-btn--ghost nx-btn--icon{/if} nx-btn--sm"
+                    @click="open = !open" @click.away="open = false"
+                    :aria-expanded="open" aria-haspopup="menu"
+                    id="button-{$name}">
+              <span class="opacity-80">{$item.icon}</span>
+              {if $name eq 'account'}<span class="hidden lg:inline">{$item.title}</span>{/if}
+            </button>
+            <div x-show="open" x-cloak x-transition
+                 class="nx-dropdown__panel right-0">
+              <div class="nx-dropdown__header">{$item.title}</div>
+              <div id="list-{$name}">
+                {foreach from=$item.items item=dropdown}
+                  {if isset($dropdown.separator)}
+                    <div class="nx-dropdown__divider"></div>
+                  {else}
+                    {if isset($dropdown.action)}
+                      <a class="nx-dropdown__item" href="#"
+                         data-link="{$dropdown.link}" data-action="{$dropdown.action}">
+                        <span class="opacity-80">{$dropdown.icon}</span>{$dropdown.title}
+                      </a>
+                    {else}
+                      <a class="nx-dropdown__item" href="{$dropdown.link}" target="{$dropdown.target}">
+                        <span class="opacity-80">{$dropdown.icon}</span>{$dropdown.title}
+                      </a>
+                    {/if}
+                  {/if}
+                {/foreach}
+              </div>
+              {if !empty($item.meta)}
+                <div class="nx-dropdown__divider"></div>
+                <a class="nx-dropdown__item text-text-muted" href="{$item.link}">{$item.meta}</a>
+              {/if}
+            </div>
+          </div>
+        {else}
+          {if $name eq 'panel'}
+            <a href="{$item.link}" target="{$item.target}" class="nx-btn nx-btn--primary nx-btn--icon nx-btn--sm" aria-label="{$item.title}">
+              <span>{$item.icon}</span>
+            </a>
+          {elseif $name eq 'register'}
+            <a href="{$item.link}" target="{$item.target}" class="nx-btn nx-btn--primary nx-btn--sm">{$item.title}</a>
+          {else}
+            <a href="{$item.link}" target="{$item.target}" class="nx-btn nx-btn--outline nx-btn--sm">{$item.title}</a>
+          {/if}
+        {/if}
+      {/foreach}
+    </div>
+  </div>
+</header>
+
+{* === Optional Hero / Server-Status (Minecraft) === *}
+{if isset($BANNER_IMAGE) || (isset($MINECRAFT) && isset($SERVER_QUERY))}
+<section class="relative overflow-hidden border-b border-border-subtle"
+         {if isset($BANNER_IMAGE)}style="background:linear-gradient(180deg, transparent, var(--bg-base)), url('{$BANNER_IMAGE}') center/cover"{/if}>
+  <div class="nx-container py-12 sm:py-16">
+    <div class="grid lg:grid-cols-2 gap-8 items-end">
+      <div>
+        <h1 class="font-display text-3xl sm:text-4xl font-bold tracking-tight text-text-primary">{$smarty.const.SITE_NAME}</h1>
+      </div>
+      {if isset($MINECRAFT) && isset($SERVER_QUERY)}
+        <div class="flex justify-start lg:justify-end">
+          <div class="nx-surface-elevated px-5 py-4 inline-flex items-center gap-4">
+            {include file='components/icon.tpl' name='server' size=20 class="text-accent"}
+            <div>
+              {if isset($SERVER_QUERY.status_value) && ($SERVER_QUERY.status_value == 1)}
+                <div class="text-text-primary text-sm font-medium">
+                  {if isset($SERVER_QUERY.status_full)}{$SERVER_QUERY.status_full}{else}{$SERVER_QUERY.x_players_online}{/if}
+                </div>
+              {else}
+                <div class="text-danger text-sm font-medium">{$SERVER_OFFLINE}</div>
+              {/if}
+              {if isset($CLICK_TO_COPY_TOOLTIP)}
+                <button class="text-text-muted text-xs hover:text-text-primary transition"
+                        onclick="copy('#ip')" data-tooltip="{$CLICK_TO_COPY_TOOLTIP}">{$CONNECT_WITH}</button>
+              {/if}
+            </div>
+          </div>
+        </div>
+      {/if}
+    </div>
+  </div>
+</section>
+{/if}
+
+{* === Main content opens here === *}
+<main id="nx-main" class="nx-container py-6 sm:py-8 lg:py-10 animate-fade-in">
+
+  {* IE warning — JS removes if not IE *}
+  <div class="nx-alert nx-alert--danger mb-4" id="ie-message">
+    {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+    <div>
+      <div class="nx-alert__title">{$INTERNET_EXPLORER_HEADER}</div>
+      <div class="nx-alert__body">{$INTERNET_EXPLORER_INFO}</div>
+    </div>
+  </div>
+
+  {if isset($NEW_UPDATE)}
+    <div class="nx-alert {if $NEW_UPDATE_URGENT eq true}nx-alert--danger{else}nx-alert--info{/if} mb-4" id="update-message">
+      {include file='components/icon.tpl' name='arrow-down' size=18 class="nx-alert__icon"}
+      <div class="flex-1">
+        <div class="nx-alert__title"><a href="{$NAMELESS_UPDATE_LINK}" class="hover:underline">{$NEW_UPDATE}</a></div>
+        <div class="nx-alert__body">
+          <span class="block">{$CURRENT_VERSION}</span>
+          <span class="block">{$NEW_VERSION}</span>
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  {if !empty($ANNOUNCEMENTS)}
+    {foreach from=$ANNOUNCEMENTS item=ANNOUNCEMENT}
+      <div class="nx-alert mb-4 animate-fade-in" id="announcement-{$ANNOUNCEMENT->id}"
+           style="background-color:{$ANNOUNCEMENT->background_colour};color:{$ANNOUNCEMENT->text_colour}">
+        {if $ANNOUNCEMENT->icon}<i class="{$ANNOUNCEMENT->icon} nx-alert__icon"></i>{/if}
+        <div class="flex-1">
+          <div class="nx-alert__title">{$ANNOUNCEMENT->header}</div>
+          <div class="nx-alert__body" style="color:inherit;opacity:.85">{$ANNOUNCEMENT->message|escape}</div>
+        </div>
+        {if $ANNOUNCEMENT->closable}
+          <button class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm" aria-label="Dismiss"
+                  onclick="this.parentElement.remove()">{include file='components/icon.tpl' name='close' size=14}</button>
+        {/if}
+      </div>
+    {/foreach}
+  {/if}
+
+  {if isset($MUST_VALIDATE_ACCOUNT)}
+    <div class="nx-alert nx-alert--warning mb-4">
+      {include file='components/icon.tpl' name='info' size=18 class="nx-alert__icon"}
+      <div class="nx-alert__body">{$MUST_VALIDATE_ACCOUNT}</div>
+    </div>
+  {/if}
+
+  {if isset($MAINTENANCE_ENABLED)}
+    <div class="nx-alert nx-alert--warning mb-4">
+      {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+      <div class="nx-alert__body">{$MAINTENANCE_ENABLED}</div>
+    </div>
+  {/if}
+
+  {if count($WIDGETS_TOP)}
+    <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
+      {foreach from=$WIDGETS_TOP item=widget}{$widget}{/foreach}
+    </div>
+  {/if}

--- a/custom/templates/Nexus/package.json
+++ b/custom/templates/Nexus/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "nexus-theme",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Nexus — AAA-grade UI/UX theme for NamelessMC",
+  "license": "MIT",
+  "scripts": {
+    "build:css": "tailwindcss -i ./src/styles/main.css -o ./assets/css/nexus.css --minify",
+    "build:js": "esbuild ./src/scripts/main.js --bundle --minify --format=iife --outfile=./assets/js/nexus.js",
+    "build": "npm run build:css && npm run build:js",
+    "dev:css": "tailwindcss -i ./src/styles/main.css -o ./assets/css/nexus.css --watch",
+    "dev:js": "esbuild ./src/scripts/main.js --bundle --format=iife --outfile=./assets/js/nexus.js --watch",
+    "dev": "npm-run-all --parallel dev:css dev:js"
+  },
+  "devDependencies": {
+    "@tailwindcss/forms": "^0.5.7",
+    "@tailwindcss/typography": "^0.5.10",
+    "alpinejs": "^3.13.5",
+    "autoprefixer": "^10.4.17",
+    "esbuild": "^0.20.0",
+    "npm-run-all": "^4.1.5",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.1"
+  }
+}

--- a/custom/templates/Nexus/portal.tpl
+++ b/custom/templates/Nexus/portal.tpl
@@ -1,0 +1,5 @@
+'Default Homepage' is set to 'Portal', which means NamelessMC renders the 'custom/templates/Nexus/portal.tpl' template file.<br>
+<br>
+This is a placeholder page, use this template for your own custom portal.<br>
+<br>
+<strong>To revert this change, go to <a href="{$GENERAL_SETTINGS_URL}">StaffCP &gt; Configuration &gt; General Settings</a> and change 'Default Homepage' to 'News'.</strong>

--- a/custom/templates/Nexus/postcss.config.js
+++ b/custom/templates/Nexus/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/custom/templates/Nexus/privacy.tpl
+++ b/custom/templates/Nexus/privacy.tpl
@@ -1,0 +1,11 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-3xl mx-auto">
+  <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6">{$PRIVACY_POLICY}</h1>
+  <div class="nx-surface p-6 sm:p-8 prose prose-invert max-w-none forum_post">
+    {$POLICY}
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/profile.tpl
+++ b/custom/templates/Nexus/profile.tpl
@@ -1,0 +1,395 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+{* === Profile hero with banner === *}
+<div class="nx-surface overflow-hidden mb-6">
+  <div class="relative h-44 sm:h-56 lg:h-64 bg-bg-elevated bg-cover bg-center"
+       {if isset($BANNER)}style="background-image:linear-gradient(180deg, transparent 0%, var(--bg-surface) 100%), url('{$BANNER}')"{/if}>
+    {if isset($LOGGED_IN)}
+      <div class="absolute top-3 right-3 flex gap-1.5">
+        {if isset($SELF)}
+          <a class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm bg-bg-overlay backdrop-blur" href="{$SETTINGS_LINK}" title="Settings">
+            {include file='components/icon.tpl' name='settings' size=16}
+          </a>
+          <button type="button" class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm bg-bg-overlay backdrop-blur"
+                  onclick="showBannerSelect()" title="Change banner">
+            {include file='components/icon.tpl' name='edit' size=16}
+          </button>
+        {else}
+          {if ($MOD_OR_ADMIN != true)}
+            <button class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm bg-bg-overlay backdrop-blur"
+                    @click="$store.modal.open('block')" title="Block">
+              {include file='components/icon.tpl' name='lock' size=16}
+            </button>
+          {/if}
+          <a class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm bg-bg-overlay backdrop-blur"
+             href="{$MESSAGE_LINK}" title="Message">
+            {include file='components/icon.tpl' name='mail' size=16}
+          </a>
+          {if isset($RESET_PROFILE_BANNER)}
+            <form action="{$RESET_PROFILE_BANNER_LINK}" method="post" class="inline">
+              <input type="hidden" name="token" value="{$TOKEN}" />
+              <button class="nx-btn nx-btn--ghost nx-btn--icon nx-btn--sm bg-bg-overlay backdrop-blur"
+                      title="{$RESET_PROFILE_BANNER}">
+                {include file='components/icon.tpl' name='trash' size=16}
+              </button>
+            </form>
+          {/if}
+        {/if}
+      </div>
+    {/if}
+  </div>
+
+  <div class="px-6 sm:px-8 pb-6 -mt-12 sm:-mt-16 relative">
+    <div class="flex flex-col sm:flex-row items-start sm:items-end gap-4 sm:gap-6">
+      <span class="nx-avatar nx-avatar--2xl ring-4 ring-bg-surface">
+        <img src="{$AVATAR}" alt="{$NICKNAME}" />
+      </span>
+      <div class="flex-1 min-w-0 sm:pb-3">
+        <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight">
+          <span {if $USERNAME_COLOUR != false}style="{$USERNAME_COLOUR}"{/if}>{$NICKNAME}</span>
+        </h1>
+        {if isset($USER_TITLE)}<p class="text-text-secondary text-sm mt-0.5">{$USER_TITLE}</p>{/if}
+        <div class="flex flex-wrap gap-1.5 mt-3">
+          {foreach from=$GROUPS item=group}{$group}{/foreach}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="grid gap-6
+            {if $CAN_VIEW && count($WIDGETS_LEFT) && count($WIDGETS_RIGHT)}lg:grid-cols-[18rem_minmax(0,1fr)_18rem]
+            {elseif $CAN_VIEW && (count($WIDGETS_LEFT) || count($WIDGETS_RIGHT))}lg:grid-cols-[18rem_minmax(0,1fr)]
+            {else}grid-cols-1{/if}">
+
+  {if $CAN_VIEW && count($WIDGETS_LEFT)}
+    <aside class="space-y-4 order-2 lg:order-1">{foreach from=$WIDGETS_LEFT item=widget}{$widget}{/foreach}</aside>
+  {/if}
+
+  <main class="order-1 lg:order-2 min-w-0">
+    {if isset($SUCCESS)}
+      <div class="nx-alert nx-alert--success mb-4">
+        {include file='components/icon.tpl' name='check' size=18 class="nx-alert__icon"}
+        <div><div class="nx-alert__title">{$SUCCESS_TITLE}</div><div class="nx-alert__body">{$SUCCESS}</div></div>
+      </div>
+    {/if}
+    {if isset($ERROR)}
+      <div class="nx-alert nx-alert--danger mb-4">
+        {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+        <div><div class="nx-alert__title">{$ERROR_TITLE}</div><div class="nx-alert__body">{$ERROR}</div></div>
+      </div>
+    {/if}
+
+    {if $CAN_VIEW}
+      <div class="nx-tabs mb-4">
+        <a class="nx-tab is-active" data-tab="feed">{$FEED}</a>
+        <a class="nx-tab" data-tab="about">{$ABOUT}</a>
+        {foreach from=$TABS key=key item=tab}<a class="nx-tab" data-tab="{$key}">{$tab.title}</a>{/foreach}
+      </div>
+
+      {* === Feed tab === *}
+      <div class="ui bottom attached tab active" data-tab="feed" id="profile-feed">
+        {if isset($LOGGED_IN) && $CAN_PROFILE_POST}
+          <form class="nx-surface p-4 mb-4 space-y-3" action="" method="post" id="form-profile-post">
+            <textarea name="post" placeholder="{$POST_ON_WALL}" class="nx-textarea"></textarea>
+            <input type="hidden" name="action" value="new_post">
+            <input type="hidden" name="token" value="{$TOKEN}">
+            <div class="flex justify-end">
+              <button type="submit" class="nx-btn nx-btn--primary nx-btn--sm">{$SUBMIT}</button>
+            </div>
+          </form>
+        {/if}
+
+        {if count($WALL_POSTS)}
+          <div class="space-y-3">
+            {foreach from=$WALL_POSTS item=post}
+              <article class="nx-surface p-4 sm:p-5" id="post-{$post.id}">
+                <div class="flex gap-3">
+                  <span class="nx-avatar nx-avatar--sm flex-shrink-0">
+                    <img src="{$post.avatar}" alt="{$post.nickname}" loading="lazy" />
+                  </span>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center flex-wrap gap-2 text-sm mb-1">
+                      <a href="{$post.profile}" data-poload="{$USER_INFO_URL}{$post.user_id}" style="{$post.user_style}"
+                         class="font-medium text-text-primary hover:text-accent transition">{$post.nickname}</a>
+                      <span class="text-text-muted text-xs" title="{$post.date}">{$post.date_rough}</span>
+                    </div>
+                    <div class="forum_post text-text-secondary">{$post.content}</div>
+
+                    {if ((isset($LOGGED_IN_USER) && $post.user_id != $USER_ID) || count($post.reactions))}
+                      <div class="flex items-center justify-between flex-wrap gap-2 mt-3 pt-3 border-t border-border-subtle" id="reactions">
+                        <div class="flex flex-wrap gap-1.5">
+                          {foreach from=$post.reactions item=reaction}
+                            <button class="nx-badge nx-badge--accent cursor-pointer"
+                                    onclick="openReactionModal({$post.id}, {$reaction.id})" title="{$reaction.name}">
+                              {$reaction.html} {$reaction.count}
+                            </button>
+                          {/foreach}
+                        </div>
+                        {if (isset($LOGGED_IN_USER) && $post.user_id != $USER_ID)}
+                          <div class="flex flex-wrap gap-1">
+                            {foreach from=$REACTIONS item=reaction}
+                              <button title="{$reaction->name}"
+                                      class="px-2 py-1 rounded-md hover:bg-bg-elevated transition {if array_key_exists($post.id, $REACTIONS_BY_USER) && in_array($reaction->id, $REACTIONS_BY_USER[$post.id])}bg-accent-subtle reaction-button-selected{else}reaction-button{/if}"
+                                      onclick="submitReaction({$post.id}, {$reaction->id});">
+                                {$reaction->html}
+                              </button>
+                            {/foreach}
+                          </div>
+                        {/if}
+                      </div>
+                    {/if}
+
+                    {if isset($LOGGED_IN_USER)}
+                      <div class="flex flex-wrap gap-3 mt-3 text-xs text-text-muted">
+                        {if $CAN_PROFILE_POST}
+                          <a class="hover:text-text-primary cursor-pointer" data-toggle="modal" data-target="#modal-reply-{$post.id}">
+                            {$REPLY}{if ($post.replies.count|regex_replace:'/[^0-9]+/':'' !=0)} ({$post.replies.count|regex_replace:'/[^0-9]+/':''}){/if}
+                          </a>
+                        {/if}
+                        {if (isset($CAN_MODERATE) && $CAN_MODERATE == 1) || $post.self == 1}
+                          <a class="hover:text-text-primary cursor-pointer" data-toggle="modal" data-target="#modal-edit-{$post.id}">{$EDIT}</a>
+                          <a class="hover:text-danger cursor-pointer" onclick="{literal}if(confirm(confirmDelete)){$('#form-delete-post-{/literal}{$post.id}{literal}').submit();}{/literal}">{$DELETE}</a>
+                          <form action="" method="post" id="form-delete-post-{$post.id}" class="hidden">
+                            <input type="hidden" name="post_id" value="{$post.id}">
+                            <input type="hidden" name="action" value="delete">
+                            <input type="hidden" name="token" value="{$TOKEN}">
+                          </form>
+                        {/if}
+                      </div>
+                    {/if}
+
+                    {if isset($post.replies.replies)}
+                      <ul class="space-y-2 mt-3 pl-4 border-l border-border-subtle">
+                        {foreach from=$post.replies.replies item=item}
+                          <li class="flex gap-2.5">
+                            <span class="nx-avatar nx-avatar--xs flex-shrink-0">
+                              <img src="{$item.avatar}" alt="{$item.nickname}" loading="lazy" />
+                            </span>
+                            <div class="flex-1 min-w-0">
+                              <div class="text-xs flex items-center flex-wrap gap-2">
+                                <a href="{$item.profile}" style="{$item.style}" class="font-medium text-text-primary hover:text-accent transition">{$item.nickname}</a>
+                                <span class="text-text-muted" title="{$item.time_full}">{$item.time_friendly}</span>
+                              </div>
+                              <div class="forum_post text-sm text-text-secondary mt-1">{$item.content}</div>
+                              {if (isset($CAN_MODERATE) && $CAN_MODERATE eq 1) || $post.self eq 1}
+                                <form class="hidden" action="" method="post" id="form-delete-{$item.id}">
+                                  <input type="hidden" name="action" value="deleteReply">
+                                  <input type="hidden" name="token" value="{$TOKEN}">
+                                  <input type="hidden" name="post_id" value="{$item.id}">
+                                </form>
+                                <a class="text-xs text-text-muted hover:text-danger cursor-pointer mt-1 inline-block"
+                                   onclick="{literal}if(confirm(confirmDelete)){$('#form-delete-{/literal}{$item.id}{literal}').submit();}{/literal}">
+                                  {$DELETE}
+                                </a>
+                              {/if}
+                            </div>
+                          </li>
+                        {/foreach}
+                      </ul>
+                    {/if}
+                  </div>
+                </div>
+              </article>
+            {/foreach}
+          </div>
+          <div class="mt-4">{$PAGINATION}</div>
+        {else}
+          <div class="nx-alert nx-alert--info">
+            {include file='components/icon.tpl' name='info' size=18 class="nx-alert__icon"}
+            <div class="nx-alert__body">{$NO_WALL_POSTS}</div>
+          </div>
+        {/if}
+      </div>
+
+      {* === About tab === *}
+      <div class="ui bottom attached tab" data-tab="about" id="profile-about">
+        <div class="nx-surface p-6">
+          <h3 class="font-display text-lg font-semibold mb-4">{$ABOUT}</h3>
+          <dl class="grid sm:grid-cols-2 gap-x-6 gap-y-4 text-sm">
+            <div class="flex items-start gap-3">
+              <span class="text-text-muted mt-0.5">{include file='components/icon.tpl' name='user' size=16}</span>
+              <div class="min-w-0">
+                <dt class="text-text-muted text-xs">{$ABOUT_FIELDS.registered.title|replace:':':''}</dt>
+                <dd class="text-text-primary">{$ABOUT_FIELDS.registered.value}</dd>
+              </div>
+            </div>
+            <div class="flex items-start gap-3">
+              <span class="text-text-muted mt-0.5">{include file='components/icon.tpl' name='clock' size=16}</span>
+              <div class="min-w-0">
+                <dt class="text-text-muted text-xs">{$ABOUT_FIELDS.last_seen.title|replace:':':''}</dt>
+                <dd class="text-text-primary">{$ABOUT_FIELDS.last_seen.value}</dd>
+              </div>
+            </div>
+            <div class="flex items-start gap-3">
+              <span class="text-text-muted mt-0.5">{include file='components/icon.tpl' name='eye' size=16}</span>
+              <div class="min-w-0">
+                <dt class="text-text-muted text-xs">{$ABOUT_FIELDS.profile_views.title|replace:':':''}</dt>
+                <dd class="text-text-primary">{$ABOUT_FIELDS.profile_views.value}</dd>
+              </div>
+            </div>
+            {foreach from=$ABOUT_FIELDS key=key item=field}
+              {if is_numeric($key)}
+                <div class="flex items-start gap-3">
+                  <span class="text-text-muted mt-0.5">{include file='components/icon.tpl' name='tag' size=16}</span>
+                  <div class="min-w-0">
+                    <dt class="text-text-muted text-xs">{$field.title}</dt>
+                    <dd class="text-text-primary">{$field.value}</dd>
+                  </div>
+                </div>
+              {/if}
+            {/foreach}
+          </dl>
+        </div>
+      </div>
+
+      {foreach from=$TABS key=key item=tab}
+        <div class="ui bottom attached tab" data-tab="{$key}" id="profile-{$key}">
+          <div class="nx-surface p-6">{include file=$tab.include}</div>
+        </div>
+      {/foreach}
+    {elseif isset($BLOCKED)}
+      <div class="nx-alert nx-alert--danger">
+        {include file='components/icon.tpl' name='lock' size=18 class="nx-alert__icon"}
+        <div class="nx-alert__body">{$BLOCKED}</div>
+      </div>
+    {else}
+      <div class="nx-alert nx-alert--danger">
+        {include file='components/icon.tpl' name='lock' size=18 class="nx-alert__icon"}
+        <div class="nx-alert__body">{$PRIVATE_PROFILE}</div>
+      </div>
+    {/if}
+  </main>
+
+  {if $CAN_VIEW && count($WIDGETS_RIGHT)}
+    <aside class="space-y-4 order-3">{foreach from=$WIDGETS_RIGHT item=widget}{$widget}{/foreach}</aside>
+  {/if}
+</div>
+
+{* === Legacy modals (preserved class hooks so Fomantic JS still wires them) === *}
+{if count($WALL_POSTS)}
+  <div class="ui small modal" id="modal-reactions">
+    <i class="close icon"></i>
+    <div class="header">{$REACTIONS_TEXT}</div>
+    <div class="scrolling content"></div>
+  </div>
+
+  {foreach from=$WALL_POSTS item=post}
+    {if (isset($CAN_MODERATE) && $CAN_MODERATE eq 1) || $post.self eq 1}
+      <div class="ui small modal" id="modal-edit-{$post.id}">
+        <div class="header">{$EDIT_POST}</div>
+        <div class="content">
+          <form action="" method="post" id="form-edit-{$post.id}">
+            <textarea name="content" class="nx-textarea">{$post.content}</textarea>
+            <input type="hidden" name="token" value="{$TOKEN}">
+            <input type="hidden" name="post_id" value="{$post.id}">
+            <input type="hidden" name="action" value="edit">
+          </form>
+        </div>
+        <div class="actions">
+          <a class="ui negative button">{$CANCEL}</a>
+          <a class="ui positive button" onclick="$('#form-edit-{$post.id}').submit();">{$SUBMIT}</a>
+        </div>
+      </div>
+    {/if}
+    {if isset($LOGGED_IN_USER)}
+      <div class="ui small modal" id="modal-reply-{$post.id}">
+        <div class="header">{$REPLY}</div>
+        <div class="content">
+          <form action="" method="post" id="form-reply-{$post.id}">
+            <textarea name="reply" placeholder="{$NEW_REPLY}" class="nx-textarea"></textarea>
+            <input type="hidden" name="token" value="{$TOKEN}">
+            <input type="hidden" name="post" value="{$post.id}">
+            <input type="hidden" name="action" value="reply">
+          </form>
+        </div>
+        <div class="actions">
+          <a class="ui negative button">{$CANCEL}</a>
+          <a class="ui positive button" onclick="$('#form-reply-{$post.id}').submit();">{$SUBMIT}</a>
+        </div>
+      </div>
+    {/if}
+  {/foreach}
+{/if}
+
+{if isset($LOGGED_IN_USER)}
+  {if !isset($SELF) && $MOD_OR_ADMIN != true}
+    <div class="ui small modal" id="modal-block">
+      <div class="header">{if isset($BLOCK_USER)}{$BLOCK_USER}{else}{$UNBLOCK_USER}{/if}</div>
+      <div class="content">
+        {if isset($CONFIRM_BLOCK_USER)}{$CONFIRM_BLOCK_USER}{else}{$CONFIRM_UNBLOCK_USER}{/if}
+        <form action="" method="post" id="form-block">
+          <input type="hidden" name="token" value="{$TOKEN}">
+          <input type="hidden" name="action" value="block">
+        </form>
+      </div>
+      <div class="actions">
+        <a class="ui negative button">{$CANCEL}</a>
+        <a class="ui positive button" onclick="$('#form-block').submit();">{$SUBMIT}</a>
+      </div>
+    </div>
+  {/if}
+  {if isset($SELF)}
+    <div class="ui small modal" id="imageModal">
+      <div class="header">{$CHANGE_BANNER}</div>
+      <div class="content">
+        <form action="" name="updateBanner" method="post">
+          <select name="banner" class="image-picker show-html">
+            {foreach from=$BANNERS item=banner}
+              <option data-img-src="{$banner.src}" value="{$banner.name}" {if $banner.active==true} selected{/if}>{$banner.name}</option>
+            {/foreach}
+          </select>
+          <input type="hidden" name="token" value="{$TOKEN}">
+          <input type="hidden" name="action" value="banner">
+        </form>
+        {if isset($PROFILE_BANNER)}
+          <div class="nx-divider">Or {$UPLOAD_PROFILE_BANNER}</div>
+          <form action="{$UPLOAD_BANNER_URL}" method="post" enctype="multipart/form-data" id="form-banner" class="flex gap-2">
+            <input type="file" class="inputFile" name="file" id="uploadBannerInput" hidden />
+            <label class="nx-btn nx-btn--outline" for="uploadBannerInput">
+              {include file='components/icon.tpl' name='arrow-up' size=14} {$BROWSE}
+            </label>
+            <input type="hidden" name="token" value="{$TOKEN}">
+            <input type="hidden" name="type" value="profile_banner">
+            <button type="submit" class="nx-btn nx-btn--primary">{$UPLOAD}</button>
+          </form>
+        {/if}
+      </div>
+      <div class="actions">
+        <button class="ui negative button">{$CANCEL}</button>
+        <button class="ui positive button" onclick="document.updateBanner.submit()">{$SUBMIT}</button>
+      </div>
+    </div>
+  {/if}
+{/if}
+
+<script>
+  const submitReaction = (post_id, reaction_id) => {
+    $.post("{$REACTIONS_URL}", { token: "{$TOKEN}", reactable_id: post_id, context: 'profile_post', reaction_id })
+      .done((r) => { if (r.startsWith('Reaction ')) { window.location.replace(window.location.href.replace(/#.*$/, '') + '#post-' + post_id); window.location.reload(); } else console.error(r); })
+      .fail(console.error);
+  };
+  const openReactionModal = (post_id, reaction_id) => {
+    const modal = $('#modal-reactions'); modal.modal('show');
+    modal.find('.content').html('<div class="text-center py-4"><span class="nx-spinner inline-block"></span></div>');
+    $.get("{$REACTIONS_URL}", { reactable_id: post_id, context: 'profile_post', tab: reaction_id })
+      .done((r) => modal.find('.content').html(r))
+      .fail(console.error);
+  };
+
+  // Tabs (Fomantic-like data-tab)
+  document.querySelectorAll('.nx-tabs .nx-tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      const key = tab.dataset.tab;
+      tab.parentElement.querySelectorAll('.nx-tab').forEach(t => t.classList.remove('is-active'));
+      tab.classList.add('is-active');
+      document.querySelectorAll('[data-tab]').forEach(el => {
+        if (el.classList.contains('nx-tab')) return;
+        el.classList.toggle('active', el.dataset.tab === key);
+      });
+    });
+  });
+</script>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/reactions_modal.tpl
+++ b/custom/templates/Nexus/reactions_modal.tpl
@@ -1,0 +1,35 @@
+{*
+ *  Nexus · Reactions modal (injected via $.get into legacy .ui.modal container)
+ *  Keeps the tab/menu DOM contract because forum/profile JS reaches in.
+*}
+<div class="ui menu mb-4">
+  {foreach from=$REACTIONS item=reaction}
+    <a class="{if $ACTIVE_TAB == $reaction.id}active {/if}item nx-btn nx-btn--ghost nx-btn--sm" data-tab="{$reaction.id}">
+      {if $reaction.id != 0}{$reaction.html} <span class="mx-1"></span>{/if}{$reaction.name}
+      <span class="nx-badge ml-1">{$reaction.count}</span>
+    </a>
+  {/foreach}
+</div>
+
+{foreach from=$REACTIONS item=reaction}
+  <div class="ui bottom attached tab {if $ACTIVE_TAB == $reaction.id}active{/if}" data-tab="{$reaction.id}">
+    <ul class="divide-y divide-border-subtle">
+      {foreach from=$reaction.users item=user}
+        <li class="flex items-center gap-3 px-2 py-3 hover:bg-bg-elevated rounded-md cursor-pointer"
+            onclick="window.location.href='{$user.profile}'">
+          <span class="nx-avatar nx-avatar--sm"><img src="{$user.avatar}" alt="{$user.nickname}" loading="lazy" /></span>
+          <span class="flex-1 min-w-0">
+            <span class="block text-text-primary font-medium truncate" style="{$user.group_style}">
+              {$user.nickname}
+              {foreach from=$user.group_html item=group_html}{$group_html}{/foreach}
+            </span>
+            <span class="block text-xs text-text-muted">{$user.reacted_time}</span>
+          </span>
+          {if $reaction.id == 0}<span class="text-lg">{$user.reaction_html}</span>{/if}
+        </li>
+      {/foreach}
+    </ul>
+  </div>
+{/foreach}
+
+<script>$('.menu .item').tab();</script>

--- a/custom/templates/Nexus/register.tpl
+++ b/custom/templates/Nexus/register.tpl
@@ -1,0 +1,135 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-2xl mx-auto">
+  <header class="mb-6">
+    <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight">{$CREATE_AN_ACCOUNT}</h1>
+    {if $OAUTH_FLOW}<p class="text-text-secondary mt-2">{$OAUTH_MESSAGE_CONTINUE}</p>{/if}
+  </header>
+
+  {if isset($REGISTRATION_ERROR)}
+    <div class="nx-alert nx-alert--danger mb-5">
+      {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+      <div class="flex-1">
+        <div class="nx-alert__title">{$ERROR_TITLE}</div>
+        <ul class="nx-alert__body list-disc pl-4 space-y-0.5">
+          {foreach from=$REGISTRATION_ERROR item=error}<li>{$error}</li>{/foreach}
+        </ul>
+      </div>
+    </div>
+  {/if}
+
+  <div class="nx-surface p-6 sm:p-8">
+    <form class="space-y-4" action="" method="post" id="form-register">
+
+      {assign var=counter value=1}
+      {foreach $FIELDS as $field_key => $field}
+        <div class="nx-field">
+          {if $field.type neq 8 && $field.type neq 9}
+            <label class="nx-label" for="{$field_key}">{$field.name}{if $field.required}<span class="nx-required">*</span>{/if}</label>
+          {/if}
+
+          {if $field.type eq 1}
+            <input type="text" name="{$field_key}" id="{$field_key}" value="{$field.value}" placeholder="{$field.placeholder}" tabindex="{$counter++}" {if $field.required}required{/if} class="nx-input" />
+          {else if $field.type eq 2}
+            <textarea name="{$field_key}" id="{$field_key}" placeholder="{$field.placeholder}" tabindex="{$counter++}" class="nx-textarea"></textarea>
+          {else if $field.type eq 3}
+            <input type="date" name="{$field_key}" id="{$field_key}" value="{$field.value}" tabindex="{$counter++}" class="nx-input" />
+          {else if $field.type eq 4}
+            <input type="password" name="{$field_key}" id="{$field_key}" value="{$field.value}" placeholder="{$field.placeholder}" tabindex="{$counter++}" {if $field.required}required{/if} class="nx-input" autocomplete="new-password" />
+          {else if $field.type eq 5}
+            <select class="nx-select" name="{$field_key}" id="{$field_key}" {if $field.required}required{/if}>
+              {foreach from=$field.options item=option}
+                <option value="{$option.value}" {if $option.value eq $field.value} selected{/if}>{$option.option}</option>
+              {/foreach}
+            </select>
+          {else if $field.type eq 6}
+            <input type="number" name="{$field_key}" id="{$field_key}" value="{$field.value}" placeholder="{$field.name}" tabindex="{$counter++}" {if $field.required}required{/if} class="nx-input" />
+          {else if $field.type eq 7}
+            <input type="email" name="{$field_key}" id="{$field_key}" value="{$field.value}" placeholder="{$field.placeholder}" tabindex="{$counter++}" {if $field.required}required{/if} class="nx-input" autocomplete="email" />
+          {else if $field.type eq 8}
+            <fieldset class="space-y-2">
+              <legend class="nx-label mb-1">{$field.name}{if $field.required}<span class="nx-required">*</span>{/if}</legend>
+              {foreach from=$field.options item=option}
+                <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer mr-4">
+                  <input type="radio" name="{$field_key}" value="{$option.value}" {if $field.value eq $option.value}checked{/if} {if $field.required}required{/if} tabindex="{$counter++}" class="nx-radio" />
+                  {$option.option}
+                </label>
+              {/foreach}
+            </fieldset>
+          {else if $field.type eq 9}
+            <fieldset class="space-y-2">
+              <legend class="nx-label mb-1">{$field.name}{if $field.required}<span class="nx-required">*</span>{/if}</legend>
+              {foreach from=$field.options item=option}
+                <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer mr-4">
+                  <input type="checkbox" name="{$field_key}[]" value="{$option.value}"
+                         {if is_array($field.value) && in_array($option.value, $field.value)}checked{/if}
+                         tabindex="{$counter++}" class="nx-checkbox" />
+                  {$option.option}
+                </label>
+              {/foreach}
+            </fieldset>
+          {/if}
+        </div>
+      {/foreach}
+
+      {if $CAPTCHA}<div class="nx-field">{$CAPTCHA}</div>{/if}
+
+      <label class="inline-flex items-start gap-2 cursor-pointer text-sm text-text-secondary">
+        <input type="checkbox" name="t_and_c" id="t_and_c" value="1" tabindex="7" class="nx-checkbox mt-0.5" />
+        <span>{$AGREE_TO_TERMS}</span>
+      </label>
+
+      <input type="hidden" name="token" value="{$TOKEN}">
+      <input id="timezone" type="hidden" name="timezone" value="">
+
+      <div class="flex flex-wrap gap-2 pt-2">
+        <button type="submit" class="nx-btn nx-btn--primary nx-btn--lg flex-1 sm:flex-initial" tabindex="8">{$REGISTER}</button>
+        {if $OAUTH_FLOW}
+          <a class="nx-btn nx-btn--outline nx-btn--lg" href="{$OAUTH_CANCEL_REGISTER_URL}">{$CANCEL}</a>
+        {/if}
+      </div>
+    </form>
+
+    {if $OAUTH_AVAILABLE and !$OAUTH_FLOW}
+      <div class="nx-divider">{$OR}</div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {foreach $OAUTH_PROVIDERS as $name => $meta}
+          <a href="{$meta.url}" class="nx-btn nx-btn--outline gap-2" {if $meta.button_css}style="{$meta.button_css}"{/if}>
+            {if $meta.logo_url}<img src="{$meta.logo_url}" {if $meta.logo_css}style="{$meta.logo_css}"{/if} alt="{$name|ucfirst}" class="w-4 h-4" />
+            {elseif $meta.icon}<i class="{$meta.icon}"></i>{/if}
+            <span {if $meta.text_css}style="{$meta.text_css}"{/if}>{$meta.continue_with}</span>
+          </a>
+        {/foreach}
+      </div>
+    {/if}
+
+    {if !$OAUTH_FLOW}
+      <div class="nx-divider">{$ALREADY_REGISTERED}</div>
+      <a href="{$LOGIN_URL}" class="nx-btn nx-btn--outline nx-btn--block">{$LOG_IN}</a>
+    {/if}
+  </div>
+</div>
+
+{if $OAUTH_FLOW && $OAUTH_EMAIL_VERIFIED}
+<script>
+  document.getElementById('email')?.addEventListener('keyup', (e) => checkEmailValidity(e.target.value));
+  const checkEmailValidity = (email) => {
+    const old = document.getElementById('email-caption'); if (old) old.remove();
+    const note = document.createElement('div');
+    note.id = 'email-caption';
+    note.className = 'nx-help-text mt-1';
+    if ('{$OAUTH_EMAIL_VERIFIED}' && email !== '{$OAUTH_EMAIL_ORIGINAL}') {
+      note.textContent = '{$OAUTH_EMAIL_NOT_VERIFIED_MESSAGE}';
+      note.style.color = 'var(--warning)';
+    } else {
+      note.textContent = '{$OAUTH_EMAIL_VERIFIED_MESSAGE}';
+      note.style.color = 'var(--success)';
+    }
+    document.getElementById('email')?.parentElement.appendChild(note);
+  };
+  window.addEventListener('load', () => checkEmailValidity('{$EMAIL_INPUT}'));
+</script>
+{/if}
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/registration_disabled.tpl
+++ b/custom/templates/Nexus/registration_disabled.tpl
@@ -1,0 +1,12 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-md mx-auto text-center">
+  <div class="inline-flex items-center justify-center w-14 h-14 rounded-xl bg-warning/15 text-warning mb-4">
+    {include file='components/icon.tpl' name='lock' size=26}
+  </div>
+  <h1 class="font-display text-2xl font-bold tracking-tight mb-2">{$CREATE_AN_ACCOUNT}</h1>
+  <p class="text-text-secondary text-sm">{$REGISTRATION_DISABLED}</p>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/src/scripts/main.js
+++ b/custom/templates/Nexus/src/scripts/main.js
@@ -1,0 +1,209 @@
+/* ================================================================
+ * Nexus · Client Bundle
+ *
+ * Alpine.js + theme management + command palette + helpers.
+ * Coexists with jQuery (window.$) and any legacy module scripts.
+ * Loaded with `defer` by NamelessMC's asset resolver.
+ * ================================================================ */
+
+import Alpine from 'alpinejs';
+
+/* ----------------------------------------------------------------
+ * 1. Theme management (Dark / Light, persisted to localStorage)
+ *    Sets data-theme="dark|light" on <html>.
+ *    Default = "dark" (Nexus is dark-first).
+ *    Honors prefers-color-scheme only on first visit.
+ * ---------------------------------------------------------------- */
+const THEME_KEY = 'nexus.theme';
+
+function getInitialTheme() {
+  try {
+    const stored = localStorage.getItem(THEME_KEY);
+    if (stored === 'dark' || stored === 'light') return stored;
+  } catch { /* SSR-ish guard */ }
+  return 'dark';
+}
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-theme', theme);
+  try { localStorage.setItem(THEME_KEY, theme); } catch {}
+}
+
+// Apply immediately to avoid FOUC (header.tpl also has an inline pre-paint script)
+applyTheme(getInitialTheme());
+
+/* ----------------------------------------------------------------
+ * 2. Alpine global stores
+ * ---------------------------------------------------------------- */
+document.addEventListener('alpine:init', () => {
+  /** theme store */
+  Alpine.store('theme', {
+    current: getInitialTheme(),
+    init() { applyTheme(this.current); },
+    toggle() {
+      this.current = this.current === 'dark' ? 'light' : 'dark';
+      applyTheme(this.current);
+    },
+    set(theme) {
+      if (theme !== 'dark' && theme !== 'light') return;
+      this.current = theme;
+      applyTheme(theme);
+    },
+  });
+
+  /** toast store: push/dismiss notifications */
+  Alpine.store('toast', {
+    items: [],
+    push({ title = '', body = '', variant = 'default', timeout = 4000 } = {}) {
+      const id = Math.random().toString(36).slice(2);
+      this.items.push({ id, title, body, variant });
+      if (timeout > 0) setTimeout(() => this.dismiss(id), timeout);
+    },
+    dismiss(id) {
+      this.items = this.items.filter((t) => t.id !== id);
+    },
+  });
+
+  /** modal store: simple registry, lets any element open/close by name */
+  Alpine.store('modal', {
+    active: null,
+    open(name)  { this.active = name; document.body.style.overflow = 'hidden'; },
+    close()     { this.active = null; document.body.style.overflow = ''; },
+    is(name)    { return this.active === name; },
+  });
+
+  /** mobile-nav store */
+  Alpine.store('mobileNav', {
+    open: false,
+    toggle() { this.open = !this.open; document.body.style.overflow = this.open ? 'hidden' : ''; },
+    close()  { this.open = false; document.body.style.overflow = ''; },
+  });
+
+  /** command palette store: holds items and visibility */
+  Alpine.store('palette', {
+    visible: false,
+    query: '',
+    items: [],
+    activeIndex: 0,
+    open() { this.visible = true; this.query = ''; this.activeIndex = 0;
+             this.$nextTick = () => requestAnimationFrame(() => document.getElementById('nx-palette-input')?.focus()); this.$nextTick(); },
+    close() { this.visible = false; },
+    register(items) { this.items = items; },
+    get filtered() {
+      const q = this.query.trim().toLowerCase();
+      if (!q) return this.items;
+      return this.items
+        .map((item) => ({
+          item,
+          score: scoreFuzzy(`${item.title} ${item.section || ''} ${item.keywords?.join(' ') || ''}`.toLowerCase(), q),
+        }))
+        .filter((x) => x.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .map((x) => x.item);
+    },
+    move(delta) {
+      const total = this.filtered.length;
+      if (!total) return;
+      this.activeIndex = (this.activeIndex + delta + total) % total;
+    },
+    activate() {
+      const item = this.filtered[this.activeIndex];
+      if (item?.href) window.location.href = item.href;
+      else if (item?.action) item.action();
+    },
+  });
+});
+
+function scoreFuzzy(haystack, needle) {
+  if (!needle) return 1;
+  if (haystack.includes(needle)) return 10 + needle.length;
+  // simple subsequence scoring
+  let i = 0, score = 0;
+  for (const ch of haystack) {
+    if (ch === needle[i]) { score += 1; i++; if (i === needle.length) return score; }
+  }
+  return i === needle.length ? score : 0;
+}
+
+/* ----------------------------------------------------------------
+ * 3. Custom Alpine directives
+ * ---------------------------------------------------------------- */
+document.addEventListener('alpine:init', () => {
+  /** x-tooltip="Some text"  — lightweight title fallback */
+  Alpine.directive('tooltip', (el, { expression }) => {
+    el.setAttribute('title', expression.replace(/^['"]|['"]$/g, ''));
+    el.dataset.nxTooltip = '1';
+  });
+
+  /** x-clipboard="value"  — copies value to clipboard, dispatches toast */
+  Alpine.directive('clipboard', (el, { expression }, { evaluate }) => {
+    el.addEventListener('click', async (e) => {
+      e.preventDefault();
+      let value = '';
+      try { value = evaluate(expression); }
+      catch { value = expression; }
+      try {
+        await navigator.clipboard.writeText(String(value));
+        Alpine.store('toast').push({
+          title: typeof window.copied === 'string' ? window.copied : 'Copied',
+          variant: 'success',
+          timeout: 1800,
+        });
+      } catch { /* clipboard blocked */ }
+    });
+  });
+});
+
+/* ----------------------------------------------------------------
+ * 4. Global keyboard shortcuts
+ * ---------------------------------------------------------------- */
+window.addEventListener('keydown', (e) => {
+  // Strg/Cmd + K opens command palette
+  if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+    e.preventDefault();
+    Alpine.store('palette').open();
+    return;
+  }
+  // Escape closes palette / modal / mobile nav
+  if (e.key === 'Escape') {
+    if (Alpine.store('palette')?.visible) Alpine.store('palette').close();
+    else if (Alpine.store('modal')?.active) Alpine.store('modal').close();
+    else if (Alpine.store('mobileNav')?.open) Alpine.store('mobileNav').close();
+  }
+});
+
+/* ----------------------------------------------------------------
+ * 5. Loading-time display (matches DefaultRevamp contract)
+ *    `loadingTime` is set as a global const by template.php inline JS.
+ * ---------------------------------------------------------------- */
+document.addEventListener('DOMContentLoaded', () => {
+  const el = document.getElementById('page_load');
+  if (el && typeof window.loadingTime === 'string') el.textContent = window.loadingTime;
+});
+
+/* ----------------------------------------------------------------
+ * 6. IE-warning hide if browser is modern
+ * ---------------------------------------------------------------- */
+document.addEventListener('DOMContentLoaded', () => {
+  const ieMsg = document.getElementById('ie-message');
+  if (ieMsg && !document.documentMode) ieMsg.remove();
+});
+
+/* ----------------------------------------------------------------
+ * 7. Smart link-active marker
+ *    Anchor with [data-nav-key] gets .is-active when its key matches
+ *    the page slug we expose via window.page (set by template.php).
+ * ---------------------------------------------------------------- */
+document.addEventListener('DOMContentLoaded', () => {
+  const page = window.page;
+  if (!page) return;
+  document.querySelectorAll('[data-nav-key]').forEach((el) => {
+    if (el.dataset.navKey === page) el.classList.add('is-active');
+  });
+});
+
+/* ----------------------------------------------------------------
+ * 8. Boot Alpine
+ * ---------------------------------------------------------------- */
+window.Alpine = Alpine;
+Alpine.start();

--- a/custom/templates/Nexus/src/styles/base.css
+++ b/custom/templates/Nexus/src/styles/base.css
@@ -1,0 +1,181 @@
+/* ================================================================
+ * Nexus · Base layer
+ * Resets, type, focus, scrollbar, body background.
+ * Intentionally LIGHT — Tailwind preflight handles the heavy reset.
+ * ================================================================ */
+
+@layer base {
+  html {
+    -webkit-text-size-adjust: 100%;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    scroll-behavior: smooth;
+    color-scheme: dark;
+  }
+
+  [data-theme="light"] {
+    color-scheme: light;
+  }
+
+  body {
+    background: var(--bg-base);
+    color: var(--text-primary);
+    font-family: var(--font-sans);
+    font-feature-settings: "ss01", "cv11", "calt";
+    line-height: 1.5;
+    min-height: 100dvh;
+  }
+
+  /* Ambient gradient mesh on body — extremely subtle, dark mode only */
+  body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background:
+      radial-gradient(60% 50% at 50% 0%, var(--accent-subtle) 0%, transparent 70%),
+      radial-gradient(40% 30% at 90% 10%, color-mix(in oklab, var(--info) 18%, transparent) 0%, transparent 70%),
+      radial-gradient(40% 30% at 5% 60%, color-mix(in oklab, var(--accent) 14%, transparent) 0%, transparent 70%);
+    opacity: .7;
+  }
+
+  [data-theme="light"] body::before {
+    opacity: .35;
+  }
+
+  /* Headings */
+  h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-display);
+    color: var(--text-primary);
+    letter-spacing: -0.015em;
+    font-weight: 600;
+    line-height: 1.15;
+  }
+
+  h1 { font-size: clamp(2rem, 4vw, 3rem); letter-spacing: -0.03em; font-weight: 700; }
+  h2 { font-size: clamp(1.625rem, 2.6vw, 2.125rem); letter-spacing: -0.02em; }
+  h3 { font-size: clamp(1.25rem, 1.8vw, 1.5rem); }
+  h4 { font-size: 1.125rem; }
+  h5 { font-size: 1rem; }
+  h6 { font-size: .875rem; text-transform: uppercase; letter-spacing: .08em; color: var(--text-secondary); }
+
+  /* Links */
+  a {
+    color: var(--text-primary);
+    text-decoration: none;
+    transition: color var(--dur-fast) var(--ease-out);
+  }
+
+  a:hover { color: var(--accent-hover); }
+
+  /* Universal focus ring */
+  :where(a, button, [role="button"], input, select, textarea, [tabindex]):focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: var(--r-xs);
+  }
+
+  /* Selection */
+  ::selection {
+    background: var(--accent);
+    color: var(--accent-fg);
+  }
+
+  /* Scrollbar (WebKit + Firefox) */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--border-strong) transparent;
+  }
+  *::-webkit-scrollbar { width: 10px; height: 10px; }
+  *::-webkit-scrollbar-track { background: transparent; }
+  *::-webkit-scrollbar-thumb {
+    background: var(--border-default);
+    border-radius: var(--r-full, 9999px);
+    border: 2px solid var(--bg-base);
+  }
+  *::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+
+  /* Code */
+  code, pre, kbd, samp {
+    font-family: var(--font-mono);
+    font-size: .9em;
+  }
+
+  code {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    padding: 0.1em 0.4em;
+    border-radius: var(--r-xs);
+  }
+
+  pre {
+    background: var(--bg-inset);
+    border: 1px solid var(--border-default);
+    padding: 1rem 1.25rem;
+    border-radius: var(--r-md);
+    overflow-x: auto;
+  }
+
+  pre code {
+    background: transparent;
+    border: 0;
+    padding: 0;
+  }
+
+  kbd {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-strong);
+    border-bottom-width: 2px;
+    border-radius: var(--r-xs);
+    padding: 0.1em 0.4em;
+    font-size: .8em;
+    color: var(--text-secondary);
+  }
+
+  /* HR */
+  hr {
+    border: 0;
+    border-top: 1px solid var(--border-default);
+    margin: 1.5rem 0;
+  }
+
+  /* Tables (fallback when not using nx-table component) */
+  table {
+    border-collapse: collapse;
+    width: 100%;
+  }
+  th, td {
+    text-align: left;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  th {
+    font-weight: 500;
+    color: var(--text-secondary);
+    background: var(--bg-surface);
+  }
+
+  /* Images don't ruin layout */
+  img, video {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* Skip link for a11y */
+  .skip-link {
+    position: absolute;
+    left: -9999px;
+    top: 0;
+    z-index: 9999;
+  }
+  .skip-link:focus {
+    left: 1rem;
+    top: 1rem;
+    padding: 0.5rem 1rem;
+    background: var(--accent);
+    color: var(--accent-fg);
+    border-radius: var(--r-sm);
+  }
+}

--- a/custom/templates/Nexus/src/styles/components.css
+++ b/custom/templates/Nexus/src/styles/components.css
@@ -1,0 +1,656 @@
+/* ================================================================
+ * Nexus · Component layer
+ * Reusable component classes prefixed with .nx-
+ * These compile via @apply so Tailwind utilities are the building blocks.
+ * ================================================================ */
+
+@layer components {
+
+  /* ============ Container ============ */
+  .nx-container {
+    @apply mx-auto w-full max-w-[var(--content-max)] px-4 sm:px-6 lg:px-8;
+  }
+
+  /* ============ Surfaces ============ */
+  .nx-surface {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-lg);
+    box-shadow: var(--shadow-sm), var(--shadow-inset);
+  }
+
+  .nx-surface-elevated {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-lg);
+    box-shadow: var(--shadow-md), var(--shadow-inset);
+  }
+
+  /* ============ Card ============ */
+  .nx-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-lg);
+    box-shadow: var(--shadow-sm), var(--shadow-inset);
+    transition: transform var(--dur-base) var(--ease-out),
+                box-shadow var(--dur-base) var(--ease-out),
+                border-color var(--dur-base) var(--ease-out);
+    overflow: hidden;
+  }
+  .nx-card--interactive { cursor: pointer; }
+  .nx-card--interactive:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg), var(--shadow-inset);
+    border-color: var(--border-strong);
+  }
+  .nx-card--glow:hover {
+    box-shadow: var(--shadow-glow);
+  }
+
+  .nx-card__header {
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .nx-card__body { padding: 1.5rem; }
+  .nx-card__footer {
+    padding: 1rem 1.5rem;
+    border-top: 1px solid var(--border-subtle);
+    background: var(--bg-inset);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+  .nx-card__title {
+    font-family: var(--font-display);
+    font-size: 1.0625rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--text-primary);
+  }
+  .nx-card__meta { color: var(--text-muted); font-size: .8125rem; }
+
+  /* ============ Button ============ */
+  .nx-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    height: 38px;
+    padding: 0 0.875rem;
+    font-family: var(--font-sans);
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1;
+    border-radius: var(--r-sm);
+    border: 1px solid transparent;
+    color: var(--text-primary);
+    background: var(--bg-elevated);
+    cursor: pointer;
+    user-select: none;
+    transition:
+      background var(--dur-fast) var(--ease-out),
+      border-color var(--dur-fast) var(--ease-out),
+      transform var(--dur-fast) var(--ease-out),
+      box-shadow var(--dur-fast) var(--ease-out),
+      color var(--dur-fast) var(--ease-out);
+    white-space: nowrap;
+  }
+  .nx-btn:hover { background: color-mix(in oklab, var(--bg-elevated) 70%, var(--text-primary) 4%); }
+  .nx-btn:active { transform: scale(.98); }
+  .nx-btn:disabled, .nx-btn[aria-disabled="true"] { opacity: .55; cursor: not-allowed; transform: none; }
+
+  .nx-btn--primary {
+    background: var(--accent);
+    color: var(--accent-fg);
+    border-color: color-mix(in oklab, var(--accent) 70%, white 10%);
+    box-shadow: 0 1px 0 rgba(255,255,255,.08) inset, 0 1px 2px rgba(0,0,0,.4);
+  }
+  .nx-btn--primary:hover { background: var(--accent-hover); }
+  .nx-btn--primary:focus-visible { box-shadow: 0 0 0 3px var(--accent-glow); }
+
+  .nx-btn--ghost {
+    background: transparent;
+    color: var(--text-secondary);
+    border-color: transparent;
+  }
+  .nx-btn--ghost:hover {
+    background: var(--bg-elevated);
+    color: var(--text-primary);
+  }
+
+  .nx-btn--outline {
+    background: transparent;
+    border-color: var(--border-strong);
+    color: var(--text-primary);
+  }
+  .nx-btn--outline:hover {
+    background: var(--bg-elevated);
+    border-color: var(--accent);
+  }
+
+  .nx-btn--danger {
+    background: var(--danger);
+    color: white;
+    border-color: color-mix(in oklab, var(--danger) 70%, white 5%);
+  }
+  .nx-btn--danger:hover { background: color-mix(in oklab, var(--danger) 90%, black 10%); }
+
+  .nx-btn--success {
+    background: var(--success);
+    color: var(--text-inverse);
+    border-color: color-mix(in oklab, var(--success) 70%, black 5%);
+  }
+
+  .nx-btn--sm { height: 30px; padding: 0 0.625rem; font-size: 0.8125rem; }
+  .nx-btn--lg { height: 44px; padding: 0 1.125rem; font-size: 0.9375rem; }
+  .nx-btn--icon { width: 38px; padding: 0; }
+  .nx-btn--icon.nx-btn--sm { width: 30px; }
+  .nx-btn--icon.nx-btn--lg { width: 44px; }
+  .nx-btn--block { width: 100%; }
+
+  /* ============ Input / Form ============ */
+  .nx-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+  .nx-label {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    letter-spacing: 0.01em;
+  }
+  .nx-required { color: var(--danger); margin-left: 0.125rem; }
+
+  .nx-input,
+  .nx-textarea,
+  .nx-select {
+    width: 100%;
+    height: 40px;
+    background: var(--bg-inset);
+    color: var(--text-primary);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-sm);
+    padding: 0 0.875rem;
+    font-family: inherit;
+    font-size: 0.9375rem;
+    transition:
+      border-color var(--dur-fast) var(--ease-out),
+      background var(--dur-fast) var(--ease-out),
+      box-shadow var(--dur-fast) var(--ease-out);
+  }
+  .nx-input::placeholder,
+  .nx-textarea::placeholder { color: var(--text-muted); }
+
+  .nx-input:hover, .nx-textarea:hover, .nx-select:hover { border-color: var(--border-strong); }
+
+  .nx-input:focus, .nx-textarea:focus, .nx-select:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-glow);
+    background: var(--bg-base);
+  }
+
+  .nx-textarea {
+    height: auto;
+    min-height: 120px;
+    padding: 0.75rem 0.875rem;
+    line-height: 1.6;
+    resize: vertical;
+  }
+
+  .nx-select {
+    appearance: none;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%23A8ADB8' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 0.875rem center;
+    padding-right: 2.25rem;
+  }
+
+  .nx-checkbox,
+  .nx-radio {
+    appearance: none;
+    width: 1.05rem;
+    height: 1.05rem;
+    border: 1px solid var(--border-strong);
+    background: var(--bg-inset);
+    border-radius: 4px;
+    cursor: pointer;
+    display: inline-grid;
+    place-content: center;
+    transition: background var(--dur-fast) var(--ease-out), border-color var(--dur-fast) var(--ease-out);
+    flex-shrink: 0;
+  }
+  .nx-radio { border-radius: 50%; }
+  .nx-checkbox:checked,
+  .nx-radio:checked { background: var(--accent); border-color: var(--accent); }
+  .nx-checkbox:checked::after {
+    content: "";
+    width: .6rem; height: .6rem;
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none'><path d='M2.5 6L5 8.5L9.5 3.5' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/></svg>") center/contain no-repeat;
+  }
+  .nx-radio:checked::after {
+    content: "";
+    width: .42rem; height: .42rem;
+    border-radius: 50%;
+    background: white;
+  }
+
+  .nx-help-text { font-size: 0.8125rem; color: var(--text-muted); }
+  .nx-error-text { font-size: 0.8125rem; color: var(--danger); }
+
+  .nx-input--error,
+  .nx-textarea--error,
+  .nx-select--error {
+    border-color: var(--danger);
+  }
+
+  .nx-input-group {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+  .nx-input-group .nx-input { padding-left: 2.5rem; }
+  .nx-input-group__icon {
+    position: absolute;
+    left: 0.875rem;
+    color: var(--text-muted);
+    pointer-events: none;
+    display: inline-flex;
+    width: 1rem; height: 1rem;
+  }
+
+  /* ============ Badge ============ */
+  .nx-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    line-height: 1;
+    border-radius: var(--r-full, 9999px);
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-default);
+  }
+  .nx-badge--accent  { background: var(--accent-subtle); color: var(--accent); border-color: color-mix(in oklab, var(--accent) 25%, transparent); }
+  .nx-badge--success { background: var(--success-bg); color: var(--success); border-color: color-mix(in oklab, var(--success) 25%, transparent); }
+  .nx-badge--warning { background: var(--warning-bg); color: var(--warning); border-color: color-mix(in oklab, var(--warning) 25%, transparent); }
+  .nx-badge--danger  { background: var(--danger-bg);  color: var(--danger);  border-color: color-mix(in oklab, var(--danger) 25%, transparent); }
+  .nx-badge--info    { background: var(--info-bg);    color: var(--info);    border-color: color-mix(in oklab, var(--info) 25%, transparent); }
+  .nx-badge--dot::before {
+    content: "";
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+  }
+
+  /* ============ Avatar ============ */
+  .nx-avatar {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px; height: 40px;
+    border-radius: 50%;
+    overflow: hidden;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    flex-shrink: 0;
+  }
+  .nx-avatar img {
+    width: 100%; height: 100%;
+    object-fit: cover;
+  }
+  .nx-avatar--xs { width: 24px; height: 24px; }
+  .nx-avatar--sm { width: 32px; height: 32px; }
+  .nx-avatar--lg { width: 56px; height: 56px; }
+  .nx-avatar--xl { width: 80px; height: 80px; }
+  .nx-avatar--2xl { width: 120px; height: 120px; border-width: 3px; }
+
+  .nx-avatar__status {
+    position: absolute;
+    bottom: 0; right: 0;
+    width: 10px; height: 10px;
+    border-radius: 50%;
+    border: 2px solid var(--bg-surface);
+  }
+  .nx-avatar__status--online  { background: var(--success); }
+  .nx-avatar__status--idle    { background: var(--warning); }
+  .nx-avatar__status--offline { background: var(--text-muted); }
+
+  /* ============ Alert / Message ============ */
+  .nx-alert {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.875rem 1rem;
+    border-radius: var(--r-md);
+    border: 1px solid var(--border-default);
+    background: var(--bg-elevated);
+    color: var(--text-primary);
+  }
+  .nx-alert__icon { flex-shrink: 0; width: 1.25rem; height: 1.25rem; margin-top: 0.05rem; }
+  .nx-alert__title { font-weight: 600; margin-bottom: 0.15rem; }
+  .nx-alert__body { color: var(--text-secondary); font-size: 0.9rem; line-height: 1.5; }
+
+  .nx-alert--success { background: var(--success-bg); border-color: color-mix(in oklab, var(--success) 30%, transparent); color: var(--success); }
+  .nx-alert--warning { background: var(--warning-bg); border-color: color-mix(in oklab, var(--warning) 30%, transparent); color: var(--warning); }
+  .nx-alert--danger  { background: var(--danger-bg);  border-color: color-mix(in oklab, var(--danger) 30%, transparent);  color: var(--danger); }
+  .nx-alert--info    { background: var(--info-bg);    border-color: color-mix(in oklab, var(--info) 30%, transparent);    color: var(--info); }
+  .nx-alert--success .nx-alert__body,
+  .nx-alert--warning .nx-alert__body,
+  .nx-alert--danger  .nx-alert__body,
+  .nx-alert--info    .nx-alert__body { color: var(--text-secondary); }
+
+  /* ============ Modal ============ */
+  .nx-modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    backdrop-filter: blur(8px) saturate(120%);
+    z-index: 80;
+  }
+  .nx-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 90;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+  .nx-modal__panel {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-lg);
+    box-shadow: var(--shadow-xl);
+    max-width: 32rem;
+    width: 100%;
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .nx-modal__header {
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid var(--border-subtle);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+  .nx-modal__title { font-family: var(--font-display); font-size: 1.0625rem; font-weight: 600; }
+  .nx-modal__body { padding: 1.5rem; overflow-y: auto; color: var(--text-secondary); line-height: 1.6; }
+  .nx-modal__footer {
+    padding: 1rem 1.5rem;
+    border-top: 1px solid var(--border-subtle);
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    background: var(--bg-inset);
+  }
+
+  /* ============ Dropdown / Popover ============ */
+  .nx-dropdown {
+    position: relative;
+    display: inline-block;
+  }
+  .nx-dropdown__panel {
+    position: absolute;
+    z-index: 50;
+    min-width: 14rem;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-md);
+    box-shadow: var(--shadow-lg);
+    padding: 0.375rem;
+    margin-top: 0.5rem;
+  }
+  .nx-dropdown__item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 0.625rem;
+    border-radius: var(--r-xs);
+    font-size: 0.875rem;
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: background var(--dur-fast) var(--ease-out);
+    text-align: left;
+    background: transparent;
+    border: 0;
+  }
+  .nx-dropdown__item:hover { background: var(--bg-surface); }
+  .nx-dropdown__item--danger { color: var(--danger); }
+  .nx-dropdown__item--danger:hover { background: var(--danger-bg); }
+  .nx-dropdown__divider {
+    height: 1px;
+    background: var(--border-subtle);
+    margin: 0.375rem -0.375rem;
+  }
+  .nx-dropdown__header {
+    padding: 0.5rem 0.625rem 0.25rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .nx-dropdown__shortcut {
+    margin-left: auto;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-family: var(--font-mono);
+  }
+
+  /* ============ Tabs ============ */
+  .nx-tabs {
+    display: flex;
+    gap: 0.25rem;
+    border-bottom: 1px solid var(--border-subtle);
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .nx-tabs::-webkit-scrollbar { display: none; }
+  .nx-tab {
+    position: relative;
+    padding: 0.65rem 0.875rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: color var(--dur-fast) var(--ease-out);
+  }
+  .nx-tab::after {
+    content: "";
+    position: absolute;
+    bottom: -1px;
+    left: 0.5rem; right: 0.5rem;
+    height: 2px;
+    background: var(--accent);
+    border-radius: 2px 2px 0 0;
+    transform: scaleX(0);
+    transform-origin: center;
+    transition: transform var(--dur-base) var(--ease-out);
+  }
+  .nx-tab:hover { color: var(--text-primary); }
+  .nx-tab[aria-selected="true"],
+  .nx-tab.is-active {
+    color: var(--text-primary);
+  }
+  .nx-tab[aria-selected="true"]::after,
+  .nx-tab.is-active::after {
+    transform: scaleX(1);
+  }
+
+  /* ============ Skeleton ============ */
+  .nx-skeleton {
+    position: relative;
+    background: var(--bg-elevated);
+    border-radius: var(--r-sm);
+    overflow: hidden;
+  }
+  .nx-skeleton::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    transform: translateX(-100%);
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0.04) 50%,
+      transparent 100%
+    );
+    animation: shimmer 1.6s linear infinite;
+  }
+
+  /* ============ Tooltip ============ */
+  .nx-tooltip {
+    position: absolute;
+    z-index: 70;
+    background: var(--bg-base);
+    color: var(--text-primary);
+    font-size: 0.75rem;
+    padding: 0.35rem 0.55rem;
+    border-radius: var(--r-xs);
+    border: 1px solid var(--border-strong);
+    box-shadow: var(--shadow-lg);
+    white-space: nowrap;
+    pointer-events: none;
+  }
+
+  /* ============ Pagination ============ */
+  .nx-pagination {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    background: var(--bg-surface);
+    padding: 0.25rem;
+    border-radius: var(--r-sm);
+    border: 1px solid var(--border-default);
+  }
+  .nx-pagination__link,
+  .nx-pagination__link.item,
+  .nx-pagination > a,
+  .nx-pagination > span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 32px;
+    height: 32px;
+    padding: 0 0.5rem;
+    border-radius: var(--r-xs);
+    font-size: 0.8125rem;
+    color: var(--text-secondary);
+    transition: background var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out);
+    background: transparent;
+  }
+  .nx-pagination__link:hover,
+  .nx-pagination > a:hover { background: var(--bg-elevated); color: var(--text-primary); }
+  .nx-pagination .active,
+  .nx-pagination__link.active {
+    background: var(--accent);
+    color: var(--accent-fg);
+  }
+
+  /* ============ Table ============ */
+  .nx-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    font-size: 0.9rem;
+  }
+  .nx-table thead th {
+    position: sticky; top: 0;
+    text-align: left;
+    font-weight: 500;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    padding: 0.65rem 1rem;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border-default);
+  }
+  .nx-table tbody td {
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--border-subtle);
+    background: var(--bg-surface);
+  }
+  .nx-table tbody tr:hover td {
+    background: var(--bg-elevated);
+  }
+  .nx-table tbody tr:last-child td { border-bottom: 0; }
+
+  /* ============ Toast ============ */
+  .nx-toast-container {
+    position: fixed;
+    bottom: 1rem; right: 1rem;
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    pointer-events: none;
+  }
+  .nx-toast {
+    pointer-events: auto;
+    min-width: 18rem;
+    max-width: 24rem;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-md);
+    box-shadow: var(--shadow-lg);
+    padding: 0.75rem 1rem;
+    display: flex;
+    gap: 0.625rem;
+    align-items: flex-start;
+  }
+
+  /* ============ Kbd shortcut hint ============ */
+  .nx-kbd {
+    display: inline-flex;
+    align-items: center;
+    height: 20px;
+    padding: 0 0.4rem;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--r-xs);
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    line-height: 1;
+  }
+
+  /* ============ Spinner ============ */
+  .nx-spinner {
+    width: 16px; height: 16px;
+    border: 2px solid var(--border-strong);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: nx-spin 0.7s linear infinite;
+  }
+  @keyframes nx-spin { to { transform: rotate(360deg); } }
+
+  /* ============ Divider with label ============ */
+  .nx-divider {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: var(--text-muted);
+    font-size: 0.8125rem;
+    margin: 1.25rem 0;
+  }
+  .nx-divider::before,
+  .nx-divider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--border-default);
+  }
+}

--- a/custom/templates/Nexus/src/styles/main.css
+++ b/custom/templates/Nexus/src/styles/main.css
@@ -1,0 +1,24 @@
+/* ================================================================
+ * Nexus · Stylesheet entry point
+ *
+ *   tokens   → base CSS custom properties (color, radius, type, motion)
+ *   tailwind → preflight + utility classes
+ *   base     → element-level resets and headings
+ *   components → reusable .nx-* classes
+ *   overrides → legacy Fomantic/Bootstrap selector compatibility
+ *
+ * Compile:
+ *   npm run build       (production, minified)
+ *   npm run dev         (watch mode)
+ * Output: ./assets/css/nexus.css
+ * ================================================================ */
+
+@import "./tokens.css";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@import "./base.css";
+@import "./components.css";
+@import "./overrides.css";

--- a/custom/templates/Nexus/src/styles/overrides.css
+++ b/custom/templates/Nexus/src/styles/overrides.css
@@ -1,0 +1,361 @@
+/* ================================================================
+ * Nexus · Legacy Compatibility Overrides
+ *
+ * Many NamelessMC modules emit Fomantic UI / Bootstrap classes
+ * inside their own templates and HTML strings (e.g. widgets,
+ * announcement components, captcha, oauth provider styling).
+ *
+ * We don't ship the upstream Fomantic CSS in Nexus, so any
+ * leftover `ui ... segment`, `ui ... button`, `ui ... message`
+ * markup would otherwise look unstyled. This layer renders those
+ * legacy class hooks consistent with the Nexus design system.
+ *
+ * Order: loaded AFTER components.css so it can refine.
+ * ================================================================ */
+
+@layer components {
+
+  /* === Generic Fomantic "ui ... segment" containers === */
+  .ui.segment,
+  .ui.segments {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-lg);
+    padding: 1rem 1.25rem;
+    box-shadow: var(--shadow-sm), var(--shadow-inset);
+    color: var(--text-primary);
+  }
+  .ui.padded.segment { padding: 1.5rem 1.75rem; }
+
+  /* === Fomantic message/alert === */
+  .ui.message {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-md);
+    padding: 0.875rem 1rem;
+    color: var(--text-primary);
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+  .ui.message > .header { font-weight: 600; margin-bottom: 0.15rem; color: inherit; }
+  .ui.message > .content { color: var(--text-secondary); font-size: 0.9rem; }
+  .ui.message .list { margin: 0.35rem 0 0; padding-left: 1.1rem; }
+  .ui.error.message,   .ui.negative.message { background: var(--danger-bg);  border-color: color-mix(in oklab, var(--danger) 30%, transparent);  color: var(--danger); }
+  .ui.success.message, .ui.positive.message { background: var(--success-bg); border-color: color-mix(in oklab, var(--success) 30%, transparent); color: var(--success); }
+  .ui.warning.message                         { background: var(--warning-bg); border-color: color-mix(in oklab, var(--warning) 30%, transparent); color: var(--warning); }
+  .ui.info.message                            { background: var(--info-bg);    border-color: color-mix(in oklab, var(--info) 30%, transparent);    color: var(--info); }
+
+  /* === Fomantic buttons → Nexus buttons === */
+  .ui.button {
+    @apply nx-btn;
+  }
+  .ui.primary.button    { @apply nx-btn--primary; }
+  .ui.positive.button   { @apply nx-btn--success; }
+  .ui.negative.button   { @apply nx-btn--danger; }
+  .ui.basic.button,
+  .ui.default.button    { @apply nx-btn--outline; }
+  .ui.small.button      { @apply nx-btn--sm; }
+  .ui.large.button      { @apply nx-btn--lg; }
+  .ui.fluid.button      { @apply nx-btn--block; }
+  .ui.icon.button       { @apply nx-btn--icon; }
+
+  /* === Fomantic forms === */
+  .ui.form .field { margin-bottom: 1rem; }
+  .ui.form .field > label {
+    display: block;
+    margin-bottom: 0.375rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+  }
+  .ui.form input[type="text"],
+  .ui.form input[type="email"],
+  .ui.form input[type="password"],
+  .ui.form input[type="number"],
+  .ui.form input[type="date"],
+  .ui.form input[type="search"],
+  .ui.form input[type="tel"],
+  .ui.form input[type="url"],
+  .ui.form textarea,
+  .ui.form select {
+    @apply nx-input;
+  }
+  .ui.form textarea { @apply nx-textarea; }
+  .ui.form select  { @apply nx-select; }
+
+  .ui.form .ui.checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-primary);
+  }
+  .ui.form .ui.checkbox input[type="checkbox"] { @apply nx-checkbox; }
+  .ui.form .ui.checkbox input[type="radio"]    { @apply nx-radio; }
+  .ui.form .ui.radio.checkbox input[type="radio"] { @apply nx-radio; }
+  .ui.form .ui.dropdown,
+  .ui.form .ui.fluid.dropdown {
+    @apply nx-select;
+  }
+
+  /* === Fomantic header === */
+  .ui.header {
+    color: var(--text-primary);
+    font-family: var(--font-display);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    margin: 0 0 0.75rem;
+  }
+  .ui.header > .sub.header,
+  .ui.header .sub.header {
+    color: var(--text-muted);
+    font-weight: 400;
+    font-size: 0.85em;
+    margin-top: 0.2rem;
+  }
+  .ui.header.inverted { color: var(--text-primary); }
+
+  /* === Fomantic dividers === */
+  .ui.divider,
+  .ui.horizontal.divider {
+    border: 0;
+    border-top: 1px solid var(--border-default);
+    margin: 1rem 0;
+    color: var(--text-muted);
+    font-size: 0.8125rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .ui.horizontal.divider {
+    display: flex; align-items: center; gap: 0.75rem; border-top: 0;
+  }
+  .ui.horizontal.divider::before,
+  .ui.horizontal.divider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--border-default);
+  }
+
+  /* === Fomantic labels (small inline tags) === */
+  .ui.label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.2rem 0.55rem;
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-full, 9999px);
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+
+  /* === Fomantic cards (used by news on home) === */
+  .ui.card,
+  .ui.cards > .card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-lg);
+    box-shadow: var(--shadow-sm), var(--shadow-inset);
+    color: var(--text-primary);
+    margin: 0 0 1rem;
+    overflow: hidden;
+  }
+  .ui.card > .content,
+  .ui.cards > .card > .content { padding: 1.25rem 1.5rem; border: 0; }
+  .ui.card > .content > .header { font-family: var(--font-display); font-weight: 600; margin-bottom: 0.35rem; }
+  .ui.card > .content > .meta { color: var(--text-muted); font-size: 0.8125rem; margin-bottom: 0.5rem; }
+  .ui.card > .content > .description { color: var(--text-secondary); line-height: 1.6; }
+  .ui.card > .extra.content {
+    border-top: 1px solid var(--border-subtle);
+    background: var(--bg-inset);
+    padding: 0.75rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  /* === Fomantic grids → CSS-grid-ish behaviour but preserve auth/login markup === */
+  .ui.grid,
+  .ui.stackable.grid {
+    display: grid;
+    grid-template-columns: repeat(16, 1fr);
+    gap: 1rem;
+  }
+  .ui.grid > .row {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: repeat(16, 1fr);
+    gap: 1rem;
+  }
+  .ui.grid > .column,
+  .ui.grid > .row > .column { grid-column: span 16; }
+
+  /* Width helpers used heavily */
+  .ui.grid .one.wide.column     { grid-column: span 1; }
+  .ui.grid .two.wide.column     { grid-column: span 2; }
+  .ui.grid .three.wide.column   { grid-column: span 3; }
+  .ui.grid .four.wide.column    { grid-column: span 4; }
+  .ui.grid .five.wide.column    { grid-column: span 5; }
+  .ui.grid .six.wide.column     { grid-column: span 6; }
+  .ui.grid .seven.wide.column   { grid-column: span 7; }
+  .ui.grid .eight.wide.column   { grid-column: span 8; }
+  .ui.grid .nine.wide.column    { grid-column: span 9; }
+  .ui.grid .ten.wide.column     { grid-column: span 10; }
+  .ui.grid .eleven.wide.column  { grid-column: span 11; }
+  .ui.grid .twelve.wide.column  { grid-column: span 12; }
+  .ui.grid .thirteen.wide.column{ grid-column: span 13; }
+  .ui.grid .fourteen.wide.column{ grid-column: span 14; }
+  .ui.grid .fifteen.wide.column { grid-column: span 15; }
+  .ui.grid .sixteen.wide.column { grid-column: span 16; }
+  .ui.grid .ui.centered.row     { justify-content: center; }
+
+  /* Below md, stack columns on mobile */
+  @media (max-width: 767px) {
+    .ui.stackable.grid > .row > .column,
+    .ui.stackable.grid > .column,
+    .ui.grid > .column,
+    .ui.grid > .row > .column {
+      grid-column: 1 / -1 !important;
+    }
+  }
+  /* Tablet/computer responsive class hooks */
+  @media (min-width: 768px) and (max-width: 991px) {
+    .ui.grid .sixteen.wide.tablet     { grid-column: span 16; }
+    .ui.grid .ten.wide.tablet         { grid-column: span 10; }
+    .ui.grid .eight.wide.tablet       { grid-column: span 8; }
+    .ui.grid .six.wide.tablet         { grid-column: span 6; }
+    .ui.grid .four.wide.tablet        { grid-column: span 4; }
+  }
+  @media (min-width: 992px) {
+    .ui.grid .twelve.wide.computer    { grid-column: span 12; }
+    .ui.grid .ten.wide.computer       { grid-column: span 10; }
+    .ui.grid .eight.wide.computer     { grid-column: span 8; }
+    .ui.grid .four.wide.computer      { grid-column: span 4; }
+  }
+
+  /* === Fomantic container === */
+  .ui.container { @apply nx-container; }
+
+  /* === Fomantic list === */
+  .ui.list { padding: 0; margin: 0; list-style: none; }
+  .ui.list > .item,
+  .ui.list .item { padding: 0.35rem 0; color: var(--text-secondary); }
+  .ui.relaxed.list > .item { padding: 0.55rem 0; }
+  .ui.link.list > .item,
+  .ui.link.list a.item { color: var(--text-secondary); }
+  .ui.link.list > .item:hover,
+  .ui.link.list a.item:hover { color: var(--text-primary); }
+
+  /* === Fomantic icon (Font Awesome inside) === */
+  .ui.icon { line-height: 1; }
+  i.icon { font-style: normal; }
+
+  /* === Fomantic modal — overlay base for legacy modals (cookies, etc.) === */
+  .ui.modal {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--r-lg);
+    box-shadow: var(--shadow-xl);
+    color: var(--text-primary);
+  }
+  .ui.modal > .header {
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid var(--border-subtle);
+    font-family: var(--font-display);
+    font-size: 1.0625rem;
+    font-weight: 600;
+  }
+  .ui.modal > .content { padding: 1.5rem; color: var(--text-secondary); line-height: 1.6; }
+  .ui.modal > .actions {
+    padding: 1rem 1.5rem;
+    border-top: 1px solid var(--border-subtle);
+    background: var(--bg-inset);
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  /* === Fomantic forum_post (rich text) === */
+  .forum_post {
+    color: var(--text-secondary);
+    line-height: 1.65;
+  }
+  .forum_post img { border-radius: var(--r-sm); }
+  .forum_post blockquote {
+    margin: 0.75rem 0;
+    padding: 0.65rem 1rem;
+    background: var(--bg-elevated);
+    border-left: 3px solid var(--accent);
+    border-radius: 0 var(--r-sm) var(--r-sm) 0;
+    color: var(--text-primary);
+  }
+
+  /* === Inverted footer segment === */
+  .ui.inverted.vertical.footer.segment {
+    background: var(--bg-inset);
+    border-top: 1px solid var(--border-default);
+    color: var(--text-secondary);
+    padding: 2rem 0 2.5rem;
+    margin-top: 4rem;
+  }
+  .ui.inverted.vertical.footer.segment .ui.inverted.header { color: var(--text-primary); }
+  .ui.inverted.vertical.footer.segment a { color: var(--text-secondary); }
+  .ui.inverted.vertical.footer.segment a:hover { color: var(--text-primary); }
+
+  /* === DataTables (Bootstrap-themed by AssetTree) === */
+  table.dataTable {
+    width: 100% !important;
+    background: var(--bg-surface);
+    border-radius: var(--r-md);
+    overflow: hidden;
+  }
+  table.dataTable thead th {
+    background: var(--bg-elevated);
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    border-bottom: 1px solid var(--border-default) !important;
+  }
+  table.dataTable tbody td { border-top: 1px solid var(--border-subtle) !important; color: var(--text-primary); }
+  .dataTables_wrapper .dataTables_filter input,
+  .dataTables_wrapper .dataTables_length select { @apply nx-input; }
+  .dataTables_wrapper .dataTables_paginate .paginate_button {
+    color: var(--text-secondary) !important;
+    border-radius: var(--r-xs) !important;
+    border: 0 !important;
+    background: transparent !important;
+  }
+  .dataTables_wrapper .dataTables_paginate .paginate_button.current,
+  .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover {
+    background: var(--accent) !important;
+    color: var(--accent-fg) !important;
+  }
+
+  /* === Select2 in Nexus dress === */
+  .select2-container .select2-selection--single {
+    height: 40px !important;
+    background: var(--bg-inset) !important;
+    border: 1px solid var(--border-default) !important;
+    border-radius: var(--r-sm) !important;
+    color: var(--text-primary) !important;
+  }
+  .select2-container--default .select2-selection--single .select2-selection__rendered {
+    line-height: 38px !important;
+    color: var(--text-primary) !important;
+    padding-left: 0.875rem !important;
+  }
+  .select2-dropdown {
+    background: var(--bg-elevated) !important;
+    border: 1px solid var(--border-default) !important;
+    border-radius: var(--r-md) !important;
+    color: var(--text-primary) !important;
+  }
+  .select2-results__option--highlighted[aria-selected] {
+    background: var(--accent) !important;
+    color: var(--accent-fg) !important;
+  }
+}

--- a/custom/templates/Nexus/src/styles/tokens.css
+++ b/custom/templates/Nexus/src/styles/tokens.css
@@ -1,0 +1,128 @@
+/* ================================================================
+ * Nexus · Design Tokens
+ * Source of truth for color, spacing, radius, shadow, motion.
+ * Tailwind reads these via tailwind.config.js extend.
+ * Override the same custom properties under [data-theme="light"]
+ * to opt into light mode.
+ * ================================================================ */
+
+:root,
+[data-theme="dark"] {
+  /* === Surface · Dark (default) === */
+  --bg-base:       #07080B;
+  --bg-surface:    #0E1014;
+  --bg-elevated:   #14171D;
+  --bg-inset:      #050609;
+  --bg-overlay:    rgba(7, 8, 11, 0.72);
+
+  /* === Border === */
+  --border-subtle:  rgba(255, 255, 255, 0.04);
+  --border-default: rgba(255, 255, 255, 0.08);
+  --border-strong:  rgba(255, 255, 255, 0.14);
+
+  /* === Text === */
+  --text-primary:   #F2F3F5;
+  --text-secondary: #A8ADB8;
+  --text-muted:     #6B7180;
+  --text-inverse:   #07080B;
+
+  /* === Accent · Nexus violet === */
+  --accent:        #7C5CFF;
+  --accent-hover:  #8E72FF;
+  --accent-subtle: rgba(124, 92, 255, 0.14);
+  --accent-fg:     #FFFFFF;
+  --accent-glow:   rgba(124, 92, 255, 0.35);
+
+  /* === Semantic === */
+  --success: #34D399;
+  --warning: #FBBF24;
+  --danger:  #F87171;
+  --info:    #60A5FA;
+
+  --success-bg: rgba(52, 211, 153, 0.12);
+  --warning-bg: rgba(251, 191, 36, 0.12);
+  --danger-bg:  rgba(248, 113, 113, 0.12);
+  --info-bg:    rgba(96, 165, 250, 0.12);
+
+  /* === Radius === */
+  --r-xs:  6px;
+  --r-sm:  10px;
+  --r-md:  14px;
+  --r-lg:  20px;
+  --r-xl:  28px;
+  --r-2xl: 36px;
+
+  /* === Shadow (layered for depth hierarchy) === */
+  --shadow-xs:   0 1px 0 rgba(0, 0, 0, 0.4);
+  --shadow-sm:   0 1px 2px rgba(0, 0, 0, 0.5);
+  --shadow-md:   0 4px 12px rgba(0, 0, 0, 0.45), 0 1px 2px rgba(0, 0, 0, 0.6);
+  --shadow-lg:   0 16px 40px rgba(0, 0, 0, 0.55), 0 2px 6px rgba(0, 0, 0, 0.5);
+  --shadow-xl:   0 32px 64px rgba(0, 0, 0, 0.6), 0 4px 12px rgba(0, 0, 0, 0.55);
+  --shadow-glow: 0 0 0 1px var(--border-strong), 0 0 24px var(--accent-glow);
+  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+
+  /* === Type === */
+  --font-sans:    "Inter", "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-display: "Geist", "Inter", -apple-system, system-ui, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, "SFMono-Regular", "Menlo", monospace;
+
+  /* === Motion === */
+  --ease-out:    cubic-bezier(.16, 1, .3, 1);
+  --ease-in-out: cubic-bezier(.65, 0, .35, 1);
+  --dur-fast:    120ms;
+  --dur-base:    200ms;
+  --dur-slow:    320ms;
+
+  /* === Component sizing === */
+  --header-h:  64px;
+  --content-max: 1280px;
+}
+
+/* === Light mode override ===
+ * Activated when <html data-theme="light">.
+ * Same token names, different values — components don't care.
+ */
+[data-theme="light"] {
+  --bg-base:       #FAFAFB;
+  --bg-surface:    #FFFFFF;
+  --bg-elevated:   #FFFFFF;
+  --bg-inset:      #F4F4F6;
+  --bg-overlay:    rgba(255, 255, 255, 0.78);
+
+  --border-subtle:  rgba(0, 0, 0, 0.04);
+  --border-default: rgba(0, 0, 0, 0.08);
+  --border-strong:  rgba(0, 0, 0, 0.14);
+
+  --text-primary:   #0B0C10;
+  --text-secondary: #4B5160;
+  --text-muted:     #7A8194;
+  --text-inverse:   #FFFFFF;
+
+  --accent:        #6A4DFF;
+  --accent-hover:  #5A3FFF;
+  --accent-subtle: rgba(106, 77, 255, 0.10);
+  --accent-fg:     #FFFFFF;
+  --accent-glow:   rgba(106, 77, 255, 0.22);
+
+  --success-bg: rgba(16, 161, 105, 0.10);
+  --warning-bg: rgba(217, 119, 6, 0.10);
+  --danger-bg:  rgba(220, 38, 38, 0.10);
+  --info-bg:    rgba(37, 99, 235, 0.10);
+
+  --shadow-xs:   0 1px 0 rgba(0, 0, 0, 0.04);
+  --shadow-sm:   0 1px 2px rgba(0, 0, 0, 0.06);
+  --shadow-md:   0 4px 12px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-lg:   0 16px 40px rgba(0, 0, 0, 0.10), 0 2px 6px rgba(0, 0, 0, 0.04);
+  --shadow-xl:   0 32px 64px rgba(0, 0, 0, 0.12), 0 4px 12px rgba(0, 0, 0, 0.05);
+  --shadow-inset: inset 0 1px 0 rgba(0, 0, 0, 0.03);
+}
+
+/* === Reduced motion === */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/custom/templates/Nexus/status.tpl
+++ b/custom/templates/Nexus/status.tpl
@@ -1,0 +1,40 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6">{$STATUS}</h1>
+
+{if count($SERVERS)}
+  <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4" id="servers">
+    {foreach from=$SERVERS item=server}
+      <div class="nx-card server" style="height:100%" id="server{$server->id|escape}"
+           data-id="{$server->id|escape}" data-bungee="{$server->bungee|escape}" data-bedrock="{$server->bedrock|escape}"
+           data-players="{$server->player_list|escape}">
+        <div class="nx-card__body">
+          <div class="flex items-start justify-between gap-3 mb-3">
+            <h3 class="nx-card__title">{$server->name|escape:'html'}</h3>
+            {if $server->show_ip}
+              <button class="nx-badge nx-badge--accent cursor-pointer"
+                      onclick="copy('#copy{$server->id|escape}')"
+                      title="{$IP}">
+                <span id="copy{$server->id|escape}">{$server->query_ip|escape:'html'}{if $server->port && $server->port != 25565}:{$server->port|escape:'html'}{/if}</span>
+              </button>
+            {/if}
+          </div>
+          <div class="text-text-secondary text-sm" id="server-status">
+            <span class="nx-spinner inline-block align-middle mr-2"></span>
+          </div>
+        </div>
+        {if !$server->bedrock}
+          <div class="nx-card__footer" id="server-players"></div>
+        {/if}
+      </div>
+    {/foreach}
+  </div>
+{else}
+  <div class="nx-alert nx-alert--danger">
+    {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+    <div><div class="nx-alert__title">{$ERROR_TITLE}</div><div class="nx-alert__body">{$NO_SERVERS}</div></div>
+  </div>
+{/if}
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/tailwind.config.js
+++ b/custom/templates/Nexus/tailwind.config.js
@@ -1,0 +1,122 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './**/*.tpl',
+    './src/scripts/**/*.js',
+  ],
+  darkMode: ['class', '[data-theme="dark"]'],
+  theme: {
+    extend: {
+      colors: {
+        bg: {
+          base:     'var(--bg-base)',
+          surface:  'var(--bg-surface)',
+          elevated: 'var(--bg-elevated)',
+          inset:    'var(--bg-inset)',
+          overlay:  'var(--bg-overlay)',
+        },
+        border: {
+          subtle:  'var(--border-subtle)',
+          DEFAULT: 'var(--border-default)',
+          strong:  'var(--border-strong)',
+        },
+        text: {
+          primary:   'var(--text-primary)',
+          secondary: 'var(--text-secondary)',
+          muted:     'var(--text-muted)',
+          inverse:   'var(--text-inverse)',
+        },
+        accent: {
+          DEFAULT: 'var(--accent)',
+          hover:   'var(--accent-hover)',
+          subtle:  'var(--accent-subtle)',
+          fg:      'var(--accent-fg)',
+        },
+        success: 'var(--success)',
+        warning: 'var(--warning)',
+        danger:  'var(--danger)',
+        info:    'var(--info)',
+      },
+      fontFamily: {
+        sans:    ['var(--font-sans)'],
+        display: ['var(--font-display)'],
+        mono:    ['var(--font-mono)'],
+      },
+      borderRadius: {
+        xs:  'var(--r-xs)',
+        sm:  'var(--r-sm)',
+        DEFAULT: 'var(--r-md)',
+        md:  'var(--r-md)',
+        lg:  'var(--r-lg)',
+        xl:  'var(--r-xl)',
+        '2xl': 'var(--r-2xl)',
+      },
+      boxShadow: {
+        xs:    'var(--shadow-xs)',
+        sm:    'var(--shadow-sm)',
+        DEFAULT: 'var(--shadow-md)',
+        md:    'var(--shadow-md)',
+        lg:    'var(--shadow-lg)',
+        xl:    'var(--shadow-xl)',
+        glow:  'var(--shadow-glow)',
+        inset: 'var(--shadow-inset)',
+      },
+      transitionTimingFunction: {
+        'out-quint': 'cubic-bezier(.16,1,.3,1)',
+        'in-out-quint': 'cubic-bezier(.65,0,.35,1)',
+      },
+      transitionDuration: {
+        fast: '120ms',
+        base: '200ms',
+        slow: '320ms',
+      },
+      backgroundImage: {
+        'gradient-mesh':
+          'radial-gradient(60% 80% at 50% 0%, var(--accent-subtle) 0%, transparent 60%), radial-gradient(40% 60% at 80% 30%, color-mix(in oklab, var(--info) 35%, transparent) 0%, transparent 70%), radial-gradient(40% 60% at 10% 80%, color-mix(in oklab, var(--accent) 25%, transparent) 0%, transparent 70%)',
+        'noise':
+          "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='1' stitchTiles='stitch'/><feColorMatrix type='matrix' values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 .04 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>\")",
+      },
+      keyframes: {
+        'fade-in': {
+          '0%': { opacity: '0', transform: 'translateY(4px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        'scale-in': {
+          '0%': { opacity: '0', transform: 'scale(.96)' },
+          '100%': { opacity: '1', transform: 'scale(1)' },
+        },
+        'slide-up': {
+          '0%': { opacity: '0', transform: 'translateY(8px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        'shimmer': {
+          '0%':   { transform: 'translateX(-100%)' },
+          '100%': { transform: 'translateX(100%)' },
+        },
+        'pulse-glow': {
+          '0%, 100%': { boxShadow: '0 0 0 0 var(--accent-glow)' },
+          '50%':      { boxShadow: '0 0 0 8px transparent' },
+        },
+      },
+      animation: {
+        'fade-in':    'fade-in 200ms cubic-bezier(.16,1,.3,1) both',
+        'scale-in':   'scale-in 180ms cubic-bezier(.16,1,.3,1) both',
+        'slide-up':   'slide-up 240ms cubic-bezier(.16,1,.3,1) both',
+        'shimmer':    'shimmer 1.6s linear infinite',
+        'pulse-glow': 'pulse-glow 2s ease-in-out infinite',
+      },
+      screens: {
+        '3xl': '1792px',
+      },
+      spacing: {
+        '4.5': '1.125rem',
+        '18':  '4.5rem',
+        '22':  '5.5rem',
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms')({ strategy: 'class' }),
+    require('@tailwindcss/typography'),
+  ],
+};

--- a/custom/templates/Nexus/template.php
+++ b/custom/templates/Nexus/template.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ *  Nexus Template for NamelessMC
+ *  AAA-grade UI/UX modernization — Cyberpunk-Minimalism + Apple-Polish
+ *
+ *  Compatible with NamelessMC 2.2.x
+ *  Licence: MIT
+ */
+
+class Nexus_Template extends SmartyTemplateBase
+{
+    private array $_template;
+    private Language $_language;
+    private User $_user;
+    private Pages $_pages;
+
+    public function __construct(Cache $cache, Language $language, User $user, Pages $pages)
+    {
+        $template = [
+            'name' => 'Nexus',
+            'version' => '1.0.0',
+            'nl_version' => '2.2.5',
+            'author' => '<a href="https://github.com/" target="_blank">Nexus Team</a>',
+        ];
+
+        $template['path'] = (defined('CONFIG_PATH') ? CONFIG_PATH : '') . '/custom/templates/' . $template['name'] . '/';
+
+        parent::__construct(
+            $template['name'],
+            $template['version'],
+            $template['nl_version'],
+            $template['author'],
+            __DIR__
+        );
+
+        $this->_settings = ROOT_PATH . '/custom/templates/Nexus/template_settings/settings.php';
+
+        // Only the vendor asset trees we actually depend on.
+        // jQuery stays — modules (Forum, Discord, etc.) rely on it.
+        // jQuery-Cookie stays — used for auto-language toggle in footer.
+        // Font Awesome is loaded for icon fallback in module-provided HTML;
+        // primary icons in Nexus use an inline SVG sprite.
+        $this->assets()->include([
+            AssetTree::JQUERY,
+            AssetTree::JQUERY_COOKIE,
+            AssetTree::FONT_AWESOME,
+        ]);
+
+        $this->getEngine()->addVariable('TEMPLATE', $template);
+        $this->getEngine()->addVariable('FORUM_SPAM_WARNING_TITLE', $language->get('general', 'warning'));
+
+        // Dark mode is server-driven via the DARK_MODE constant.
+        // Nexus is dark-first but supports the legacy toggle.
+        $cache->setCache('template_settings');
+        $nexusDarkMode = true; // default
+        if (defined('DARK_MODE')) {
+            $nexusDarkMode = (DARK_MODE == '1');
+        }
+
+        $accent = '#7C5CFF';
+        if ($cache->isCached('nexusAccent')) {
+            $cachedAccent = $cache->retrieve('nexusAccent');
+            if (is_string($cachedAccent) && preg_match('/^#[0-9A-Fa-f]{6}$/', $cachedAccent)) {
+                $accent = $cachedAccent;
+            }
+        }
+
+        $this->getEngine()->addVariables([
+            'NEXUS_DARK_MODE' => $nexusDarkMode,
+            'NEXUS_ACCENT' => $accent,
+            'NEXUS_THEME_NAME' => $template['name'],
+            'NEXUS_THEME_VERSION' => $template['version'],
+        ]);
+
+        if (defined('AUTO_LANGUAGE_VALUE')) {
+            $this->getEngine()->addVariable('AUTO_LANGUAGE_VALUE', AUTO_LANGUAGE_VALUE);
+        }
+
+        $this->_template = $template;
+        $this->_language = $language;
+        $this->_user = $user;
+        $this->_pages = $pages;
+    }
+
+    public function onPageLoad()
+    {
+        $page_load = microtime(true) - PAGE_START_TIME;
+        define('PAGE_LOAD_TIME', $this->_language->get('general', 'page_loaded_in', ['time' => round($page_load, 3)]));
+
+        // Nexus compiled stylesheet. Version bump invalidates browser cache.
+        $this->addCSSFiles([
+            $this->_template['path'] . 'assets/css/nexus.css?v=' . $this->_template['version'] => [],
+        ]);
+
+        $route = (isset($_GET['route']) ? rtrim($_GET['route'], '/') : '/');
+
+        // JS variables consumed by Nexus + legacy module scripts.
+        // The names mirror DefaultRevamp's contract so module scripts keep working.
+        $JSVariables = [
+            'siteName' => Output::getClean(SITE_NAME),
+            'siteURL' => URL::build('/'),
+            'fullSiteURL' => URL::getSelfURL() . ltrim(URL::build('/'), '/'),
+            'page' => PAGE,
+            'avatarSource' => AvatarSource::getUrlToFormat(),
+            'copied' => $this->_language->get('general', 'copied'),
+            'cookieNotice' => $this->_language->get('general', 'cookie_notice'),
+            'noMessages' => $this->_language->get('user', 'no_messages'),
+            'newMessage1' => $this->_language->get('user', '1_new_message'),
+            'newMessagesX' => $this->_language->get('user', 'x_new_messages'),
+            'noAlerts' => $this->_language->get('user', 'no_alerts'),
+            'newAlert1' => $this->_language->get('user', '1_new_alert'),
+            'newAlertsX' => $this->_language->get('user', 'x_new_alerts'),
+            'bungeeInstance' => $this->_language->get('general', 'bungee_instance'),
+            'andMoreX' => $this->_language->get('general', 'and_x_more'),
+            'onePlayerOnline' => $this->_language->get('general', 'currently_1_player_online'),
+            'xPlayersOnline' => $this->_language->get('general', 'currently_x_players_online'),
+            'noPlayersOnline' => $this->_language->get('general', 'no_players_online'),
+            'offline' => $this->_language->get('general', 'offline'),
+            'confirmDelete' => $this->_language->get('general', 'confirm_deletion'),
+            'debugging' => (defined('DEBUGGING') && DEBUGGING == 1) ? '1' : '0',
+            'loggedIn' => $this->_user->isLoggedIn() ? '1' : '0',
+            'cookie' => defined('COOKIE_NOTICE') ? '1' : '0',
+            'loadingTime' => Settings::get('page_loading') === '1' ? PAGE_LOAD_TIME : '',
+            'route' => $route,
+            'csrfToken' => Token::get(),
+        ];
+
+        $cache = new Cache(['name' => 'nameless', 'extension' => '.cache', 'path' => ROOT_PATH . '/cache/']);
+        $cache->setCache('backgroundcache');
+        $logo_image = $cache->retrieve('logo_image');
+        $JSVariables['logoImage'] = !empty($logo_image) ? $logo_image : null;
+
+        // jQuery-UI only on heavy interactive pages (matches DefaultRevamp behaviour)
+        if (str_contains($route, '/forum/topic/') || PAGE === 'profile') {
+            $this->assets()->include([AssetTree::JQUERY_UI]);
+        }
+
+        $JSVars = '';
+        $i = 0;
+        foreach ($JSVariables as $var => $value) {
+            $JSVars .= ($i == 0 ? 'const ' : ', ') . $var . ' = ' . json_encode($value);
+            $i++;
+        }
+
+        $this->addJSScript($JSVars);
+
+        // Nexus bundle (Alpine + helpers + legacy bridges).
+        // Loaded with defer attribute by the framework's asset resolver.
+        $this->addJSFiles([
+            $this->_template['path'] . 'assets/js/nexus.js?v=' . $this->_template['version'] => [],
+        ]);
+
+        // Preserve module ajax hook contract
+        foreach ($this->_pages->getAjaxScripts() as $script) {
+            $this->addJSScript('$.getJSON(\'' . $script . '\', function(data) {});');
+        }
+    }
+}
+
+/**
+ * @var Cache    $cache
+ * @var Language $language
+ * @var User     $user
+ * @var Pages    $pages
+ */
+$template = new Nexus_Template($cache, $language, $user, $pages);
+
+// Pagination markup hook used by core list rendering
+$template_pagination = [
+    'div' => 'nx-pagination',
+    'a' => 'nx-pagination__link',
+];

--- a/custom/templates/Nexus/template_settings/settings.php
+++ b/custom/templates/Nexus/template_settings/settings.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Nexus template settings.
+ *
+ * @license MIT
+ *
+ * @var Cache        $cache
+ * @var Language     $language
+ * @var TemplateBase $current_template
+ */
+
+if (Input::exists()) {
+    if (Token::check()) {
+        $cache->setCache('template_settings');
+
+        if (isset($_POST['nexusAccent'])) {
+            $accentInput = trim($_POST['nexusAccent']);
+            // Whitelist hex colours only.
+            if (preg_match('/^#[0-9A-Fa-f]{6}$/', $accentInput)) {
+                $cache->store('nexusAccent', $accentInput);
+            }
+        }
+
+        Session::flash('admin_templates', $language->get('admin', 'successfully_updated'));
+    } else {
+        $errors = [$language->get('general', 'invalid_token')];
+    }
+}
+
+$cache->setCache('template_settings');
+
+if ($cache->isCached('nexusAccent')) {
+    $nexusAccent = $cache->retrieve('nexusAccent');
+} else {
+    $nexusAccent = '#7C5CFF';
+    $cache->store('nexusAccent', $nexusAccent);
+}
+
+$current_template->getEngine()->addVariables([
+    'NEXUS_ACCENT' => $nexusAccent,
+    'NEXUS_ACCENT_LABEL' => 'Accent colour',
+    'NEXUS_NOTE' => 'Nexus is dark-mode first with an optional light mode toggled by users via the navbar. The accent colour below drives buttons, focus rings, and the brand gradient. After changing it, rebuild theme assets (npm run build) so Tailwind picks up the new token value.',
+    'TOKEN' => Token::get(),
+    'SUBMIT' => $language->get('general', 'submit'),
+    'SETTINGS_TEMPLATE' => ROOT_PATH . '/custom/templates/Nexus/template_settings/settings.tpl',
+]);
+
+if (isset($errors)) {
+    $current_template->getEngine()->addVariable('TEMPLATE_ERRORS', $errors);
+}

--- a/custom/templates/Nexus/template_settings/settings.tpl
+++ b/custom/templates/Nexus/template_settings/settings.tpl
@@ -1,0 +1,26 @@
+{*
+ *  Nexus · Admin template settings panel
+ *  Rendered inside the StaffCP → Layout → Templates → "Settings" view.
+ *  Uses the panel template's own chrome (so we DON'T include header/footer).
+*}
+{if isset($TEMPLATE_ERRORS)}
+  <div class="ui error message">
+    <ul class="list">
+      {foreach from=$TEMPLATE_ERRORS item=error}<li>{$error}</li>{/foreach}
+    </ul>
+  </div>
+{/if}
+
+<form action="" method="post" class="ui form">
+  <p style="color: #555;">{$NEXUS_NOTE}</p>
+
+  <div class="field">
+    <label for="nexusAccent">{$NEXUS_ACCENT_LABEL}</label>
+    <input type="text" id="nexusAccent" name="nexusAccent" value="{$NEXUS_ACCENT}"
+           placeholder="#7C5CFF" pattern="^#[0-9A-Fa-f]{6}$" maxlength="7" required>
+    <small>Hex colour, e.g. <code>#7C5CFF</code>. Theme rebuild needed after change.</small>
+  </div>
+
+  <input type="hidden" name="token" value="{$TOKEN}">
+  <button type="submit" class="ui primary button">{$SUBMIT}</button>
+</form>

--- a/custom/templates/Nexus/terms.tpl
+++ b/custom/templates/Nexus/terms.tpl
@@ -1,0 +1,11 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-3xl mx-auto">
+  <h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6">{$TERMS}</h1>
+  <div class="nx-surface p-6 sm:p-8 prose prose-invert max-w-none forum_post">
+    {$SITE_TERMS}
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/tfa.tpl
+++ b/custom/templates/Nexus/tfa.tpl
@@ -1,0 +1,32 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<div class="max-w-sm mx-auto">
+  <div class="text-center mb-6">
+    <div class="inline-flex items-center justify-center w-14 h-14 rounded-xl bg-accent-subtle text-accent mb-4">
+      {include file='components/icon.tpl' name='shield' size=26}
+    </div>
+    <h1 class="font-display text-2xl font-bold tracking-tight">{$TWO_FACTOR_AUTH}</h1>
+    <p class="text-text-secondary mt-2 text-sm">{$TFA_ENTER_CODE}</p>
+  </div>
+
+  {if isset($ERROR)}
+    <div class="nx-alert nx-alert--danger mb-5">
+      {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+      <div><div class="nx-alert__title">{$ERROR_TITLE}</div><div class="nx-alert__body">{$ERROR}</div></div>
+    </div>
+  {/if}
+
+  <div class="nx-surface p-6 sm:p-8">
+    <form class="space-y-4" action="" method="post" id="form-tfa">
+      <input type="text" name="tfa_code" inputmode="numeric" pattern="[0-9]*" autocomplete="one-time-code"
+             maxlength="6" autofocus
+             class="nx-input text-center text-2xl tracking-[0.5em] font-mono" />
+      <input type="hidden" name="tfa" value="true">
+      <input type="hidden" name="token" value="{$TOKEN}">
+      <button type="submit" class="nx-btn nx-btn--primary nx-btn--block">{$SUBMIT}</button>
+    </form>
+  </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user/alert.tpl
+++ b/custom/templates/Nexus/user/alert.tpl
@@ -1,0 +1,47 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h2 class="ui header">
+    {$TITLE}
+</h2>
+
+<div class="ui stackable grid" id="alerts">
+    <div class="ui centered row">
+        <div class="ui six wide tablet four wide computer column">
+            {include file='user/navigation.tpl'}
+        </div>
+        <div class="ui ten wide tablet twelve wide computer column">
+            <div class="ui segment">
+                <h3 class="ui header">
+                    {$ALERT_TITLE}
+                    {if !$ALERT_READ}
+                        <span class="ui green label">
+                            {$NEW}
+                        </span>
+                    {/if}
+                    <div class="res right floated">
+                        {if isset($VIEW)}
+                            <a href="{$VIEW_LINK}" class="ui mini button">{$VIEW}</a>
+                        {/if}
+                        <a href="{$BACK_LINK}" class="ui mini blue button">{$BACK}</a>
+                        <form action="{$DELETE_LINK}" method="post" style="display:inline">
+                            <input type="hidden" name="token" value="{$TOKEN}">
+                            <button type="submit" class="ui mini negative button">{$DELETE}</button>
+                        </form>
+                    </div>
+                </h3>
+                {if isset($ERROR)}
+                <div class="ui negative message">{$ERROR}</div>
+                {/if}
+
+                <div class="ui divider"></div>
+
+                <div class="forum_post">
+                    {$ALERT_CONTENT}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user/alerts.tpl
+++ b/custom/templates/Nexus/user/alerts.tpl
@@ -1,0 +1,61 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h2 class="ui header">
+    {$TITLE}
+</h2>
+
+<div class="ui stackable grid" id="alerts">
+    <div class="ui centered row">
+        <div class="ui six wide tablet four wide computer column">
+            {include file='user/navigation.tpl'}
+        </div>
+        <div class="ui ten wide tablet twelve wide computer column">
+            <div class="ui segment">
+                <h3 class="ui header">
+                    {$ALERTS}
+                    {if count($ALERTS_LIST)}
+                    <div class="res right floated">
+                        <form action="{$DELETE_ALL_LINK}" method="post" style="display:inline">
+                            <input type="hidden" name="token" value="{$TOKEN}">
+                            <button type="submit" class="ui mini negative button">{$DELETE_ALL}</button>
+                        </form>
+                    </div>
+                    {/if}
+                </h3>
+                {if isset($ERROR)}
+                <div class="ui negative message">{$ERROR}</div>
+                {/if}
+                <div class="ui middle aligned relaxed selection list">
+                    {nocache}
+                    {if count($ALERTS_LIST)}
+                    {foreach from=$ALERTS_LIST item=alert}
+                    <a class="item" href="{$alert.view_link}">
+                        <i class="angle right icon"></i>
+                        <div class="content">
+                            <div class="description">
+                                {if $alert.read eq 0}
+                                <strong>{$alert.title}</strong>
+                                {else}
+                                {$alert.title}
+                                {/if}
+                                <br />{$alert.date_nice}
+                            </div>
+                        </div>
+                    </a>
+                    {/foreach}
+                    {else}
+                    <div class="ui info message">
+                        <div class="content">
+                            {$NO_ALERTS}
+                        </div>
+                    </div>
+                    {/if}
+                    {/nocache}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user/connections.tpl
+++ b/custom/templates/Nexus/user/connections.tpl
@@ -1,0 +1,107 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h2 class="ui header">
+    {$TITLE}
+</h2>
+
+{if isset($SUCCESS)}
+<div class="ui success icon message">
+    <i class="check icon"></i>
+    <div class="content">
+        <div class="header">{$SUCCESS_TITLE}</div>
+        {$SUCCESS}
+    </div>
+</div>
+{/if}
+
+{if isset($ERRORS)}
+<div class="ui error icon message">
+    <i class="x icon"></i>
+    <div class="content">
+        <ul class="list">
+            {foreach from=$ERRORS item=error}
+            <li>{$error}</li>
+            {/foreach}
+        </ul>
+    </div>
+</div>
+{/if}
+
+<div class="ui stackable grid" id="alerts">
+    <div class="ui centered row">
+        <div class="ui six wide tablet four wide computer column">
+            {include file='user/navigation.tpl'}
+        </div>
+        <div class="ui ten wide tablet twelve wide computer column">
+            <div class="ui segment">
+                <h3 class="ui header">
+                    {$CONNECTIONS}
+                </h3>
+
+                {foreach from=$INTEGRATIONS item=integration}
+                <div class="ui segment">
+                    <div class="ui middle aligned stackable grid">
+                        <div class="one wide column right aligned mobile hidden">
+                            <svg width="14" height="14" viewBox="0 0 14 14"
+                                fill="{if $integration.connected}{if $integration.verified}green{else}orange{/if}{else}red{/if}"
+                                xmlns="http://www.w3.org/2000/svg">
+                                <path
+                                    d="M3 7C3 4.79086 4.79086 3 7 3V3C9.20914 3 11 4.79086 11 7V7C11 9.20914 9.20914 11 7 11V11C4.79086 11 3 9.20914 3 7V7Z" />
+                                <path fill-rule="evenodd" clip-rule="evenodd"
+                                    d="M7 14C3.13401 14 0 10.866 0 7C0 3.13401 3.13401 0 7 0C10.866 0 14 3.13401 14 7C14 10.866 10.866 14 7 14ZM7 3C4.79086 3 3 4.79086 3 7C3 9.20914 4.79086 11 7 11C9.20914 11 11 9.20914 11 7C11 4.79086 9.20914 3 7 3Z"
+                                    fill-opacity="0.27" />
+                            </svg>
+                        </div>
+                        <div class="nine wide column">
+                            <strong>{$integration.name}</strong>
+                            {if $integration.connected && !$integration.verified}
+                            <div class="ui orange tiny label">{$PENDING_VERIFICATION}</div> {if $integration.required}
+                            <div class="ui red tiny label">{$REQUIRED}</div>{/if}
+                            {else if !$integration.connected && $integration.required}
+                            <div class="ui red tiny label">{$REQUIRED}</div>
+                            {/if}
+                            </br>
+                            {if $integration.connected}
+                            {$integration.username}
+                            {else}
+                            {$NOT_CONNECTED}
+                            {/if}
+                        </div>
+                        <div class="six wide column right aligned">
+                            {if $integration.connected}
+                            {if $integration.connected && !$integration.verified}
+                            <form class="ui form" action="" method="post" style="display: inline">
+                                <input type="hidden" name="token" value="{$TOKEN}">
+                                <input type="hidden" name="action" value="verify">
+                                <input type="hidden" name="integration" value="{$integration.name}">
+                                <input type="submit" class="ui mini orange button" value="{$VERIFY}">
+                            </form>
+                            {/if}
+                            {if $integration.can_unlink}
+                            <form class="ui form" action="" method="post" style="display: inline">
+                                <input type="hidden" name="token" value="{$TOKEN}">
+                                <input type="hidden" name="action" value="unlink">
+                                <input type="hidden" name="integration" value="{$integration.name}">
+                                <input type="submit" class="ui mini negative button" value="{$UNLINK}">
+                            </form>
+                            {/if}
+                            {else}
+                            <form class="ui form" action="" method="post" style="display: inline">
+                                <input type="hidden" name="token" value="{$TOKEN}">
+                                <input type="hidden" name="action" value="link">
+                                <input type="hidden" name="integration" value="{$integration.name}">
+                                <input type="submit" class="ui mini positive button" value="{$CONNECT}">
+                            </form>
+                            {/if}
+                        </div>
+                    </div>
+                </div>
+                {/foreach}
+
+            </div>
+        </div>
+    </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user/index.tpl
+++ b/custom/templates/Nexus/user/index.tpl
@@ -1,0 +1,36 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6">{$TITLE}</h1>
+
+<div class="grid lg:grid-cols-[18rem_minmax(0,1fr)] gap-6" id="user">
+  <aside>{include file='user/navigation.tpl'}</aside>
+
+  <main class="min-w-0 space-y-4">
+    <div class="nx-surface p-6">
+      <h2 class="font-display text-lg font-semibold mb-4">{$OVERVIEW}</h2>
+      <dl class="space-y-3">
+        {nocache}
+        {foreach from=$USER_DETAILS_VALUES key=name item=value}
+          <div class="flex items-start gap-3 py-2 border-b border-border-subtle last:border-0">
+            <span class="text-text-muted mt-0.5">{include file='components/icon.tpl' name='chevron-right' size=14}</span>
+            <div class="flex-1 min-w-0">
+              <dt class="text-text-secondary text-sm font-medium">{$name}</dt>
+              <dd class="text-text-primary mt-0.5">{$value}</dd>
+            </div>
+          </div>
+        {/foreach}
+        {/nocache}
+      </dl>
+    </div>
+
+    {if isset($FORUM_GRAPH)}
+      <div class="nx-surface p-6">
+        <h2 class="font-display text-lg font-semibold mb-4">{$FORUM_GRAPH}</h2>
+        <div id="chartWrapper"><canvas id="dataChart" width="100%" height="40"></canvas></div>
+      </div>
+    {/if}
+  </main>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user/messaging.tpl
+++ b/custom/templates/Nexus/user/messaging.tpl
@@ -1,0 +1,81 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h2 class="ui header">
+    {$TITLE}
+</h2>
+
+<div class="ui stackable grid" id="messages">
+    <div class="ui centered row">
+        <div class="ui six wide tablet four wide computer column">
+            {include file='user/navigation.tpl'}
+        </div>
+        <div class="ui ten wide tablet twelve wide computer column">
+            <div class="ui segment">
+                <h3 class="ui header">{$MESSAGING}
+                    {if isset($NEW_MESSAGE)}
+                    <div class="res right floated">
+                        <a class="ui mini primary button" href="{$NEW_MESSAGE_LINK}">{$NEW_MESSAGE}</a>
+                    </div>
+                    {/if}
+                </h3>
+                {nocache}
+                {if count($MESSAGES)}
+                <table class="ui fixed single line selectable unstackable small padded res table">
+                    <thead>
+                        <tr>
+                            <th class="nine wide">
+                                <h5>{$MESSAGE_TITLE}</h5>
+                            </th>
+                            <th class="seven wide">
+                                <h5>{$LAST_MESSAGE}</h5>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {foreach from=$MESSAGES item=message}
+                        <tr>
+                            <td>
+                                <h5 class="ui header">
+                                    <div class="content">
+                                        <a href="{$message.link}" data-toggle="popup">{$message.title}</a>
+                                        <div class="ui wide popup">
+                                            <h4 class="ui header">{$message.title}</h4>
+                                            {$message.participants}
+                                        </div>
+                                        <div class="sub header">{$message.participants}</div>
+                                    </div>
+                                </h5>
+                            </td>
+                            <td>
+                                <h5 class="ui image header">
+                                    <img src="{$message.last_message_user_avatar}" class="ui mini circular image">
+                                    <div class="content">
+                                        <a href="{$message.last_message_user_profile}"
+                                            style="{$message.last_message_user_style}"
+                                            data-poload="{$USER_INFO_URL}{$message.last_message_user_id}">{$message.last_message_user}</a>
+                                        <div class="sub header" data-toggle="tooltip"
+                                            data-content="{$message.last_message_date_full}">
+                                            {$message.last_message_date}</div>
+                                    </div>
+                                </h5>
+                            </td>
+                        </tr>
+                        {/foreach}
+                    </tbody>
+                </table>
+                {$PAGINATION}
+                {else}
+                <div class="ui info message">
+                    <div class="content">
+                        {$NO_MESSAGES}
+                    </div>
+                </div>
+                {/if}
+                {/nocache}
+            </div>
+        </div>
+    </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user/navigation.tpl
+++ b/custom/templates/Nexus/user/navigation.tpl
@@ -1,0 +1,10 @@
+{*  Nexus · User-CP sidebar nav *}
+<nav class="nx-surface p-2 space-y-0.5 h-fit lg:sticky lg:top-20" aria-label="Account">
+  {foreach from=$CC_NAV_LINKS key=name item=item}
+    <a href="{$item.link}" target="{$item.target}"
+       class="flex items-center gap-2 px-3 py-2 rounded-md text-sm transition
+              {if isset($item.active)}bg-accent-subtle text-text-primary{else}text-text-secondary hover:text-text-primary hover:bg-bg-elevated{/if}">
+      {$item.title}
+    </a>
+  {/foreach}
+</nav>

--- a/custom/templates/Nexus/user/new_message.tpl
+++ b/custom/templates/Nexus/user/new_message.tpl
@@ -1,0 +1,58 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h2 class="ui header">
+    {$TITLE}
+</h2>
+
+{if isset($ERROR)}
+    <div class="ui error icon message">
+        <i class="x icon"></i>
+        <div class="content">
+            <div class="header">{$ERROR_TITLE}</div>
+            {$ERROR}
+        </div>
+    </div>
+{/if}
+
+<div class="ui stackable grid" id="new-message">
+    <div class="ui centered row">
+        <div class="ui six wide tablet four wide computer column">
+            {include file='user/navigation.tpl'}
+        </div>
+        <div class="ui ten wide tablet twelve wide computer column">
+            <div class="ui segment">
+                <h3 class="ui header">{$NEW_MESSAGE}</h3>
+                <form class="ui form" action="" method="post" id="form-new-message">
+                    <div class="field">
+                        <label for="inputTitle">{$MESSAGE_TITLE}</label>
+                        <input type="text" name="title" id="inputTitle" placeholder="{$MESSAGE_TITLE}"
+                            value="{$MESSAGE_TITLE_VALUE}">
+                    </div>
+                    <div class="field">
+                        <label for="InputTo">{$TO}</label>
+                        <div class="ui fluid multiple search selection dropdown">
+                            <input name="to" id="InputTo" type="hidden" {if isset($TO_USER)}value="{$TO_USER}" {/if}>
+                            <i class="dropdown icon"></i>
+                            <div class="default text">{$TO}</div>
+                            <div class="menu">
+                                {if count($ALL_USERS) > 0}
+                                    {foreach from=$ALL_USERS item="username"}
+                                        <div class="item" data-value="{$username}">{$username}</div>
+                                    {/foreach}
+                                {/if}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="field">
+                        <textarea name="content" id="reply"></textarea>
+                    </div>
+                    <input type="hidden" name="token" value="{$TOKEN}">
+                    <input type="submit" class="ui primary button" value="{$SUBMIT}">
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user/notification_settings.tpl
+++ b/custom/templates/Nexus/user/notification_settings.tpl
@@ -1,0 +1,78 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h2 class="ui header">
+    {$TITLE}
+</h2>
+
+<div class="ui stackable grid" id="notification_settings">
+    <div class="ui centered row">
+        <div class="ui six wide tablet four wide computer column">
+            {include file='user/navigation.tpl'}
+        </div>
+        <div class="ui ten wide tablet twelve wide computer column">
+            <div class="ui segment">
+                <h3 class="ui header">{$NOTIFICATION_SETTINGS_TITLE}</h3>
+
+                {if isset($SUCCESS)}
+                    <div class="ui success icon message">
+                        <i class="check icon"></i>
+                        <div class="content">
+                            <div class="header">{$SUCCESS_TITLE}</div>
+                            {$SUCCESS}
+                        </div>
+                    </div>
+                {/if}
+
+                {if isset($ERRORS)}
+                    <div class="ui error icon message">
+                        <i class="x icon"></i>
+                        <div class="content">
+                            <ul class="list">
+                                {foreach from=$ERRORS item=error}
+                                    <li>{$error}</li>
+                                {/foreach}
+                            </ul>
+                        </div>
+                    </div>
+                {/if}
+
+                <form action="" method="post">
+                    <table class="ui definition celled table">
+                        <thead>
+                            <tr>
+                                <th class="four wide"></th>
+                                <th class="six wide">{$ALERT}</th>
+                                <th class="six wide">{$EMAIL}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {foreach $NOTIFICATION_SETTINGS as $setting}
+                                <tr>
+                                    <td>{$setting.value}</td>
+                                    <td>
+                                        <div class="ui toggle checkbox">
+                                            <input type="checkbox" name="{$setting.type}:alert"{if $setting.alert} checked{/if}>
+                                            <label class="screenreader-only">{$ALERT}</label>
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <div class="ui toggle checkbox">
+                                            <input type="checkbox" name="{$setting.type}:email"{if $setting.email} checked{/if}>
+                                            <label class="screenreader-only">{$EMAIL}</label>
+                                        </div>
+                                    </td>
+                                </tr>
+                            {/foreach}
+                        </tbody>
+                    </table>
+
+                    <input type="hidden" name="token" value="{$TOKEN}">
+                    <input type="submit" class="ui primary button" value="{$SUBMIT}">
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user/oauth.tpl
+++ b/custom/templates/Nexus/user/oauth.tpl
@@ -1,0 +1,122 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h2 class="ui header">
+    {$USER_CP}
+</h2>
+
+<div class="ui stackable grid" id="alerts">
+    <div class="ui centered row">
+        <div class="ui six wide tablet four wide computer column">
+            {include file='user/navigation.tpl'}
+        </div>
+        <div class="ui ten wide tablet twelve wide computer column">
+            <div class="ui segment">
+                <h3 class="ui header">
+                    {$OAUTH}
+                </h3>
+                {if isset($SUCCESS_MESSAGE)}
+                <div class="ui success icon message">
+                    <i class="check icon"></i>
+                    <div class="content">
+                        <div class="header">{$SUCCESS}</div>
+                        {$SUCCESS_MESSAGE}
+                    </div>
+                </div>
+                {/if}
+                {if isset($ERROR_MESSAGE)}
+                <div class="ui negative icon message">
+                    <i class="x icon"></i>
+                    <div class="content">
+                        <div class="header">{$ERROR}</div>
+                        {$ERROR_MESSAGE}
+                    </div>
+                </div>
+                {/if}
+                <div class="ui middle aligned relaxed selection list">
+                    {nocache}
+                    {if count($OAUTH_PROVIDERS)}
+                    <table class="ui striped table">
+                        <tbody>
+                            {foreach $OAUTH_PROVIDERS as $provider_name => $provider_data}
+                            <tr>
+                                <td>
+                                    <div class="ui stackable middle aligned grid">
+                                        <div class="row">
+                                            <div class="ten wide column">
+                                                {if $provider_data.icon}
+                                                <i class="{$provider_data.icon} fa-lg">&nbsp;</i>
+                                                {/if}
+                                                {$provider_name|ucfirst}
+                                            </div>
+                                            <div class="four wide column">
+                                                {if isset($USER_OAUTH_PROVIDERS[$provider_name])}
+                                                <div class="res right floated">
+                                                    <code>{$USER_OAUTH_PROVIDERS[$provider_name]->provider_id}</code>
+                                                </div>
+                                                {/if}
+                                            </div>
+                                            <div class="two wide column right aligned">
+                                                {if isset($USER_OAUTH_PROVIDERS[$provider_name])}
+                                                <a class="ui mini red button" href="#" data-toggle="modal"
+                                                    data-target="#modal-unlink-{$provider_name}">{$UNLINK}</a>
+                                                {else}
+                                                <a class="ui mini green button" href="#" data-toggle="modal"
+                                                    data-target="#modal-link-{$provider_name}">{$LINK}</a>
+                                                {/if}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            {/foreach}
+                        </tbody>
+                    </table>
+                    {else}
+                    <div class="ui info message">
+                        <div class="content">
+                            {$NO_PROVIDERS}
+                        </div>
+                    </div>
+                    {/if}
+                    {/nocache}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{foreach $OAUTH_PROVIDERS as $provider_name => $provider_data}
+<div class="ui small modal" id="modal-unlink-{$provider_name}">
+    <div class="header">
+        {$UNLINK} {$provider_name|ucfirst}
+    </div>
+    <div class="content">
+        {$OAUTH_MESSAGES[$provider_name]['unlink_confirm']}
+    </div>
+    <div class="actions">
+        <a class="ui negative button">{$NO}</a>
+        <form class="ui form" action="" method="post" style="display: inline">
+            <input type="hidden" name="token" value="{$TOKEN}">
+            <input type="hidden" name="action" value="unlink">
+            <input type="hidden" name="provider" value="{$provider_name}">
+            <input type="submit" class="ui green button" value="{$YES}">
+        </form>
+    </div>
+</div>
+
+<div class="ui small modal" id="modal-link-{$provider_name}">
+    <div class="header">
+        {$LINK} {$provider_name|ucfirst}
+    </div>
+    <div class="content">
+        {$OAUTH_MESSAGES[$provider_name]['link_confirm']}
+    </div>
+    <div class="actions">
+        <a class="ui negative button">{$NO}</a>
+        <a class="ui green button" href="{$provider_data.url}">{$CONFIRM}</a>
+    </div>
+</div>
+{/foreach}
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user/placeholders.tpl
+++ b/custom/templates/Nexus/user/placeholders.tpl
@@ -1,0 +1,98 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h2 class="ui header">
+    {$TITLE}
+</h2>
+
+{if isset($SUCCESS)}
+<div class="ui success icon message">
+    <i class="check icon"></i>
+    <div class="content">
+        <div class="header">{$SUCCESS_TITLE}</div>
+        {$SUCCESS}
+    </div>
+</div>
+{/if}
+
+{if isset($ERRORS)}
+<div class="ui error icon message">
+    <i class="x icon"></i>
+    <div class="content">
+        <ul class="list">
+            {foreach from=$ERRORS item=error}
+            <li>{$error}</li>
+            {/foreach}
+        </ul>
+    </div>
+</div>
+{/if}
+
+<div class="ui stackable grid" id="alerts">
+    <div class="ui centered row">
+        <div class="ui six wide tablet four wide computer column">
+            {include file='user/navigation.tpl'}
+        </div>
+        <div class="ui ten wide tablet twelve wide computer column">
+            <div class="ui segment">
+                <h3 class="ui header">
+                    {$PLACEHOLDERS}
+                </h3>
+                <div class="ui middle aligned">
+                    {nocache}
+                    {if count($PLACEHOLDERS_LIST)}
+                    <table class="ui fixed single line selectable unstackable small padded res table">
+                        <thead>
+                            <tr>
+                                <th>{$NAME}</th>
+                                <th>{$VALUE}</th>
+                                <th>{$LAST_UPDATED}</th>
+                                <th>{$SHOW_ON_PROFILE}</th>
+                                <th>{$SHOW_ON_FORUM}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+
+                            {foreach from=$PLACEHOLDERS_LIST item=data}
+                            <tr>
+                                <td>
+                                    {$data.friendly_name}
+                                </td>
+                                <td>
+                                    {$data.value}
+                                </td>
+                                <td>
+                                    {$data.last_updated}
+                                </td>
+                                <td>
+                                    {if $data.show_on_profile eq 1}
+                                    <i class="fa fa-check-circle"></i>
+                                    {else}
+                                    <i class="fa fa-times-circle"></i>
+                                    {/if}
+                                </td>
+                                <td>
+                                    {if $data.show_on_forum eq 1}
+                                    <i class="fa fa-check-circle"></i>
+                                    {else}
+                                    <i class="fa fa-times-circle"></i>
+                                    {/if}
+                                </td>
+                            </tr>
+                            {/foreach}
+                    </table>
+                    {else}
+                    <div class="ui info message">
+                        <div class="content">
+                            {$NO_PLACEHOLDERS}
+                        </div>
+                    </div>
+                    {/if}
+                    {/nocache}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user/sessions.tpl
+++ b/custom/templates/Nexus/user/sessions.tpl
@@ -1,0 +1,118 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h2 class="ui header">
+    {$SESSIONS}
+</h2>
+
+<div class="ui stackable grid" id="alerts">
+    <div class="ui centered row">
+        <div class="ui six wide tablet four wide computer column">
+            {include file='user/navigation.tpl'}
+        </div>
+        <div class="ui ten wide tablet twelve wide computer column">
+            <div class="ui segment">
+                <h3 class="ui header">
+                    {$SESSIONS}
+                    {if $CAN_LOGOUT_ALL}
+                        <div class="right floated">
+                            <a class="ui mini negative button" href="#" data-toggle="modal" data-target="#modal-logout-all">
+                                {$LOGOUT_OTHER_SESSIONS}
+                            </a>
+                        </div>
+                    {/if}
+                </h3>
+                {if isset($SUCCESS_MESSAGE)}
+                    <div class="ui success icon message">
+                        <i class="check icon"></i>
+                        <div class="content">
+                            <div class="header">{$SUCCESS}</div>
+                            {$SUCCESS_MESSAGE}
+                        </div>
+                    </div>
+                {/if}
+                {if isset($ERROR_MESSAGE)}
+                    <div class="ui negative icon message">
+                        <i class="x icon"></i>
+                        <div class="content">
+                            <div class="header">{$ERROR}</div>
+                            {$ERROR_MESSAGE}
+                        </div>
+                    </div>
+                {/if}
+                {foreach from=$SESSIONS_LIST item=session}
+                    <div class="ui segment">
+                        <div class="ui middle aligned stackable grid">
+                            <div class="one wide column">
+                                <i class="{if $session.device_type === 'phone'}mobile alternate{elseif $session.device_type === 'tablet'}tablet alternate{elseif $session.device_type === 'laptop'}laptop alternate{else}desktop{/if} icon big"></i>
+                            </div>
+                            <div class="nine wide column">
+                                <span>{$session.device_os} &middot; {$session.device_browser} {$session.device_browser_version}</span>
+                                <br>
+                                {$session.location}, {if $session.is_current}<span class="ui success text">{$THIS_DEVICE}</span>{else}<span data-tooltip="{$session.last_seen}">{$session.last_active}</span>{/if}
+                                {if $session.is_admin}
+                                    <br>
+                                    <span class="ui mini label">
+                                        <i class="user secret icon"></i> {$ADMIN_LOGGED_IN}
+                                    </span>
+                                {elseif $session.is_remembered}
+                                    <br>
+                                    <span class="ui mini label">
+                                        <i class="check icon"></i> {$REMEMBERED}
+                                    </span>
+                                {/if}
+                            </div>
+                            <div class="six wide column right aligned">
+                                {if !$session.is_current}
+                                    <a class="ui mini negative button" href="#" data-toggle="modal" data-target="#modal-logout-{$session.id}">
+                                        {$LOGOUT}
+                                    </a>
+                                {/if}
+                            </div>
+                        </div>
+                    </div>
+                {/foreach}
+            </div>
+        </div>
+    </div>
+</div>
+
+{if $CAN_LOGOUT_ALL}
+    <div class="ui small modal" id="modal-logout-all">
+        <div class="header">
+            {$LOGOUT}
+        </div>
+        <div class="content">
+            {$LOGOUT_ALL_CONFIRM}
+        </div>
+        <div class="actions">
+            <a class="ui negative button">{$NO}</a>
+            <form action="" method="post" style="display: inline;">
+                <input type="hidden" name="token" value="{$TOKEN}" />
+                <input type="hidden" name="action" value="logout_other_sessions" />
+                <input type="submit" class="ui green button" value="{$YES}" />
+            </form>
+        </div>
+    </div>
+{/if}
+
+{foreach from=$SESSIONS_LIST item=session}
+    <div class="ui small modal" id="modal-logout-{$session.id}">
+        <div class="header">
+            {$LOGOUT}
+        </div>
+        <div class="content">
+            {$LOGOUT_CONFIRM}
+        </div>
+        <div class="actions">
+            <a class="ui negative button">{$NO}</a>
+            <form action="" method="post" style="display: inline;">
+                <input type="hidden" name="token" value="{$TOKEN}" />
+                <input type="hidden" name="session_hash" value="{$session.id}" />
+                <input type="submit" class="ui green button" value="{$YES}" />
+            </form>
+        </div>
+    </div>
+{/foreach}
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user/settings.tpl
+++ b/custom/templates/Nexus/user/settings.tpl
@@ -1,0 +1,172 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h1 class="font-display text-2xl sm:text-3xl font-bold tracking-tight mb-6">{$TITLE}</h1>
+
+{if !empty($SUCCESS)}
+  <div class="nx-alert nx-alert--success mb-4">
+    {include file='components/icon.tpl' name='check' size=18 class="nx-alert__icon"}
+    <div><div class="nx-alert__title">{$SUCCESS_TITLE}</div><div class="nx-alert__body">{$SUCCESS}</div></div>
+  </div>
+{/if}
+{if (isset($ERRORS) || isset($ERROR))}
+  <div class="nx-alert nx-alert--danger mb-4">
+    {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+    <div class="flex-1">
+      <ul class="nx-alert__body list-disc pl-4 space-y-0.5">
+        {foreach from=$ERRORS item=error}<li>{$error}</li>{/foreach}
+        {if isset($ERROR)}<li>{$ERROR}</li>{/if}
+      </ul>
+    </div>
+  </div>
+{/if}
+
+<div class="grid lg:grid-cols-[18rem_minmax(0,1fr)] gap-6" id="user-settings">
+  <aside>{include file='user/navigation.tpl'}</aside>
+
+  <main class="min-w-0 space-y-4">
+
+    <section class="nx-surface p-6">
+      <h2 class="font-display text-lg font-semibold mb-4">{$SETTINGS}</h2>
+      <form class="space-y-4" action="" method="post" id="form-user-settings">
+        {nocache}
+        {foreach from=$PROFILE_FIELDS key=name item=field}
+          {if !isset($field.disabled)}
+            <div class="nx-field">
+              <label class="nx-label" for="input{$field.id}">{$field.name}{if $field.required}<span class="nx-required">*</span>{/if}</label>
+              {if $field.type == "text"}
+                <input type="text" name="{if $name == 'nickname'}nickname{else}profile_fields[{$field.id}]{/if}" id="input{$field.id}" value="{$field.value}" placeholder="{$field.description}" class="nx-input" />
+              {elseif $field.type == "textarea"}
+                <textarea name="profile_fields[{$field.id}]" id="input{$field.id}" placeholder="{$field.description}" class="nx-textarea">{$field.value}</textarea>
+              {elseif $field.type == "date"}
+                <input type="date" name="profile_fields[{$field.id}]" id="input{$field.id}" value="{$field.value}" class="nx-input" />
+              {/if}
+            </div>
+          {/if}
+        {/foreach}
+
+        {if isset($TOPIC_UPDATES)}
+          <div class="nx-field"><label class="nx-label" for="inputTopicUpdates">{$TOPIC_UPDATES}</label>
+            <select class="nx-select" name="topicUpdates" id="inputTopicUpdates">
+              <option value="1" {if $TOPIC_UPDATES_ENABLED==true}selected{/if}>{$ENABLED}</option>
+              <option value="0" {if $TOPIC_UPDATES_ENABLED==false}selected{/if}>{$DISABLED}</option>
+            </select></div>
+        {/if}
+        {if isset($AUTHME_SYNC_PASSWORD)}
+          <div class="nx-field"><label class="nx-label" for="inputAuthmeSync">{$AUTHME_SYNC_PASSWORD} <span class="text-text-muted ml-1" title="{$AUTHME_SYNC_PASSWORD_INFO}">ⓘ</span></label>
+            <select class="nx-select" name="authmeSync" id="inputAuthmeSync">
+              <option value="1" {if $AUTHME_SYNC_PASSWORD_ENABLED==true}selected{/if}>{$ENABLED}</option>
+              <option value="0" {if $AUTHME_SYNC_PASSWORD_ENABLED==false}selected{/if}>{$DISABLED}</option>
+            </select></div>
+        {/if}
+        {if isset($PRIVATE_PROFILE)}
+          <div class="nx-field"><label class="nx-label" for="inputPrivateProfile">{$PRIVATE_PROFILE}</label>
+            <select class="nx-select" name="privateProfile" id="inputPrivateProfile">
+              <option value="1" {if $PRIVATE_PROFILE_ENABLED==true}selected{/if}>{$ENABLED}</option>
+              <option value="0" {if $PRIVATE_PROFILE_ENABLED==false}selected{/if}>{$DISABLED}</option>
+            </select></div>
+        {/if}
+        {if isset($CUSTOM_AVATARS)}
+          <div class="nx-field"><label class="nx-label" for="inputGravatar">{$GRAVATAR}</label>
+            <select class="nx-select" name="gravatar" id="inputGravatar">
+              <option value="0" {if $GRAVATAR_VALUE=='0'}selected{/if}>{$DISABLED}</option>
+              <option value="1" {if $GRAVATAR_VALUE=='1'}selected{/if}>{$ENABLED}</option>
+            </select></div>
+        {/if}
+        <div class="nx-field"><label class="nx-label" for="inputLanguage">{$ACTIVE_LANGUAGE}</label>
+          <select class="nx-select" name="language" id="inputLanguage">
+            {foreach from=$LANGUAGES item=language}<option value="{$language.name}" {if $language.active}selected{/if}>{$language.name}</option>{/foreach}
+          </select></div>
+        {if count($TEMPLATES) > 2}
+          <div class="nx-field"><label class="nx-label" for="inputTemplate">{$ACTIVE_TEMPLATE}</label>
+            <select class="nx-select" name="template" id="inputTemplate">
+              {foreach from=$TEMPLATES item=template}<option value="{$template.id}" {if $template.active==true}selected{/if}>{$template.name}</option>{/foreach}
+            </select></div>
+        {/if}
+        <div class="nx-field"><label class="nx-label" for="inputTimezone">{$TIMEZONE}</label>
+          <select class="nx-select" name="timezone" id="inputTimezone">
+            {foreach from=$TIMEZONES key=KEY item=ITEM}<option value="{$KEY}" {if $SELECTED_TIMEZONE eq $KEY}selected{/if}>({$ITEM.offset}) {$ITEM.name} &middot; ({$ITEM.time})</option>{/foreach}
+          </select></div>
+        {if isset($SIGNATURE)}
+          <div class="nx-field"><label class="nx-label" for="inputSignature">{$SIGNATURE}</label>
+            <textarea name="signature" id="inputSignature" class="nx-textarea">{$SIGNATURE_VALUE}</textarea></div>
+        {/if}
+        {/nocache}
+        <input type="hidden" name="action" value="settings">
+        <input type="hidden" name="token" value="{$TOKEN}">
+        <button type="submit" class="nx-btn nx-btn--primary">{$SUBMIT}</button>
+      </form>
+    </section>
+
+    <section class="nx-surface p-6">
+      <h2 class="font-display text-lg font-semibold mb-4">{$CHANGE_EMAIL_ADDRESS}</h2>
+      <form class="space-y-4" action="" method="post" id="form-user-email">
+        <div class="nx-field"><label class="nx-label" for="inputPassword">{$CURRENT_PASSWORD}</label>
+          <input type="password" name="password" id="inputPassword" class="nx-input" autocomplete="current-password" /></div>
+        <div class="nx-field"><label class="nx-label" for="inputEmail">{$EMAIL_ADDRESS}</label>
+          <input type="email" name="email" id="inputEmail" value="{$CURRENT_EMAIL}" class="nx-input" autocomplete="email" /></div>
+        <input type="hidden" name="action" value="email">
+        <input type="hidden" name="token" value="{$TOKEN}">
+        <button type="submit" class="nx-btn nx-btn--primary">{$SUBMIT}</button>
+      </form>
+    </section>
+
+    <section class="nx-surface p-6">
+      <h2 class="font-display text-lg font-semibold mb-4">{$CHANGE_PASSWORD}</h2>
+      <form class="space-y-4" action="" method="post" id="form-user-password">
+        <div class="nx-field"><label class="nx-label" for="inputOldPassword">{$CURRENT_PASSWORD}</label>
+          <input type="password" name="old_password" id="inputOldPassword" class="nx-input" autocomplete="current-password" /></div>
+        <div class="nx-field"><label class="nx-label" for="inputNewPassword">{$NEW_PASSWORD}</label>
+          <input type="password" name="new_password" id="inputNewPassword" class="nx-input" autocomplete="new-password" /></div>
+        <div class="nx-field"><label class="nx-label" for="inputNewPasswordAgain">{$CONFIRM_NEW_PASSWORD}</label>
+          <input type="password" name="new_password_again" id="inputNewPasswordAgain" class="nx-input" autocomplete="new-password" /></div>
+        <input type="hidden" name="action" value="password">
+        <input type="hidden" name="token" value="{$TOKEN}">
+        <button type="submit" class="nx-btn nx-btn--primary">{$SUBMIT}</button>
+      </form>
+    </section>
+
+    <section class="nx-surface p-6">
+      <h2 class="font-display text-lg font-semibold mb-4 flex items-center gap-2">
+        {include file='components/icon.tpl' name='shield' size=18 class="text-accent"}{$TWO_FACTOR_AUTH}
+      </h2>
+      {if isset($ENABLE)}
+        <a class="nx-btn nx-btn--success" href="{$ENABLE_LINK}">{$ENABLE}</a>
+      {elseif isset($FORCED)}
+        <button class="nx-btn nx-btn--danger" disabled>{$DISABLE}</button>
+      {else}
+        <form action="{$DISABLE_LINK}" method="post">
+          <input type="hidden" name="token" value="{$TOKEN}">
+          <button type="submit" class="nx-btn nx-btn--danger">{$DISABLE}</button>
+        </form>
+      {/if}
+    </section>
+
+    {if isset($CUSTOM_AVATARS)}
+      <section class="nx-surface p-6">
+        <h2 class="font-display text-lg font-semibold mb-4">{$UPLOAD_NEW_PROFILE_IMAGE}</h2>
+        <form class="space-y-4" action="{$CUSTOM_AVATARS_SCRIPT}" method="post" enctype="multipart/form-data" id="form-user-avatar">
+          <label class="nx-btn nx-btn--outline cursor-pointer">
+            {include file='components/icon.tpl' name='arrow-up' size=14}{$BROWSE}
+            <input type="file" name="file" hidden />
+          </label>
+          <input type="hidden" name="type" value="avatar">
+          <input type="hidden" name="token" value="{$TOKEN}">
+          <button type="submit" class="nx-btn nx-btn--primary">{$SUBMIT}</button>
+        </form>
+      </section>
+      {if $HAS_CUSTOM_AVATAR}
+        <section class="nx-surface p-6">
+          <h2 class="font-display text-lg font-semibold mb-4">{$REMOVE_AVATAR}</h2>
+          <form action="" method="post" id="form-reset-avatar">
+            <input type="hidden" name="action" value="reset_avatar">
+            <input type="hidden" name="token" value="{$TOKEN}">
+            <button type="submit" class="nx-btn nx-btn--danger">{$REMOVE}</button>
+          </form>
+        </section>
+      {/if}
+    {/if}
+  </main>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user/tfa.tpl
+++ b/custom/templates/Nexus/user/tfa.tpl
@@ -1,0 +1,73 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h2 class="ui header">
+    {$TITLE}
+</h2>
+
+{if isset($ERROR)}
+<div class="ui error icon message">
+    <i class="x icon"></i>
+    <div class="content">
+        <div class="header">{$ERROR_TITLE}</div>
+        {$ERROR}
+    </div>
+</div>
+{/if}
+{if isset($ERRORS)}
+<div class="ui error icon message">
+    <i class="x icon"></i>
+    <div class="content">
+        <ul class="list">
+            {foreach from=$ERRORS item=error}
+            <li>{$error}</li>
+            {/foreach}
+        </ul>
+    </div>
+</div>
+{/if}
+
+<div class="ui stackable grid" id="tfa-code">
+    <div class="ui centered row">
+        <div class="ui six wide tablet four wide computer column">
+            {include file='user/navigation.tpl'}
+        </div>
+        <div class="ui ten wide tablet twelve wide computer column">
+            <div class="ui segment">
+                <h3 class="ui header">{$TWO_FACTOR_AUTH}</h3>
+                {if isset($TFA_SCAN_CODE_TEXT)}
+                <div class="ui form">
+                    <div class="field">
+                        {$TFA_SCAN_CODE_TEXT}
+                        <br />
+                        <img src="{$IMG_SRC}">
+                    </div>
+                </div>
+                <div class="ui info message">
+                    {$TFA_CODE_TEXT} <strong>{$TFA_CODE}</strong>
+                </div>
+                <a class="ui primary button" href="{$LINK}">{$NEXT}</a>
+                <form class="ui form" action="{$CANCEL_LINK}" method="post">
+                    <input type="hidden" name="token" value="{$TOKEN}">
+                    <input type="submit" value="{$CANCEL}" class="ui red button">
+                </form>
+                {else}
+                <form class="ui form" action="" method="post" id="form-tfa-code">
+                    <div class="field">
+                        {$TFA_ENTER_CODE}
+                        <input type="text" name="tfa_code">
+                    </div>
+                    <input type="hidden" name="token" value="{$TOKEN}">
+                    <input type="submit" class="ui primary button" value="{$SUBMIT}">
+                    <form class="ui form" action="{$CANCEL_LINK}" method="post">
+                        <input type="hidden" name="token" value="{$TOKEN}">
+                        <input type="submit" value="{$CANCEL}" class="ui negative button">
+                    </form>
+                </form>
+                {/if}
+            </div>
+        </div>
+    </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user/view_message.tpl
+++ b/custom/templates/Nexus/user/view_message.tpl
@@ -1,0 +1,95 @@
+{include file='header.tpl'}
+{include file='navbar.tpl'}
+
+<h2 class="ui header">
+    {$TITLE}
+</h2>
+
+{if isset($ERROR)}
+<div class="ui error icon message">
+    <i class="x icon"></i>
+    <div class="content">
+        <div class="header">{$ERROR_TITLE}</div>
+        {$ERROR}
+    </div>
+</div>
+{/if}
+
+{if isset($MESSAGE_SENT)}
+<div class="ui success icon message">
+    <i class="check icon"></i>
+    <div class="content">
+        <div class="header">{$SUCCESS_TITLE}</div>
+        {$MESSAGE_SENT}
+    </div>
+</div>
+{/if}
+
+<div class="ui stackable grid" id="view-message">
+    <div class="ui centered row">
+        <div class="ui six wide tablet four wide computer column">
+            {include file='user/navigation.tpl'}
+        </div>
+        <div class="ui ten wide tablet twelve wide computer column">
+            <div class="ui segment">
+                <h3 class="ui header">
+                    {$MESSAGE_TITLE}
+                    <div class="sub header">{$PARTICIPANTS_TEXT}: {$PARTICIPANTS}</div>
+                </h3>
+            </div>
+            {$PAGINATION}
+            <div class="res right floated">
+                <a class="ui small primary button" href="{$BACK_LINK}">{$BACK}</a>
+                <button class="ui small negative button" type="button" data-toggle="modal"
+                    data-target="#modal-leave">{$LEAVE_CONVERSATION}</button>
+            </div>
+            {foreach from=$MESSAGES item=message}
+            <div class="ui fluid card" id="message">
+                <div class="content">
+                    <img class="ui left floated mini circular image" src="{$message.author_avatar}">
+                    <div class="header">
+                        <a href="{$message.author_profile}" data-poload="{$USER_INFO_URL}{$message.author_id}"
+                            style="{$message.author_style}">{$message.author_username}</a>
+                    </div>
+                    <div class="meta">
+                        <span data-toggle="tooltip"
+                            data-content="{$message.message_date_full}">{$message.message_date}</span>
+                    </div>
+                    <div class="description forum_post">
+                        {$message.content}
+                    </div>
+                </div>
+            </div>
+            {/foreach}
+            {$PAGINATION}
+            <div class="ui segment">
+                <h3 class="ui header">{$NEW_REPLY}</h3>
+                <form class="ui form" action="" method="post">
+                    <div class="field">
+                        <textarea name="content" id="reply"></textarea>
+                    </div>
+                    <input type="hidden" name="token" value="{$TOKEN}">
+                    <input type="submit" class="ui primary button" value="{$SUBMIT}">
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="ui small modal" id="modal-leave">
+    <div class="header">
+        {$LEAVE_CONVERSATION}
+    </div>
+    <div class="content">
+        {$CONFIRM_LEAVE}
+        <form action="{$LEAVE_CONVERSATION_LINK}" method="post" id="leave-form">
+            <input type="hidden" name="token" value="{$TOKEN}">
+        </form>
+    </div>
+    <div class="actions">
+        <a class="ui negative button">{$NO}</a>
+        <a class="ui positive button" onclick="$('#leave-form').submit();">{$YES}</a>
+    </div>
+</div>
+
+{include file='footer.tpl'}

--- a/custom/templates/Nexus/user_not_exist.tpl
+++ b/custom/templates/Nexus/user_not_exist.tpl
@@ -1,0 +1,15 @@
+{include file='header.tpl'}
+
+<div class="nx-container py-16 text-center">
+  <div class="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-bg-elevated text-text-muted mb-4">
+    {include file='components/icon.tpl' name='user' size=28}
+  </div>
+  <h1 class="font-display text-3xl font-bold tracking-tight mb-2">404</h1>
+  <p class="text-text-secondary text-sm mb-6">User does not exist.</p>
+  <div class="flex justify-center gap-2">
+    <button class="nx-btn nx-btn--outline" onclick="javascript:history.go(-1)">Back</button>
+    <a class="nx-btn nx-btn--primary" href="/">Home</a>
+  </div>
+</div>
+</body>
+</html>

--- a/custom/templates/Nexus/user_popover.tpl
+++ b/custom/templates/Nexus/user_popover.tpl
@@ -1,0 +1,44 @@
+{*
+ *  Nexus · User popover (returned via ajax for hover-cards)
+*}
+<div id="user-popup" class="nx-surface-elevated p-4 min-w-[260px]">
+  <div class="flex items-center gap-3 mb-2">
+    <span class="nx-avatar"><img src="{$AVATAR}" alt="{$USERNAME}" loading="lazy" /></span>
+    <div class="flex-1 min-w-0">
+      <h4 class="font-display font-semibold text-text-primary truncate" style="{$STYLE}">{$NICKNAME}</h4>
+      <div class="flex flex-wrap gap-1 mt-1">
+        {if count($GROUPS)}
+          {foreach from=$GROUPS item=group_html}{$group_html}{/foreach}
+        {else}
+          <span class="nx-badge">{$GUEST}</span>
+        {/if}
+      </div>
+    </div>
+  </div>
+
+  {if isset($REGISTERED)}
+    <hr class="border-border-subtle my-3" />
+    <dl class="space-y-1 text-sm">
+      <div class="flex justify-between gap-3">
+        <dt class="text-text-muted">{$REGISTERED|regex_replace:'/[:].*/':''}</dt>
+        <dd class="text-text-primary font-medium" title="{$REGISTERED_DATE}">{$REGISTERED|regex_replace:'/^[^:]+:\h*/':''}</dd>
+      </div>
+      {if isset($LAST_SEEN)}
+        <div class="flex justify-between gap-3">
+          <dt class="text-text-muted">{$LAST_SEEN|regex_replace:'/[:].*/':''}</dt>
+          <dd class="text-text-primary font-medium" title="{$LAST_SEEN_DATE}">{$LAST_SEEN|regex_replace:'/^[^:]+:\h*/':''}</dd>
+        </div>
+      {/if}
+      {if isset($TOPICS) && isset($POSTS)}
+        <div class="flex justify-between gap-3">
+          <dt class="text-text-muted">{$TOPICS|regex_replace:'/[0-9]+/':''|capitalize}</dt>
+          <dd class="text-text-primary font-medium">{$TOPICS|regex_replace:'/[^0-9]+/':''}</dd>
+        </div>
+        <div class="flex justify-between gap-3">
+          <dt class="text-text-muted">{$POSTS|regex_replace:'/[0-9]+/':''|capitalize}</dt>
+          <dd class="text-text-primary font-medium">{$POSTS|regex_replace:'/[^0-9]+/':''}</dd>
+        </div>
+      {/if}
+    </dl>
+  {/if}
+</div>

--- a/custom/templates/Nexus/widgets/cookie_notice.tpl
+++ b/custom/templates/Nexus/widgets/cookie_notice.tpl
@@ -1,0 +1,9 @@
+<div class="nx-surface overflow-hidden">
+  <header class="nx-card__header"><h3 class="nx-card__title">{$COOKIE_NOTICE_HEADER}</h3></header>
+  <div class="p-4 space-y-3">
+    <p class="text-text-secondary text-sm">{$COOKIE_NOTICE_BODY}</p>
+    {if $COOKIE_DECISION_MADE}
+      <a class="nx-btn nx-btn--primary nx-btn--block" href="{$COOKIE_URL}">{$COOKIE_NOTICE_CONFIGURE}</a>
+    {/if}
+  </div>
+</div>

--- a/custom/templates/Nexus/widgets/forum/latest_posts.tpl
+++ b/custom/templates/Nexus/widgets/forum/latest_posts.tpl
@@ -1,0 +1,21 @@
+<div class="nx-surface overflow-hidden" id="widget-latest-posts">
+  <header class="nx-card__header"><h3 class="nx-card__title">{$LATEST_POSTS}</h3></header>
+  <div class="p-4">
+    <ul class="space-y-3">
+      {foreach from=$LATEST_POSTS_ARRAY name=latest_posts item=post}
+        <li class="flex gap-2.5 pb-3 border-b border-border-subtle last:pb-0 last:border-0">
+          <span class="nx-avatar nx-avatar--sm flex-shrink-0"><img src="{$post.last_reply_avatar}" alt="{$post.last_reply_username}" loading="lazy" /></span>
+          <div class="flex-1 min-w-0">
+            <a href="{$post.last_reply_link}" class="block text-sm text-text-primary hover:text-accent transition font-medium truncate">{$post.topic_title}</a>
+            <div class="text-xs text-text-muted mt-0.5 truncate">
+              <a href="{$post.last_reply_profile_link}" style="{$post.last_reply_style}" data-poload="{$USER_INFO_URL}{$post.last_reply_user_id}" class="hover:text-text-primary">{$post.last_reply_username}</a>
+              · <span title="{$post.last_reply}">{$post.last_reply_rough}</span>
+            </div>
+          </div>
+        </li>
+      {foreachelse}
+        <li class="text-sm text-text-muted">{$NO_POSTS_FOUND}</li>
+      {/foreach}
+    </ul>
+  </div>
+</div>

--- a/custom/templates/Nexus/widgets/minecraft_account.tpl
+++ b/custom/templates/Nexus/widgets/minecraft_account.tpl
@@ -1,0 +1,32 @@
+<div class="nx-surface overflow-hidden">
+  <header class="nx-card__header"><h3 class="nx-card__title">{$MINECRAFT_ACCOUNT}</h3></header>
+  <div class="p-4 flex justify-center">
+    <canvas id="skin_container"></canvas>
+  </div>
+  <footer class="nx-card__footer text-xs">
+    <span>
+      {$LAST_SEEN_TEXT}
+      <span {if !$ALL_UNKNOWN}title="{$LAST_ONLINE}"{/if}>{$LAST_ONLINE_AGO}</span>
+      {$ON}
+      <span {if !$ALL_UNKNOWN && !$SERVER_UNKNOWN}onclick="copy('#last_seen_ip')" class="cursor-pointer hover:text-text-primary transition" title="{$LAST_ONLINE_SERVER_IP}"{/if}>{$LAST_ONLINE_SERVER}</span>
+      {if !$ALL_UNKNOWN && !$SERVER_UNKNOWN}<span class="hidden" id="last_seen_ip">{$LAST_ONLINE_SERVER_IP}</span>{/if}
+    </span>
+  </footer>
+</div>
+
+<style>
+  @font-face { font-family: 'Minecraft'; src: url('{$MINECRAFT_FONT_URL}') format('woff2'); }
+</style>
+<script src="{$SKINVIEW_3D_JS_URL}"></script>
+<script>
+  const skinViewer = new skinview3d.SkinViewer({
+    canvas: document.getElementById("skin_container"),
+    skin: "https://crafthead.net/skin/{$UUID}",
+  });
+  skinViewer.width = 150; skinViewer.height = 200;
+  skinViewer.nameTag = '{$USERNAME}';
+  skinViewer.zoom = 0.8;
+  skinViewer.animation = new skinview3d.IdleAnimation();
+  skinViewer.controls.enablePan = false;
+  skinViewer.controls.enableZoom = false;
+</script>

--- a/custom/templates/Nexus/widgets/online_staff.tpl
+++ b/custom/templates/Nexus/widgets/online_staff.tpl
@@ -1,0 +1,23 @@
+<div class="nx-surface overflow-hidden" id="widget-online-staff">
+  <header class="nx-card__header"><h3 class="nx-card__title">{$ONLINE_STAFF}</h3></header>
+  <div class="p-4">
+    {if isset($ONLINE_STAFF_LIST)}
+      <ul class="space-y-2">
+        {foreach from=$ONLINE_STAFF_LIST name=online_staff_arr item=user}
+          <li class="flex items-center gap-2">
+            <span class="nx-avatar nx-avatar--sm"><img src="{$user.avatar}" alt="{$user.username}" loading="lazy" /></span>
+            <div class="flex-1 min-w-0">
+              <a href="{$user.profile}" data-poload="{$USER_INFO_URL}{$user.id}" style="{$user.style}"
+                 class="block text-sm text-text-primary hover:text-accent truncate">{$user.nickname}</a>
+              <div class="flex flex-wrap gap-1 mt-0.5">{$user.group}</div>
+            </div>
+            <span class="w-2 h-2 rounded-full bg-success flex-shrink-0"></span>
+          </li>
+        {/foreach}
+      </ul>
+    {else}
+      <p class="text-sm text-text-muted">{$NO_STAFF_ONLINE}</p>
+    {/if}
+  </div>
+  <footer class="nx-card__footer"><span class="nx-card__meta">{$TOTAL_ONLINE_STAFF}</span></footer>
+</div>

--- a/custom/templates/Nexus/widgets/online_users.tpl
+++ b/custom/templates/Nexus/widgets/online_users.tpl
@@ -1,0 +1,19 @@
+<div class="nx-surface overflow-hidden" id="widget-online-users">
+  <header class="nx-card__header"><h3 class="nx-card__title">{$ONLINE_USERS}</h3></header>
+  <div class="p-4">
+    {if isset($ONLINE_USERS_LIST)}
+      <div class="flex flex-wrap gap-1.5">
+        {foreach from=$ONLINE_USERS_LIST name=online_users_arr item=user}
+          <a href="{$user.profile}" data-poload="{$USER_INFO_URL}{$user.id}"
+             class="inline-flex items-center gap-1.5 pl-1 pr-2 py-1 rounded-full bg-bg-elevated border border-border-default hover:border-accent transition text-xs">
+            <img src="{$user.avatar}" alt="" class="w-5 h-5 rounded-full" loading="lazy" />
+            <span>{if $SHOW_NICKNAME_INSTEAD}{$user.nickname}{else}{$user.username}{/if}</span>
+          </a>
+        {/foreach}
+      </div>
+    {else}
+      <p class="text-sm text-text-muted">{$NO_USERS_ONLINE}</p>
+    {/if}
+  </div>
+  <footer class="nx-card__footer"><span class="nx-card__meta">{$TOTAL_ONLINE_USERS}</span></footer>
+</div>

--- a/custom/templates/Nexus/widgets/profile_posts.tpl
+++ b/custom/templates/Nexus/widgets/profile_posts.tpl
@@ -1,0 +1,23 @@
+<div class="nx-surface overflow-hidden" id="widget-profile-posts">
+  <header class="nx-card__header"><h3 class="nx-card__title">{$LATEST_PROFILE_POSTS}</h3></header>
+  <div class="p-4">
+    {if isset($PROFILE_POSTS_ARRAY)}
+      <ul class="space-y-3">
+        {foreach from=$PROFILE_POSTS_ARRAY name=profile_posts item=post}
+          <li class="flex gap-2.5 pb-3 border-b border-border-subtle last:pb-0 last:border-0">
+            <span class="nx-avatar nx-avatar--sm flex-shrink-0"><img src="{$post.avatar}" alt="{$post.username}" loading="lazy" /></span>
+            <div class="flex-1 min-w-0">
+              <a href="{$post.link}" class="block text-sm text-text-primary hover:text-accent transition line-clamp-2">{$post.content}</a>
+              <div class="text-xs text-text-muted mt-1">
+                <a href="{$post.user_profile_link}" style="{$post.username_style}" data-poload="{$USER_INFO_URL}{$post.user_id}" class="hover:text-text-primary">{$post.username}</a>
+                · <span title="{$post.date_ago}">{$post.ago}</span>
+              </div>
+            </div>
+          </li>
+        {/foreach}
+      </ul>
+    {else}
+      <p class="text-sm text-text-muted">{$NO_PROFILE_POSTS}</p>
+    {/if}
+  </div>
+</div>

--- a/custom/templates/Nexus/widgets/reactions.tpl
+++ b/custom/templates/Nexus/widgets/reactions.tpl
@@ -1,0 +1,36 @@
+<div class="nx-surface overflow-hidden">
+  <header class="nx-card__header"><h3 class="nx-card__title">{$REACTIONS_TEXT}</h3></header>
+  <div class="p-4">
+    <table class="nx-table text-center">
+      <thead>
+        <tr><th></th><th>{$RECEIVED}</th><th>{$GIVEN}</th></tr>
+      </thead>
+      <tbody>
+        {foreach from=$ALL_REACTIONS item=reaction}
+          <tr>
+            <td title="{$reaction.name}">{$reaction.html}</td>
+            <td class="text-text-primary font-medium tabular-nums">{$reaction.received}</td>
+            <td class="text-text-primary font-medium tabular-nums">{$reaction.given}</td>
+          </tr>
+        {/foreach}
+      </tbody>
+    </table>
+  </div>
+  <footer class="nx-card__footer">
+    <span class="text-sm">{$REACTION_SCORE}</span>
+    <span class="font-display font-semibold text-lg
+      {if $REACTION_SCORE_AGGREGATE < 0}text-danger
+      {elseif $REACTION_SCORE_AGGREGATE eq 0}text-warning
+      {else}text-success{/if}">{$REACTION_SCORE_AGGREGATE}</span>
+  </footer>
+  {if count($CONTEXT_REACTION_SCORES)}
+    <div class="px-4 py-3 border-t border-border-subtle text-xs space-y-1">
+      {foreach $CONTEXT_REACTION_SCORES as $context => $score}
+        <div class="flex items-center justify-between">
+          <span class="text-text-muted">{$context}</span>
+          <span class="font-medium {if $score < 0}text-danger{elseif $score eq 0}text-warning{else}text-success{/if}">{$score}</span>
+        </div>
+      {/foreach}
+    </div>
+  {/if}
+</div>

--- a/custom/templates/Nexus/widgets/server_status.tpl
+++ b/custom/templates/Nexus/widgets/server_status.tpl
@@ -1,0 +1,37 @@
+<div class="nx-surface overflow-hidden" id="widget-server-status">
+  <header class="nx-card__header flex items-center justify-between">
+    <h3 class="nx-card__title">{$SERVER_STATUS}</h3>
+    {if isset($SERVER) && $SERVER.status_value eq 1}
+      <span class="nx-badge nx-badge--success nx-badge--dot">{$ONLINE}</span>
+    {elseif isset($SERVER)}
+      <span class="nx-badge nx-badge--danger nx-badge--dot">{$OFFLINE}</span>
+    {/if}
+  </header>
+  <div class="p-4">
+    {if isset($SERVER)}
+      <div class="text-text-secondary text-sm mb-3">{$SERVER.name}</div>
+      {if $SERVER.status_value eq 1}
+        <div class="flex items-center justify-between text-sm mb-3">
+          <span class="text-text-muted">{$ONLINE}</span>
+          <span class="text-text-primary font-medium">{$SERVER.player_count} / {$SERVER.player_count_max}</span>
+        </div>
+        {if isset($SERVER.format_player_list) && count($SERVER.format_player_list) && ($SERVER.player_count > 0)}
+          <div class="flex flex-wrap gap-1 mb-3">
+            {foreach from=$SERVER.format_player_list item=player}
+              <a href="{$player.profile}" title="{$player.username}">
+                <img class="w-7 h-7 rounded-full border border-border-default" src="{$player.avatar}" alt="{$player.username}" loading="lazy" />
+              </a>
+            {/foreach}
+          </div>
+        {/if}
+        {if isset($VERSION)}<p class="text-xs text-text-muted">{$VERSION}</p>{/if}
+      {/if}
+      <div class="flex items-center justify-between text-sm pt-2 border-t border-border-subtle">
+        <span class="text-text-muted">{$IP}</span>
+        <code class="text-text-primary text-xs">{$SERVER.join_at}</code>
+      </div>
+    {else}
+      <p class="text-sm text-text-muted">{$NO_SERVERS}</p>
+    {/if}
+  </div>
+</div>

--- a/custom/templates/Nexus/widgets/statistics.tpl
+++ b/custom/templates/Nexus/widgets/statistics.tpl
@@ -1,0 +1,26 @@
+<div class="nx-surface overflow-hidden" id="widget-statistics">
+  <header class="nx-card__header"><h3 class="nx-card__title">{$STATISTICS}</h3></header>
+  <dl class="p-4 space-y-2 text-sm">
+    {if isset($FORUM_STATISTICS)}
+      <div class="flex items-center justify-between">
+        <dt class="text-text-muted">{$TOTAL_THREADS}</dt>
+        <dd class="text-text-primary font-medium tabular-nums">{$TOTAL_THREADS_VALUE}</dd>
+      </div>
+      <div class="flex items-center justify-between">
+        <dt class="text-text-muted">{$TOTAL_POSTS}</dt>
+        <dd class="text-text-primary font-medium tabular-nums">{$TOTAL_POSTS_VALUE}</dd>
+      </div>
+    {/if}
+    <div class="flex items-center justify-between">
+      <dt class="text-text-muted">{$USERS_REGISTERED}</dt>
+      <dd class="text-text-primary font-medium tabular-nums">{$USERS_REGISTERED_VALUE}</dd>
+    </div>
+    <div class="flex items-center justify-between pt-2 border-t border-border-subtle">
+      <dt class="text-text-muted">{$LATEST_MEMBER}</dt>
+      <dd>
+        <a href="{$LATEST_MEMBER_VALUE.profile}" data-poload="{$USER_INFO_URL}{$LATEST_MEMBER_VALUE.id}"
+           style="{$LATEST_MEMBER_VALUE.style}" class="text-text-primary font-medium hover:text-accent">{$LATEST_MEMBER_VALUE.nickname}</a>
+      </dd>
+    </div>
+  </dl>
+</div>

--- a/custom/templates/Nexus/widgets/widget_error.tpl
+++ b/custom/templates/Nexus/widgets/widget_error.tpl
@@ -1,0 +1,7 @@
+<div class="nx-alert nx-alert--warning">
+  {include file='components/icon.tpl' name='alert' size=18 class="nx-alert__icon"}
+  <div class="flex-1 min-w-0">
+    <div class="nx-alert__body">{$WIDGET_ERROR_CONTENT}</div>
+    <pre class="mt-2 text-xs overflow-x-auto">{$WIDGET_ERROR_MESSAGE}</pre>
+  </div>
+</div>

--- a/modules/Cookie Consent/module.php
+++ b/modules/Cookie Consent/module.php
@@ -18,8 +18,8 @@ class CookieConsent_Module extends Module {
 
         $name = 'Cookie Consent';
         $author = '<a href="https://samerton.dev" target="_blank" rel="nofollow noopener">Samerton</a>';
-        $module_version = '2.2.4';
-        $nameless_version = '2.2.4';
+        $module_version = '2.2.5';
+        $nameless_version = '2.2.5';
 
         parent::__construct($this, $name, $author, $module_version, $nameless_version);
 

--- a/modules/Core/module.php
+++ b/modules/Core/module.php
@@ -19,8 +19,8 @@ class Core_Module extends Module {
 
         $name = 'Core';
         $author = '<a href="https://samerton.me" target="_blank" rel="nofollow noopener">Samerton</a>';
-        $module_version = '2.2.4';
-        $nameless_version = '2.2.4';
+        $module_version = '2.2.5';
+        $nameless_version = '2.2.5';
 
         parent::__construct($this, $name, $author, $module_version, $nameless_version);
 

--- a/modules/Discord Integration/module.php
+++ b/modules/Discord Integration/module.php
@@ -16,8 +16,8 @@ class Discord_Module extends Module {
 
         $name = 'Discord Integration';
         $author = '<a href="https://tadhg.sh" target="_blank" rel="nofollow noopener">Aberdeener</a>';
-        $module_version = '2.2.4';
-        $nameless_version = '2.2.4';
+        $module_version = '2.2.5';
+        $nameless_version = '2.2.5';
 
         parent::__construct($this, $name, $author, $module_version, $nameless_version);
 

--- a/modules/Forum/module.php
+++ b/modules/Forum/module.php
@@ -18,8 +18,8 @@ class Forum_Module extends Module {
 
         $name = 'Forum';
         $author = '<a href="https://samerton.dev" target="_blank" rel="nofollow noopener">Samerton</a>';
-        $module_version = '2.2.4';
-        $nameless_version = '2.2.4';
+        $module_version = '2.2.5';
+        $nameless_version = '2.2.5';
 
         parent::__construct($this, $name, $author, $module_version, $nameless_version);
 

--- a/modules/Members/module.php
+++ b/modules/Members/module.php
@@ -18,8 +18,8 @@ class Members_Module extends Module {
 
         $name = 'Members';
         $author = '<a href="https://tadhg.sh" target="_blank" rel="nofollow noopener">Aberdeener</a>';
-        $module_version = '2.2.4';
-        $nameless_version = '2.2.4';
+        $module_version = '2.2.5';
+        $nameless_version = '2.2.5';
 
         parent::__construct($this, $name, $author, $module_version, $nameless_version);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nameless",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "repository": "https://github.com/NamelessMC/Nameless",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## Summary

Introduces **Nexus**, a complete new public-frontend theme that ships **alongside** the existing `DefaultRevamp`. DefaultRevamp, the core, all modules, and the panel templates are **untouched** — this PR is purely additive.

Nexus is dark-first with optional light mode, built on **TailwindCSS + Alpine.js**, and coexists with the legacy jQuery / Fomantic UI stack that modules rely on. Design language is in the Linear / Vercel / Discord / Notion / Raycast direction.

## What's in the box

- **Theme bootstrap:** `template.php`, `template_settings/{settings.php,settings.tpl}`, `package.json`, `tailwind.config.js`, `postcss.config.js`
- **Design system:** `src/styles/tokens.css` (CSS-variable tokens), `base.css`, `components.css` (`.nx-*` component library), `overrides.css` (legacy compatibility layer that restyles `.ui.button`, `.ui.segment`, `.ui.form`, `.ui.message`, `.ui.modal`, `.ui.grid`, DataTables, Select2, etc. so module-emitted markup looks consistent)
- **Alpine bundle** (`src/scripts/main.js`): theme / toast / modal / mobileNav / palette stores, `Cmd+K` command palette, `x-tooltip` & `x-clipboard` directives, global escape handling, jQuery coexistence
- **Layout:** new `header.tpl`, glassmorphic sticky `navbar.tpl` with off-canvas mobile drawer, `footer.tpl`
- **All public-frontend pages re-implemented:** landing, portal, auth flow (login/register/forgot/change/tfa/complete-signup/authme/registration-disabled/user-not-exist), profile (banner, tabs, wall posts with reactions, replies, edit/delete/block/banner modals), user CP (index, settings, navigation + baseline copies for the rest), forum (index/view-forum/view-topic/new-topic/edit/search/follow/merge/move/redirect-confirm/no-discussions), members directory, leaderboards, status, 403/404/maintenance, cookies/privacy/terms, custom, reactions modal, user popover
- **Widgets:** `online_staff`, `online_users`, `server_status`, `statistics`, `minecraft_account` (with skinview3d), `profile_posts`, `reactions`, `cookie_notice`, `widget_error`, `forum/latest_posts`
- **Docs:** `README.md` (install + build + activate + customize + smoke-test + troubleshooting), `docs/CHANGES.md` (file-by-file inventory)

## Why

DefaultRevamp's Fomantic UI design is functional but dated. This PR provides a modern alternative without forcing anyone off the existing theme. Operators can switch between Nexus and DefaultRevamp from StaffCP → Layout → Templates at any time.

Crucially, **the Smarty-variable contract is preserved**. Every page consumes the same `\$NAV_LINKS`, `\$USER_SECTION`, `\$WIDGETS_*`, `\$REACTIONS_*`, `\$FORUMS`, `\$REPLIES`, etc. that DefaultRevamp does, so all controllers and module integrations keep working.

## Not in this PR

- Admin panel (`custom/panel_templates/`) — slated for a follow-up.
- Email templates and deep TinyMCE skinning — slated for a follow-up.

## Reviewer checklist

- [ ] `custom/templates/Nexus/` is fully self-contained
- [ ] `custom/templates/DefaultRevamp/`, `core/`, `modules/`, and `custom/panel_templates/` have **zero** diffs in this PR
- [ ] Build artifacts (`assets/css/*.css`, `assets/js/*.js`, `node_modules/`) are gitignored
- [ ] Smarty template safety: no PHP static method calls inside `.tpl` files, no unsupported `\{` brace escapes, every `{include file=…}` target exists, every `{\$smarty.foreach.X.…}` has a matching `name=X` declaration

## Local testing

```bash
cd custom/templates/Nexus
npm install
npm run build
```

Then StaffCP → Layout → Templates → activate **Nexus**. Walk the smoke-test plan in [`custom/templates/Nexus/README.md` §6](custom/templates/Nexus/README.md).

## Test plan

- [ ] Visit `/`, `/forum`, `/profile/<user>`, `/login`, `/register` on desktop + mobile — no console errors, theme toggle persists across reloads
- [ ] Create / reply / react / edit / delete a forum topic
- [ ] Edit profile + change avatar + post on wall + react
- [ ] Cmd/Ctrl+K opens command palette, Escape closes overlays, off-canvas drawer works on mobile
- [ ] Switch back to DefaultRevamp — everything still works (parallel-theme guarantee)
- [ ] Lighthouse on local install: Performance ≥ 90, A11y ≥ 95