### PR TITLE
Mass message failing with a falsy clause

### DIFF
--- a/modules/Core/pages/panel/mass_message.php
+++ b/modules/Core/pages/panel/mass_message.php
@@ -119,7 +119,9 @@ if (Input::exists()) {
                         $glue = 'AND';
                     }
 
-                    $clause = "AND $clause";
+                    if ($clause) {
+                        $clause = "AND $clause";
+                    }
 
                     $ids = array_merge($filterGroups ?? [], $filterUsers ?? []);
                     $users = DB::getInstance()->query(


### PR DESCRIPTION
If `$clause` was falsy when sending a mass message (the case I'd found was sending a message to a single user whilst bypassing their notification preferences), the message would fail to send as the query had an invalid empty `AND` appended.